### PR TITLE
update tekton minor versions for 2.19

### DIFF
--- a/renovate/default-renovate.json
+++ b/renovate/default-renovate.json
@@ -28,7 +28,7 @@
       },
       {
         "matchManagers": ["tekton"],
-        "matchBaseBranches": ["rhoai-2.18"],
+        "matchBaseBranches": ["rhoai-2.19"],
         "matchUpdateTypes": ["digest", "minor"],
         "enabled": true,
         "groupName": "Tekton Updates",


### PR DESCRIPTION
this is for the same reason it was done for 2.18, to fix conforma errors about outdated pipeline tasks
