### PR TITLE
disable renovate for 2.19, formatting changes

### DIFF
--- a/renovate/custom-renovate.json
+++ b/renovate/custom-renovate.json
@@ -8,6 +8,7 @@
   "ignoreTests": true,
   "automergeType": "pr",
   "automerge": true,
+  "prHourlyLimit": 0,
   "enabledManagers": ["tekton"],
   "tekton": {
     "schedule": ["* 0-3 1 * *"],
@@ -20,6 +21,12 @@
     ],
     "packageRules": [
       {
+        "matchManagers": ["tekton"],
+        "matchBaseBranches": ["rhoai-2.19"],
+        "enabled": false
+      }   
+    ],
+    "tekton": {
         "matchPackagePatterns": [
           "^quay.io/redhat-appstudio-tekton-catalog/",
           "^quay.io/konflux-ci/tekton-catalog/"
@@ -45,8 +52,5 @@
         "prBodyTemplate": "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{controls}}}{{{footer}}}",
         "recreateWhen": "always",
         "rebaseWhen": "behind-base-branch"
-      }
-    ]
-  },
- "prHourlyLimit": 0
+    }
 }

--- a/renovate/default-renovate.json
+++ b/renovate/default-renovate.json
@@ -6,6 +6,7 @@
     "ignoreTests": true,
     "automergeType": "pr",
     "automerge": true,
+    "prHourlyLimit": 0,
     "enabledManagers": ["dockerfile", "tekton", "rpm"],
     "packageRules": [
       {
@@ -20,11 +21,6 @@
         "groupName": "Dockerfile Digest Updates",
         "branchPrefix": "renovate/docker-main/",
         "semanticCommits": "enabled"
-      },
-      {
-        "matchManagers": ["dockerfile"],
-        "matchBaseBranches": ["rhoai-2.19"],
-        "enabled": false
       },
       {
         "matchManagers": ["tekton"],
@@ -50,7 +46,12 @@
         "schedule": ["at any time"],
         "branchPrefix": "renovate/rpm/",
        "semanticCommits": "enabled"
-      }    
+      },
+      {
+        "matchManagers": ["rpm", "tekton", "dockerfile"],
+        "matchBaseBranches": ["rhoai-2.19"],
+        "enabled": false
+      }   
     ],
     "dockerfile": {
       "enabled": true,
@@ -116,8 +117,7 @@
       ]
     },
     "rpm": {
-    "enabled": true,   
-    "schedule": ["at any time"]
-  },
-    "prHourlyLimit": 0
+      "enabled": true,   
+      "schedule": ["at any time"]
+    }
   }


### PR DESCRIPTION
added lines to disable renovate for rhoai-2.19.

Also changed the organization of the custom (fbc) renovate to be more
consistent with how the default renovate is.
