### PR TITLE
Revert "onboard rhoai-konflux-tasks"

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -28,4 +28,3 @@
 - renovate-config: "renovate/custom-renovate.json"
   sync-repositories:
     - name: "red-hat-data-services/RHOAI-Build-Config"
-    - name: "red-hat-data-services/rhoai-konflux-tasks"

--- a/renovate/custom-renovate.json
+++ b/renovate/custom-renovate.json
@@ -17,8 +17,7 @@
       "\\.yml$"
     ],
     "includePaths": [
-      ".tekton/**",
-      "pipelines/**"
+      ".tekton/**"
     ],
     "packageRules": [
     ],


### PR DESCRIPTION
Reverts red-hat-data-services/renovate-central#6

trying to make it work with https://github.com/red-hat-data-services/rhoai-konflux-tasks/pull/11 instead