### PR TITLE
update renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "baseBranches": ["rhoai-2.20", "rhoai-2.21"],
+  "baseBranches": ["/^rhoai-\\d+\\.\\d+$/"],
   "enabledManagers": ["tekton"],
   "tekton": {
     "schedule": ["at any time"],

--- a/renovate/custom-renovate.json
+++ b/renovate/custom-renovate.json
@@ -4,7 +4,7 @@
     "config:recommended"
   ],
   "branchPrefix": "renovate/",
-  "baseBranches": ["main", "rhoai-2.8", "rhoai-2.16","rhoai-2.19", "rhoai-2.20", "rhoai-2.21"],
+  "baseBranches": ["main", "rhoai-2.8", "rhoai-2.16", "rhoai-2.20"],
   "ignoreTests": true,
   "automergeType": "pr",
   "automerge": true,

--- a/renovate/default-renovate.json
+++ b/renovate/default-renovate.json
@@ -24,7 +24,7 @@
       },
       {
         "matchManagers": ["tekton"],
-        "matchBaseBranches": ["rhoai-2.8", "rhoai-2.16", "rhoai-2.19"],
+        "matchBaseBranches": ["rhoai-2.8", "rhoai-2.16"],
         "matchUpdateTypes": ["digest", "minor"],
         "schedule": ["* 0-3 1 * *"], 
         "enabled": true,


### PR DESCRIPTION
remove 2.19 from old konflux-central renovate config, because 2.19 is using
konflux-central pipelinerefs now

also making the base renovate.json for konflux-central match on a regex
pattern for rhoai-[number].[number]
