### PR TITLE
switch all quay targets back to rhel8

### DIFF
--- a/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-argoexec-v2-19-push.yaml
+++ b/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-argoexec-v2-19-push.yaml
@@ -29,7 +29,7 @@ spec:
         - version=v2.19.1
         - io.openshift.tags=odh-data-science-pipelines-argo-argoexec
     - name: output-image
-      value: quay.io/rhoai/odh-data-science-pipelines-argo-argoexec-rhel9:{{target_branch}}
+      value: quay.io/rhoai/odh-data-science-pipelines-argo-argoexec-rhel8:{{target_branch}}
     - name: dockerfile
       value: argo-argoexec/Dockerfile.konflux
     - name: path-context

--- a/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-workflowcontroller-v2-19-push.yaml
+++ b/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-workflowcontroller-v2-19-push.yaml
@@ -28,7 +28,7 @@ spec:
         - version=v2.19.1
         - io.openshift.tags=odh-data-science-pipelines-argo-workflowcontroller
     - name: output-image
-      value: quay.io/rhoai/odh-data-science-pipelines-argo-workflowcontroller-rhel9:{{target_branch}}
+      value: quay.io/rhoai/odh-data-science-pipelines-argo-workflowcontroller-rhel8:{{target_branch}}
     - name: dockerfile
       value: argo-workflowcontroller/Dockerfile.konflux
     - name: path-context

--- a/pipelineruns/codeflare-operator/.tekton/odh-codeflare-operator-v2-19-push.yaml
+++ b/pipelineruns/codeflare-operator/.tekton/odh-codeflare-operator-v2-19-push.yaml
@@ -29,7 +29,7 @@ spec:
         - version=v2.19.1
         - io.openshift.tags=odh-codeflare-operator
     - name: output-image
-      value: quay.io/rhoai/odh-codeflare-operator-rhel9:{{target_branch}}
+      value: quay.io/rhoai/odh-codeflare-operator-rhel8:{{target_branch}}
     - name: dockerfile
       value: Dockerfile.konflux
     - name: path-context

--- a/pipelineruns/data-science-pipelines-operator/.tekton/odh-data-science-pipelines-operator-controller-v2-19-push.yaml
+++ b/pipelineruns/data-science-pipelines-operator/.tekton/odh-data-science-pipelines-operator-controller-v2-19-push.yaml
@@ -29,7 +29,7 @@ spec:
         - version=v2.19.1
         - io.openshift.tags=odh-data-science-pipelines-operator-controller
     - name: output-image
-      value: quay.io/rhoai/odh-data-science-pipelines-operator-controller-rhel9:{{target_branch}}
+      value: quay.io/rhoai/odh-data-science-pipelines-operator-controller-rhel8:{{target_branch}}
     - name: dockerfile
       value: Dockerfile.konflux
     - name: path-context

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-api-server-v2-v2-19-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-api-server-v2-v2-19-push.yaml
@@ -29,7 +29,7 @@ spec:
         - version=v2.19.1
         - io.openshift.tags=odh-ml-pipelines-api-server-v2
     - name: output-image
-      value: quay.io/rhoai/odh-ml-pipelines-api-server-v2-rhel9:{{target_branch}}
+      value: quay.io/rhoai/odh-ml-pipelines-api-server-v2-rhel8:{{target_branch}}
     - name: dockerfile
       value: backend/Dockerfile.konflux.api
     - name: path-context

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-driver-v2-19-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-driver-v2-19-push.yaml
@@ -29,7 +29,7 @@ spec:
         - version=v2.19.1
         - io.openshift.tags=odh-ml-pipelines-driver
     - name: output-image
-      value: quay.io/rhoai/odh-ml-pipelines-driver-rhel9:{{target_branch}}
+      value: quay.io/rhoai/odh-ml-pipelines-driver-rhel8:{{target_branch}}
     - name: dockerfile
       value: backend/Dockerfile.konflux.driver
     - name: path-context

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-launcher-v2-19-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-launcher-v2-19-push.yaml
@@ -29,7 +29,7 @@ spec:
         - version=v2.19.1
         - io.openshift.tags=odh-ml-pipelines-launcher
     - name: output-image
-      value: quay.io/rhoai/odh-ml-pipelines-launcher-rhel9:{{target_branch}}
+      value: quay.io/rhoai/odh-ml-pipelines-launcher-rhel8:{{target_branch}}
     - name: dockerfile
       value: backend/Dockerfile.konflux.launcher
     - name: path-context

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-persistenceagent-v2-v2-19-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-persistenceagent-v2-v2-19-push.yaml
@@ -29,7 +29,7 @@ spec:
         - version=v2.19.1
         - io.openshift.tags=odh-ml-pipelines-persistenceagent-v2
     - name: output-image
-      value: quay.io/rhoai/odh-ml-pipelines-persistenceagent-v2-rhel9:{{target_branch}}
+      value: quay.io/rhoai/odh-ml-pipelines-persistenceagent-v2-rhel8:{{target_branch}}
     - name: dockerfile
       value: backend/Dockerfile.konflux.persistenceagent
     - name: path-context

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-scheduledworkflow-v2-v2-19-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-scheduledworkflow-v2-v2-19-push.yaml
@@ -29,7 +29,7 @@ spec:
         - version=v2.19.1
         - io.openshift.tags=odh-ml-pipelines-scheduledworkflow-v2
     - name: output-image
-      value: quay.io/rhoai/odh-ml-pipelines-scheduledworkflow-v2-rhel9:{{target_branch}}
+      value: quay.io/rhoai/odh-ml-pipelines-scheduledworkflow-v2-rhel8:{{target_branch}}
     - name: dockerfile
       value: backend/Dockerfile.konflux.scheduledworkflow
     - name: path-context

--- a/pipelineruns/fms-guardrails-orchestrator/.tekton/fms-guardrails-orchestrator-v2-19-push.yaml
+++ b/pipelineruns/fms-guardrails-orchestrator/.tekton/fms-guardrails-orchestrator-v2-19-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/modh/odh-fms-guardrails-orchestrator-rhel9:{{target_branch}}
+    value: quay.io/modh/odh-fms-guardrails-orchestrator-rhel8:{{target_branch}}
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'

--- a/pipelineruns/ilab-on-ocp/.tekton/odh-ml-pipelines-runtime-generic-v2-19-push.yaml
+++ b/pipelineruns/ilab-on-ocp/.tekton/odh-ml-pipelines-runtime-generic-v2-19-push.yaml
@@ -29,7 +29,7 @@ spec:
         - version=v2.19.1
         - io.openshift.tags=odh-ml-pipelines-runtime-generic
     - name: output-image
-      value: quay.io/rhoai/odh-ml-pipelines-runtime-generic-rhel9:{{target_branch}}
+      value: quay.io/rhoai/odh-ml-pipelines-runtime-generic-rhel8:{{target_branch}}
     - name: dockerfile
       value: Dockerfile.konflux
     - name: path-context

--- a/pipelineruns/kubeflow/.tekton/odh-kf-notebook-controller-v2-19-push.yaml
+++ b/pipelineruns/kubeflow/.tekton/odh-kf-notebook-controller-v2-19-push.yaml
@@ -32,7 +32,7 @@ spec:
         - version=v2.19.1
         - io.openshift.tags=odh-kf-notebook-controller
     - name: output-image
-      value: quay.io/rhoai/odh-kf-notebook-controller-rhel9:{{target_branch}}
+      value: quay.io/rhoai/odh-kf-notebook-controller-rhel8:{{target_branch}}
     - name: dockerfile
       value: notebook-controller/Dockerfile.konflux
     - name: path-context

--- a/pipelineruns/kubeflow/.tekton/odh-notebook-controller-v2-19-push.yaml
+++ b/pipelineruns/kubeflow/.tekton/odh-notebook-controller-v2-19-push.yaml
@@ -32,7 +32,7 @@ spec:
         - version=v2.19.1
         - io.openshift.tags=odh-notebook-controller
     - name: output-image
-      value: quay.io/rhoai/odh-notebook-controller-rhel9:{{target_branch}}
+      value: quay.io/rhoai/odh-notebook-controller-rhel8:{{target_branch}}
     - name: dockerfile
       value: odh-notebook-controller/Dockerfile.konflux
     - name: path-context

--- a/pipelineruns/kuberay/.tekton/odh-kuberay-operator-controller-v2-19-push.yaml
+++ b/pipelineruns/kuberay/.tekton/odh-kuberay-operator-controller-v2-19-push.yaml
@@ -29,7 +29,7 @@ spec:
         - version=v2.19.1
         - io.openshift.tags=odh-kuberay-operator-controller
     - name: output-image
-      value: quay.io/rhoai/odh-kuberay-operator-controller-rhel9:{{target_branch}}
+      value: quay.io/rhoai/odh-kuberay-operator-controller-rhel8:{{target_branch}}
     - name: dockerfile
       value: ./ray-operator/Dockerfile.konflux
     - name: path-context

--- a/pipelineruns/kueue/.tekton/odh-kueue-controller-v2-19-push.yaml
+++ b/pipelineruns/kueue/.tekton/odh-kueue-controller-v2-19-push.yaml
@@ -29,7 +29,7 @@ spec:
         - version=v2.19.1
         - io.openshift.tags=odh-kueue-controller
     - name: output-image
-      value: quay.io/rhoai/odh-kueue-controller-rhel9:{{target_branch}}
+      value: quay.io/rhoai/odh-kueue-controller-rhel8:{{target_branch}}
     - name: dockerfile
       value: Dockerfile.konflux
     - name: path-context

--- a/pipelineruns/ml-metadata/.tekton/odh-mlmd-grpc-server-v2-19-push.yaml
+++ b/pipelineruns/ml-metadata/.tekton/odh-mlmd-grpc-server-v2-19-push.yaml
@@ -30,7 +30,7 @@ spec:
       value:
         - version=v2.19.1
     - name: output-image
-      value: quay.io/rhoai/odh-mlmd-grpc-server-rhel9:{{target_branch}}
+      value: quay.io/rhoai/odh-mlmd-grpc-server-rhel8:{{target_branch}}
     - name: dockerfile
       value: ml_metadata/tools/docker_server/Dockerfile.konflux
     - name: path-context

--- a/pipelineruns/model-registry-operator/.tekton/odh-model-registry-operator-v2-19-push.yaml
+++ b/pipelineruns/model-registry-operator/.tekton/odh-model-registry-operator-v2-19-push.yaml
@@ -29,7 +29,7 @@ spec:
         - version=v2.19.1
         - io.openshift.tags=odh-model-registry-operator
     - name: output-image
-      value: quay.io/rhoai/odh-model-registry-operator-rhel9:{{target_branch}}
+      value: quay.io/rhoai/odh-model-registry-operator-rhel8:{{target_branch}}
     - name: dockerfile
       value: Dockerfile.konflux
     - name: path-context

--- a/pipelineruns/model-registry/.tekton/odh-model-registry-v2-19-push.yaml
+++ b/pipelineruns/model-registry/.tekton/odh-model-registry-v2-19-push.yaml
@@ -29,7 +29,7 @@ spec:
         - version=v2.19.1
         - io.openshift.tags=odh-model-registry
     - name: output-image
-      value: quay.io/rhoai/odh-model-registry-rhel9:{{target_branch}}
+      value: quay.io/rhoai/odh-model-registry-rhel8:{{target_branch}}
     - name: dockerfile
       value: Dockerfile.konflux
     - name: path-context

--- a/pipelineruns/modelmesh-runtime-adapter/.tekton/odh-modelmesh-runtime-adapter-v2-19-push.yaml
+++ b/pipelineruns/modelmesh-runtime-adapter/.tekton/odh-modelmesh-runtime-adapter-v2-19-push.yaml
@@ -30,7 +30,7 @@ spec:
         - version=v2.19.1
         - io.openshift.tags=odh-model-serving-runtime-adapter
     - name: output-image
-      value: quay.io/rhoai/odh-modelmesh-runtime-adapter-rhel9:{{target_branch}}
+      value: quay.io/rhoai/odh-modelmesh-runtime-adapter-rhel8:{{target_branch}}
     - name: dockerfile
       value: Dockerfile.konflux
     - name: path-context

--- a/pipelineruns/modelmesh-serving/.tekton/odh-modelmesh-serving-controller-v2-19-push.yaml
+++ b/pipelineruns/modelmesh-serving/.tekton/odh-modelmesh-serving-controller-v2-19-push.yaml
@@ -29,7 +29,7 @@ spec:
         - version=v2.19.1
         - io.openshift.tags=odh-modelmesh-serving-controller
     - name: output-image
-      value: quay.io/rhoai/odh-modelmesh-serving-controller-rhel9:{{target_branch}}
+      value: quay.io/rhoai/odh-modelmesh-serving-controller-rhel8:{{target_branch}}
     - name: dockerfile
       value: Dockerfile.konflux
     - name: path-context

--- a/pipelineruns/modelmesh/.tekton/odh-modelmesh-v2-19-push.yaml
+++ b/pipelineruns/modelmesh/.tekton/odh-modelmesh-v2-19-push.yaml
@@ -29,7 +29,7 @@ spec:
         - version=v2.19.1
         - io.openshift.tags=odh-modelmesh
     - name: output-image
-      value: quay.io/rhoai/odh-modelmesh-rhel9:{{target_branch}}
+      value: quay.io/rhoai/odh-modelmesh-rhel8:{{target_branch}}
     - name: dockerfile
       value: Dockerfile.konflux
     - name: path-context

--- a/pipelineruns/odh-dashboard/.tekton/odh-dashboard-v2-19-push.yaml
+++ b/pipelineruns/odh-dashboard/.tekton/odh-dashboard-v2-19-push.yaml
@@ -31,7 +31,7 @@ spec:
         - version=v2.19.1
         - io.openshift.tags=odh-dashboard
     - name: output-image
-      value: quay.io/rhoai/odh-dashboard-rhel9:{{target_branch}}
+      value: quay.io/rhoai/odh-dashboard-rhel8:{{target_branch}}
     - name: build-platforms
       value:
         - linux/x86_64

--- a/pipelineruns/odh-model-controller/.tekton/odh-model-controller-v2-19-push.yaml
+++ b/pipelineruns/odh-model-controller/.tekton/odh-model-controller-v2-19-push.yaml
@@ -29,7 +29,7 @@ spec:
         - version=v2.19.1
         - io.openshift.tags=odh-model-controller
     - name: output-image
-      value: quay.io/rhoai/odh-model-controller-rhel9:{{target_branch}}
+      value: quay.io/rhoai/odh-model-controller-rhel8:{{target_branch}}
     - name: build-platforms
       value:
         - linux/x86_64

--- a/pipelineruns/rest-proxy/.tekton/odh-mm-rest-proxy-v2-19-push.yaml
+++ b/pipelineruns/rest-proxy/.tekton/odh-mm-rest-proxy-v2-19-push.yaml
@@ -29,7 +29,7 @@ spec:
         - version=v2.19.1
         - io.openshift.tags=odh-mm-rest-proxy
     - name: output-image
-      value: quay.io/rhoai/odh-mm-rest-proxy-rhel9:{{target_branch}}
+      value: quay.io/rhoai/odh-mm-rest-proxy-rhel8:{{target_branch}}
     - name: dockerfile
       value: Dockerfile.konflux
     - name: path-context

--- a/pipelineruns/rhods-operator/.tekton/odh-operator-v2-19-push.yaml
+++ b/pipelineruns/rhods-operator/.tekton/odh-operator-v2-19-push.yaml
@@ -36,7 +36,7 @@ spec:
         - version=v2.19.1
         - io.openshift.tags=odh-operator
     - name: output-image
-      value: quay.io/rhoai/odh-rhel9-operator:{{target_branch}}
+      value: quay.io/rhoai/odh-rhel8-operator:{{target_branch}}
     - name: build-platforms
       value:
         - linux/x86_64

--- a/pipelineruns/rhods-operator/.tekton/odh-operator-v2-19-scheduled.yaml
+++ b/pipelineruns/rhods-operator/.tekton/odh-operator-v2-19-scheduled.yaml
@@ -32,7 +32,7 @@ spec:
         - version=v2.19.1
         - io.openshift.tags=odh-operator
     - name: output-image
-      value: quay.io/rhoai/odh-rhel9-operator:{{target_branch}}
+      value: quay.io/rhoai/odh-rhel8-operator:{{target_branch}}
     - name: build-platforms
       value:
         - linux/x86_64

--- a/pipelineruns/training-operator/.tekton/odh-training-operator-v2-19-push.yaml
+++ b/pipelineruns/training-operator/.tekton/odh-training-operator-v2-19-push.yaml
@@ -29,7 +29,7 @@ spec:
         - version=v2.19.1
         - io.openshift.tags=odh-training-operator
     - name: output-image
-      value: quay.io/rhoai/odh-training-operator-rhel9:{{target_branch}}
+      value: quay.io/rhoai/odh-training-operator-rhel8:{{target_branch}}
     - name: dockerfile
       value: build/images/training-operator/Dockerfile.konflux
     - name: path-context

--- a/pipelineruns/trustyai-explainability/.tekton/odh-trustyai-service-v2-19-push.yaml
+++ b/pipelineruns/trustyai-explainability/.tekton/odh-trustyai-service-v2-19-push.yaml
@@ -29,7 +29,7 @@ spec:
         - version=v2.19.1
         - io.openshift.tags=odh-trustyai-service
     - name: output-image
-      value: quay.io/rhoai/odh-trustyai-service-rhel9:{{target_branch}}
+      value: quay.io/rhoai/odh-trustyai-service-rhel8:{{target_branch}}
     - name: dockerfile
       value: Dockerfile.konflux
     - name: path-context

--- a/pipelineruns/trustyai-service-operator/.tekton/odh-trustyai-service-operator-v2-19-push.yaml
+++ b/pipelineruns/trustyai-service-operator/.tekton/odh-trustyai-service-operator-v2-19-push.yaml
@@ -29,7 +29,7 @@ spec:
         - version=v2.19.1
         - io.openshift.tags=odh-trustyai-service-operator
     - name: output-image
-      value: quay.io/rhoai/odh-trustyai-service-operator-rhel9:{{target_branch}}
+      value: quay.io/rhoai/odh-trustyai-service-operator-rhel8:{{target_branch}}
     - name: dockerfile
       value: Dockerfile.konflux
     - name: path-context


### PR DESCRIPTION
this was a side effect of copying over pipelines from 2.21 to 2.19