### PR TITLE
Update renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,15 +6,11 @@
     "schedule": ["at any time"],
     "fileMatch": ["\\.yaml$", "\\.yml$"],
     "includePaths": ["pipelineruns/**", "pipelines/**", "tasks/**"],
-    "automerge": false,
+    "automerge": true,
     "packageRules": [
       {
         "matchUpdateTypes": ["major", "minor", "pin", "pinDigest"],
         "enabled": false
-      },
-      {
-        "matchUpdateTypes": ["digest", "patch"],
-        "enabled": true
       }
     ]
   }


### PR DESCRIPTION
– Enabling auto-merge, as we already have a check in place.
– All update types are enabled by default. Instead of explicitly enabling the ones we want, we only need to disable the ones we don’t. So, including just the "enabled: false" rule is sufficient.