### PR TITLE
pin rhoai-init tekton task to latest commit sha

### DIFF
--- a/pipelines/container-build.yaml
+++ b/pipelines/container-build.yaml
@@ -70,8 +70,8 @@ spec:
     description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
     name: build-args-file
     type: string
-  - default: "does-not-exist" 
-    description: Kubernetes secret to mount into build, see https://www.redhat.com/en/blog/sensitive-data-containers 
+  - default: "does-not-exist"
+    description: Kubernetes secret to mount into build, see https://www.redhat.com/en/blog/sensitive-data-containers
     name: additional-build-secret
     type: string
   - default: "synk-secret"
@@ -121,7 +121,7 @@ spec:
       - name: url
         value: https://github.com/red-hat-data-services/rhoai-konflux-tasks.git
       - name: revision
-        value: main
+        value: 19a01971a39db7e50c40e6db8405dfa957eec70b
       - name: pathInRepo
         value: konflux-tekton-tasks/rhoai-init/0.1/rhoai-init.yaml
   - name: init
@@ -581,7 +581,7 @@ spec:
     - input: $(tasks.rhoai-init.results.skip-slack-message)
       operator: in
       values:
-      - "false" 
+      - "false"
   workspaces:
   - name: git-auth
     optional: true


### PR DESCRIPTION
This is required for the Conforma checks
to pass, otherwise they highlight:
Task rhoai-init is used by pipeline task
rhoai-init via an unpinned reference.