### PR TITLE
pin rhoai-init task to a known working version

### DIFF
--- a/.tekton/container-build-pull-request.yaml
+++ b/.tekton/container-build-pull-request.yaml
@@ -16,7 +16,7 @@ metadata:
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: konflux-central-2-22
+    appstudio.openshift.io/component: pull-request-pipelines
     pipelines.appstudio.openshift.io/type: build
   name: container-build-on-pull-request
   namespace: rhoai-tenant
@@ -36,7 +36,7 @@ spec:
     - version=v2.Y.Z
     - io.openshift.tags=ADDITIONAL_TAG_HERE
   - name: output-image
-    value: quay.io/redhat-user-workloads/rhoai-tenant/konflux-central-2-22:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/rhoai-tenant/pull-request-pipelines:konflux-central-{{revision}}
   - name: dockerfile
     value: ./canary-build/Dockerfile.konflux
   - name: path-context
@@ -53,7 +53,8 @@ spec:
       value: '{{ revision }}'
     - name: pathInRepo
       value: pipelines/container-build.yaml
-  taskRunTemplate: {}
+  taskRunTemplate: 
+    serviceAccountName: build-pipeline-pull-request-pipelines
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/multi-arch-container-build-pull-request.yaml
+++ b/.tekton/multi-arch-container-build-pull-request.yaml
@@ -16,7 +16,7 @@ metadata:
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: konflux-central-2-22
+    appstudio.openshift.io/component: pull-request-pipelines
     pipelines.appstudio.openshift.io/type: build
   name: multi-arch-container-build-on-pull-request
   namespace: rhoai-tenant
@@ -36,7 +36,7 @@ spec:
     - version=v2.Y.Z
     - io.openshift.tags=ADDITIONAL_TAG_HERE
   - name: output-image
-    value: quay.io/redhat-user-workloads/rhoai-tenant/konflux-central-2-22:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/rhoai-tenant/pull-request-pipelines:konflux-central-multi-arch-{{revision}}
   - name: dockerfile
     value: ./canary-build/Dockerfile.konflux
   - name: path-context
@@ -56,7 +56,8 @@ spec:
       value: '{{ revision }}'
     - name: pathInRepo
       value: pipelines/multi-arch-container-build.yaml
-  taskRunTemplate: {}
+  taskRunTemplate: 
+    serviceAccountName: build-pipeline-pull-request-pipelines
   workspaces:
   - name: git-auth
     secret:

--- a/pipelines/container-build.yaml
+++ b/pipelines/container-build.yaml
@@ -70,8 +70,8 @@ spec:
     description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
     name: build-args-file
     type: string
-  - default: "does-not-exist" 
-    description: Kubernetes secret to mount into build, see https://www.redhat.com/en/blog/sensitive-data-containers 
+  - default: "does-not-exist"
+    description: Kubernetes secret to mount into build, see https://www.redhat.com/en/blog/sensitive-data-containers
     name: additional-build-secret
     type: string
   - default: "synk-secret"
@@ -121,7 +121,7 @@ spec:
       - name: url
         value: https://github.com/red-hat-data-services/rhoai-konflux-tasks.git
       - name: revision
-        value: main
+        value: 19a01971a39db7e50c40e6db8405dfa957eec70b
       - name: pathInRepo
         value: konflux-tekton-tasks/rhoai-init/0.1/rhoai-init.yaml
   - name: init
@@ -581,7 +581,7 @@ spec:
     - input: $(tasks.rhoai-init.results.skip-slack-message)
       operator: in
       values:
-      - "false" 
+      - "false"
   workspaces:
   - name: git-auth
     optional: true

--- a/pipelines/fbc-fragment-build.yaml
+++ b/pipelines/fbc-fragment-build.yaml
@@ -70,8 +70,8 @@ spec:
     description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
     name: build-args-file
     type: string
-  - default: "does-not-exist" 
-    description: Kubernetes secret to mount into build, see https://www.redhat.com/en/blog/sensitive-data-containers 
+  - default: "does-not-exist"
+    description: Kubernetes secret to mount into build, see https://www.redhat.com/en/blog/sensitive-data-containers
     name: additional-build-secret
     type: string
   - default: "synk-secret"
@@ -138,7 +138,7 @@ spec:
       - name: url
         value: https://github.com/red-hat-data-services/rhoai-konflux-tasks.git
       - name: revision
-        value: main
+        value: 19a01971a39db7e50c40e6db8405dfa957eec70b
       - name: pathInRepo
         value: konflux-tekton-tasks/rhoai-init/0.1/rhoai-init.yaml
   - name: init
@@ -631,14 +631,14 @@ spec:
         script: |
           #!/bin/bash
           set -e
-  
+
           OWNER="red-hat-data-services"
           REPO="conforma-reporter"
           WORKFLOW_FILE="conforma-reporter.yaml"
-          
+
           echo "Target branch is: '$TARGET_BRANCH'"
           echo "Triggering Conforma workflow for branch: $TARGET_BRANCH"
-  
+
           curl -X POST "https://api.github.com/repos/$OWNER/$REPO/actions/workflows/$WORKFLOW_FILE/dispatches" \
           -H "Accept: application/vnd.github.v3+json" \
           -H "Authorization: Bearer $GITHUB_TOKEN" \
@@ -670,20 +670,20 @@ spec:
         script: |
           #!/bin/bash
           set -e
-  
+
           OWNER="red-hat-data-services"
           REPO="conforma-reporter"
           WORKFLOW_FILE="smoke-trigger.yaml"
-          
+
           echo "Target branch is: '$TARGET_BRANCH'"
           echo "Triggering Conforma workflow for branch: $TARGET_BRANCH"
-  
+
           curl -X POST "https://api.github.com/repos/$OWNER/$REPO/actions/workflows/$WORKFLOW_FILE/dispatches" \
           -H "Accept: application/vnd.github.v3+json" \
           -H "Authorization: Bearer $GITHUB_TOKEN" \
           -H "Content-Type: application/json" \
           -d '{ "ref": "main", "inputs": { "target_branch": "'"$TARGET_BRANCH"'" } }'
-          
+
   - name: custom-task
     taskSpec:
       steps:

--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -70,8 +70,8 @@ spec:
     description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
     name: build-args-file
     type: string
-  - default: "does-not-exist" 
-    description: Kubernetes secret to mount into build, see https://www.redhat.com/en/blog/sensitive-data-containers 
+  - default: "does-not-exist"
+    description: Kubernetes secret to mount into build, see https://www.redhat.com/en/blog/sensitive-data-containers
     name: additional-build-secret
     type: string
   - default: "synk-secret"
@@ -125,7 +125,7 @@ spec:
       - name: url
         value: https://github.com/red-hat-data-services/rhoai-konflux-tasks.git
       - name: revision
-        value: main
+        value: 19a01971a39db7e50c40e6db8405dfa957eec70b
       - name: pathInRepo
         value: konflux-tekton-tasks/rhoai-init/0.1/rhoai-init.yaml
   - name: init
@@ -595,7 +595,7 @@ spec:
     - input: $(tasks.rhoai-init.results.skip-slack-message)
       operator: in
       values:
-      - "false" 
+      - "false"
   workspaces:
   - name: git-auth
     optional: true

--- a/pipelines/vllm-cpu-container-build.yaml
+++ b/pipelines/vllm-cpu-container-build.yaml
@@ -82,8 +82,8 @@ spec:
   - default: linux/ppc64le
     name: ppc64le-build-platform
     type: string
-  - default: "does-not-exist" 
-    description: Kubernetes secret to mount into build, see https://www.redhat.com/en/blog/sensitive-data-containers 
+  - default: "does-not-exist"
+    description: Kubernetes secret to mount into build, see https://www.redhat.com/en/blog/sensitive-data-containers
     name: additional-build-secret
     type: string
   - default: "synk-secret"
@@ -133,7 +133,7 @@ spec:
       - name: url
         value: https://github.com/red-hat-data-services/rhoai-konflux-tasks.git
       - name: revision
-        value: main
+        value: 19a01971a39db7e50c40e6db8405dfa957eec70b
       - name: pathInRepo
         value: konflux-tekton-tasks/rhoai-init/0.1/rhoai-init.yaml
   - name: init
@@ -657,7 +657,7 @@ spec:
     - input: $(tasks.rhoai-init.results.skip-slack-message)
       operator: in
       values:
-      - "false" 
+      - "false"
   workspaces:
   - name: git-auth
     optional: true


### PR DESCRIPTION
Conforma requires konflux tasks to be pinned
to a specific version/revision.