### PR TITLE
fix issue with container-build

### DIFF
--- a/pipelines/container-build.yaml
+++ b/pipelines/container-build.yaml
@@ -589,7 +589,7 @@ spec:
     - name: ADDITIONAL_SECRET
       value: $(params.additional-build-secret)
     - name: IMAGE
-      value: $(params.output-image)
+      value: $(params.sealights-config.output-image)
     - name: DOCKERFILE
       value: $(params.dockerfile)
     - name: CONTEXT


### PR DESCRIPTION
sealights images were inadvertently being pushed to the real quay repo instead of the sealights one
