### PR TITLE
change container build name

### DIFF
--- a/pipelines/container-build.yaml
+++ b/pipelines/container-build.yaml
@@ -576,7 +576,7 @@ spec:
       - name: url
         value: https://github.com/red-hat-data-services/rhoai-konflux-tasks.git
       - name: revision
-        value: 69c1b54b1563436374a1172b78508075b64b7b84
+        value: 1193a3b72b9d0d7e9ffac10731caf9bdd727e8e7
       - name: pathInRepo
         value: konflux-tekton-tasks/rhoai-inject-sealights-oci-ta/0.1/rhoai-inject-sealights-oci-ta.yaml
     when:
@@ -584,7 +584,7 @@ spec:
       operator: in
       values:
       - "true"
-  - name: build-sealights-images
+  - name: build-sealights-container
     params:
     - name: ADDITIONAL_SECRET
       value: $(params.additional-build-secret)

--- a/pipelines/fbc-fragment-build.yaml
+++ b/pipelines/fbc-fragment-build.yaml
@@ -583,8 +583,7 @@ spec:
       - name: url
         value: https://github.com/red-hat-data-services/rhoai-konflux-tasks.git
       - name: revision
-        value: sealights-tweaks
-        # value: 69c1b54b1563436374a1172b78508075b64b7b84
+        value: 1193a3b72b9d0d7e9ffac10731caf9bdd727e8e7 
       - name: pathInRepo
         value: konflux-tekton-tasks/rhoai-inject-sealights-oci-ta/0.1/rhoai-inject-sealights-oci-ta.yaml
     when:


### PR DESCRIPTION
need to make the build step name differentiable from the multi-arch build step names so that we can figure out which step needs to be analyzed using cosign for both single arch and multi arch builds
