### PR TITLE
stop renovate for rhoai-2.21

### DIFF
--- a/renovate/default-renovate.json
+++ b/renovate/default-renovate.json
@@ -2,7 +2,7 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": ["config:recommended"],
     "branchPrefix": "renovate/",
-    "baseBranches": ["main", "rhoai-2.8", "rhoai-2.16", "rhoai-2.19",  "rhoai-2.21",  "rhoai-2.22"],
+    "baseBranches": ["main", "rhoai-2.8", "rhoai-2.16", "rhoai-2.19",  "rhoai-2.22"],
     "ignoreTests": true,
     "automergeType": "pr",
     "automerge": true,
@@ -11,7 +11,7 @@
     "packageRules": [
       {
         "matchManagers": ["dockerfile"],
-        "matchBaseBranches": ["main", "rhoai-2.8", "rhoai-2.16", "rhoai-2.19", "rhoai-2.21",  "rhoai-2.22"],
+        "matchBaseBranches": ["main", "rhoai-2.8", "rhoai-2.16", "rhoai-2.19",  "rhoai-2.22"],
         "matchUpdateTypes": ["digest"],
         "matchFileNames": ["*Dockerfile.konflux*"],
         "enabled": true,
@@ -46,11 +46,6 @@
         "schedule": ["at any time"],
         "branchPrefix": "renovate/rpm/",
        "semanticCommits": "enabled"
-      },
-      {
-        "matchManagers": ["rpm"],
-        "matchBaseBranches": ["rhoai-2.21"],
-        "enabled": false
       }
     ],
     "dockerfile": {


### PR DESCRIPTION
we are past code freeze and dependency updates should stop to ease the effort to release.