### PR TITLE
update used service account for odh-trustyai-service-operator

### DIFF
--- a/pipelineruns/trustyai-service-operator/.tekton/odh-trustyai-service-operator-v2-21-push.yaml
+++ b/pipelineruns/trustyai-service-operator/.tekton/odh-trustyai-service-operator-v2-21-push.yaml
@@ -52,7 +52,7 @@ spec:
     - name: pathInRepo
       value: pipelines/container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-trustyai-service-operator-v2-21
+    serviceAccountName: build-pipeline-odh-trustyai-service-operator
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
```
failed to create task run pod "odh-trustyai-service-operator-v2-21-on-push-xqqff-rhoai-init": translating TaskSpec to Pod: serviceaccounts "build-pipeline-odh-trustyai-service-operator-v2-21" not found. Maybe missing or invalid Task rhoai-tenant/
```