### PR TITLE
use centralized renovate configuration for pipelines

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,18 +1,7 @@
+
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "baseBranches": ["/^rhoai-\\d+\\.\\d+$/"],
-  "dependencyDashboard": true,
-  "enabledManagers": ["tekton"],
-  "tekton": {
-    "schedule": ["at any time"],
-    "fileMatch": ["\\.yaml$", "\\.yml$"],
-    "includePaths": ["pipelineruns/**", "pipelines/**", "tasks/**"],
-    "automerge": true,
-    "packageRules": [
-      {
-        "matchUpdateTypes": ["major", "minor", "pin", "pinDigest"],
-        "enabled": false
-      }
-    ]
-  }
+  "extends": [
+    "github>red-hat-data-services/konflux-central//renovate/pipelines-renovate.json"
+  ]
 }

--- a/renovate/pipelines-renovate.json
+++ b/renovate/pipelines-renovate.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "baseBranches": ["/^rhoai-\\d+\\.\\d+$/"],
+  "dependencyDashboard": true,
+  "enabledManagers": ["tekton"],
+  "tekton": {
+    "schedule": ["at any time"],
+    "fileMatch": ["\\.yaml$", "\\.yml$"],
+    "includePaths": ["pipelineruns/**", "pipelines/**", "tasks/**"],
+    "automerge": true,
+    "packageRules": [
+      {
+        "matchUpdateTypes": ["major", "minor", "pin", "pinDigest"],
+        "enabled": false
+      }
+    ]
+  }
+}


### PR DESCRIPTION
related to #198

create another custom configuration of konflux-central and extend that config in .github/renovate.json of konflux-central repository