### PR TITLE
add pipeline success indicator task (rhoai-2.22)

### DIFF
--- a/pipelines/container-build.yaml
+++ b/pipelines/container-build.yaml
@@ -558,6 +558,25 @@ spec:
       operator: in
       values:
       - "false"
+  - name: pipeline-success-indicator
+    runAfter:
+    - build-source-image
+    - sast-shell-check
+    - sast-unicode-check
+    - deprecated-base-image-check
+    - clair-scan
+    - ecosystem-cert-preflight-checks
+    - sast-snyk-check
+    - clamav-scan
+    - apply-tags
+    - push-dockerfile
+    - rpms-signature-scan
+    taskSpec:
+      steps:
+      - name: noop
+        image: quay.io/rhoai-konflux/alpine:latest
+        script: |
+          echo "Success"
   - name: inject-sealights
     params:
     - name: oci-storage
@@ -672,10 +691,10 @@ spec:
         value: task
       resolver: bundles
     when:
-    - input: $(tasks.status)
-      operator: in
+    - input: $(tasks.pipeline-success-indicator.status)
+      operator: notin
       values:
-      - "Failed"
+      - "Succeeded"
     - input: $(tasks.rhoai-init.results.skip-slack-message)
       operator: in
       values:

--- a/pipelines/fbc-fragment-build.yaml
+++ b/pipelines/fbc-fragment-build.yaml
@@ -418,7 +418,7 @@ spec:
       - name: name
         value: deprecated-image-check
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:ecd33669676b3a193ff4c2c6223cb912cc1b0cf5cc36e080eaec7718500272cf
+        value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:3c8b81fa868e27c6266e7660a4bfb4c822846dcf4304606e71e20893b0d3e515
       - name: kind
         value: task
       resolver: bundles

--- a/pipelines/fbc-fragment-build.yaml
+++ b/pipelines/fbc-fragment-build.yaml
@@ -564,6 +564,20 @@ spec:
           echo -n "${slack_message}" > "$(results.slack-message-sucess-text.path)"
     runAfter:
     - build-image-index
+  - name: pipeline-success-indicator
+    runAfter:
+    - fbc-fips-check-oci-ta
+    - sast-shell-check
+    - sast-unicode-check
+    - deprecated-base-image-check
+    - apply-tags,prepare-slack-message
+    - fbc-target-index-pruning-check
+    taskSpec:
+      steps:
+      - name: noop
+        image: quay.io/rhoai-konflux/alpine:latest
+        script: |
+          echo "Success"
   - name: inject-sealights
     params:
     - name: oci-storage
@@ -717,10 +731,10 @@ spec:
         value: task
       resolver: bundles
     when:
-    - input: $(tasks.status)
-      operator: in
+    - input: $(tasks.pipeline-success-indicator.status)
+      operator: notin
       values:
-      - "Failed"
+      - "Succeeded"
   - name: share-fbc-details
     params:
     - name: message

--- a/pipelines/fbc-fragment-build.yaml
+++ b/pipelines/fbc-fragment-build.yaml
@@ -570,7 +570,8 @@ spec:
     - sast-shell-check
     - sast-unicode-check
     - deprecated-base-image-check
-    - apply-tags,prepare-slack-message
+    - apply-tags
+    - prepare-slack-message
     - fbc-target-index-pruning-check
     taskSpec:
       steps:

--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -595,6 +595,25 @@ spec:
       operator: in
       values:
       - "false"
+  - name: pipeline-success-indicator
+    runAfter:
+    - build-source-image
+    - sast-shell-check
+    - sast-unicode-check
+    - deprecated-base-image-check
+    - clair-scan
+    - ecosystem-cert-preflight-checks
+    - sast-snyk-check
+    - clamav-scan
+    - apply-tags
+    - push-dockerfile
+    - rpms-signature-scan
+    taskSpec:
+      steps:
+      - name: noop
+        image: quay.io/rhoai-konflux/alpine:latest
+        script: |
+          echo "Success"
   - name: sealights-nodejs-instrumentation
     when:
     - input: $(params.sealights-config.build)
@@ -772,10 +791,10 @@ spec:
         value: task
       resolver: bundles
     when:
-    - input: $(tasks.status)
-      operator: in
+    - input: $(tasks.pipeline-success-indicator.status)
+      operator: notin
       values:
-      - "Failed"
+      - "Succeeded"
     - input: $(tasks.rhoai-init.results.skip-slack-message)
       operator: in
       values:

--- a/pipelines/vllm-cpu-container-build.yaml
+++ b/pipelines/vllm-cpu-container-build.yaml
@@ -618,6 +618,25 @@ spec:
       operator: in
       values:
       - "false"
+  - name: pipeline-success-indicator
+    runAfter:
+    - build-source-image
+    - sast-shell-check
+    - sast-unicode-check
+    - deprecated-base-image-check
+    - clair-scan
+    - ecosystem-cert-preflight-checks
+    - sast-snyk-check
+    - clamav-scan
+    - apply-tags
+    - push-dockerfile
+    - rpms-signature-scan
+    taskSpec:
+      steps:
+      - name: noop
+        image: quay.io/rhoai-konflux/alpine:latest
+        script: |
+          echo "Success"
   finally:
   - name: show-sbom
     params:
@@ -650,10 +669,10 @@ spec:
         value: task
       resolver: bundles
     when:
-    - input: $(tasks.status)
-      operator: in
+    - input: $(tasks.pipeline-success-indicator.status)
+      operator: notin
       values:
-      - "Failed"
+      - "Succeeded"
     - input: $(tasks.rhoai-init.results.skip-slack-message)
       operator: in
       values:


### PR DESCRIPTION
part of https://issues.redhat.com/browse/RHOAIENG-27779

this PR adds a task that runs after all critical tasks in a pipeline.

specifically, it doesn't run after sealights tasks.

currently, a failure in a sealights task mark the aggregated status (`$(tasks.status)`) as failed. with this change, we will not look at the aggregated status, but at the aggregated status of critical tasks only.

this will help us avoid slack noise for sealights related failures.

slack thread: https://redhat-internal.slack.com/archives/CSPS1077U/p1750252742385719