### PR TITLE
remove 2.16 from tekton renovate updates

### DIFF
--- a/renovate/default-renovate.json
+++ b/renovate/default-renovate.json
@@ -24,7 +24,7 @@
       },
       {
         "matchManagers": ["tekton"],
-        "matchBaseBranches": ["rhoai-2.8", "rhoai-2.16"],
+        "matchBaseBranches": ["rhoai-2.8"],
         "matchUpdateTypes": ["digest", "minor"],
         "schedule": ["* 0-3 1 * *"], 
         "enabled": true,


### PR DESCRIPTION
now that 2.16 is onboarded to konflux-central, we do not want to have the component repo's renovate bots updating the tekton files. instead, the konflux-central renovate bot will update.
