### PR TITLE
multi-arch pipelines migration (rhoai-2.24)

### DIFF
--- a/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-argoexec-v2-24-push.yaml
+++ b/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-argoexec-v2-24-push.yaml
@@ -45,7 +45,7 @@ spec:
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-argoexec-v2-24-push.yaml
+++ b/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-argoexec-v2-24-push.yaml
@@ -46,6 +46,9 @@ spec:
     value: true
   - name: build-image-index
     value: false
+  - name: build-platforms
+    value:
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:
@@ -54,7 +57,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-data-science-pipelines-argo-argoexec-v2-24
   workspaces:

--- a/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-workflowcontroller-v2-24-push.yaml
+++ b/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-workflowcontroller-v2-24-push.yaml
@@ -45,6 +45,9 @@ spec:
     value: true
   - name: build-image-index
     value: false
+  - name: build-platforms
+    value:
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:
@@ -53,7 +56,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-data-science-pipelines-argo-workflowcontroller-v2-24
   workspaces:

--- a/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-workflowcontroller-v2-24-push.yaml
+++ b/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-workflowcontroller-v2-24-push.yaml
@@ -44,7 +44,7 @@ spec:
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/codeflare-operator/.tekton/odh-codeflare-operator-v2-24-push.yaml
+++ b/pipelineruns/codeflare-operator/.tekton/odh-codeflare-operator-v2-24-push.yaml
@@ -46,6 +46,9 @@ spec:
     value: true
   - name: build-image-index
     value: false
+  - name: build-platforms
+    value:
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:
@@ -54,7 +57,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-codeflare-operator-v2-24
   workspaces:

--- a/pipelineruns/codeflare-operator/.tekton/odh-codeflare-operator-v2-24-push.yaml
+++ b/pipelineruns/codeflare-operator/.tekton/odh-codeflare-operator-v2-24-push.yaml
@@ -45,7 +45,7 @@ spec:
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/data-science-pipelines-operator/.tekton/odh-data-science-pipelines-operator-controller-v2-24-push.yaml
+++ b/pipelineruns/data-science-pipelines-operator/.tekton/odh-data-science-pipelines-operator-controller-v2-24-push.yaml
@@ -46,6 +46,9 @@ spec:
     value: true
   - name: build-image-index
     value: false
+  - name: build-platforms
+    value:
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:
@@ -54,7 +57,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-data-science-pipelines-operator-controller-v2-24
   workspaces:

--- a/pipelineruns/data-science-pipelines-operator/.tekton/odh-data-science-pipelines-operator-controller-v2-24-push.yaml
+++ b/pipelineruns/data-science-pipelines-operator/.tekton/odh-data-science-pipelines-operator-controller-v2-24-push.yaml
@@ -45,7 +45,7 @@ spec:
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-api-server-v2-v2-24-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-api-server-v2-v2-24-push.yaml
@@ -46,6 +46,9 @@ spec:
     value: true
   - name: build-image-index
     value: false
+  - name: build-platforms
+    value:
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:
@@ -54,7 +57,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-ml-pipelines-api-server-v2-v2-24
   workspaces:

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-api-server-v2-v2-24-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-api-server-v2-v2-24-push.yaml
@@ -45,7 +45,7 @@ spec:
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-driver-v2-24-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-driver-v2-24-push.yaml
@@ -46,6 +46,9 @@ spec:
     value: true
   - name: build-image-index
     value: false
+  - name: build-platforms
+    value:
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:
@@ -54,7 +57,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-ml-pipelines-driver-v2-24
   workspaces:

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-driver-v2-24-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-driver-v2-24-push.yaml
@@ -45,7 +45,7 @@ spec:
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-launcher-v2-24-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-launcher-v2-24-push.yaml
@@ -45,7 +45,7 @@ spec:
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-launcher-v2-24-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-launcher-v2-24-push.yaml
@@ -46,6 +46,9 @@ spec:
     value: true
   - name: build-image-index
     value: false
+  - name: build-platforms
+    value:
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:
@@ -54,7 +57,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-ml-pipelines-launcher-v2-24
   workspaces:

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-persistenceagent-v2-v2-24-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-persistenceagent-v2-v2-24-push.yaml
@@ -45,7 +45,7 @@ spec:
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-persistenceagent-v2-v2-24-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-persistenceagent-v2-v2-24-push.yaml
@@ -46,6 +46,9 @@ spec:
     value: true
   - name: build-image-index
     value: false
+  - name: build-platforms
+    value:
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:
@@ -54,7 +57,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-ml-pipelines-persistenceagent-v2-v2-24
   workspaces:

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-scheduledworkflow-v2-v2-24-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-scheduledworkflow-v2-v2-24-push.yaml
@@ -45,7 +45,7 @@ spec:
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-scheduledworkflow-v2-v2-24-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-scheduledworkflow-v2-v2-24-push.yaml
@@ -46,6 +46,9 @@ spec:
     value: true
   - name: build-image-index
     value: false
+  - name: build-platforms
+    value:
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:
@@ -54,7 +57,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-ml-pipelines-scheduledworkflow-v2-v2-24
   workspaces:

--- a/pipelineruns/feast/.tekton/odh-feast-operator-v2-24-push.yaml
+++ b/pipelineruns/feast/.tekton/odh-feast-operator-v2-24-push.yaml
@@ -45,7 +45,7 @@ spec:
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/feast/.tekton/odh-feast-operator-v2-24-push.yaml
+++ b/pipelineruns/feast/.tekton/odh-feast-operator-v2-24-push.yaml
@@ -46,6 +46,9 @@ spec:
     value: true
   - name: build-image-index
     value: false
+  - name: build-platforms
+    value:
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:
@@ -54,7 +57,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-feast-operator-v2-24
   workspaces:

--- a/pipelineruns/feast/.tekton/odh-feature-server-v2-24-push.yaml
+++ b/pipelineruns/feast/.tekton/odh-feature-server-v2-24-push.yaml
@@ -57,6 +57,9 @@ spec:
     value: true
   - name: build-image-index
     value: false
+  - name: build-platforms
+    value:
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:
@@ -65,7 +68,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-feature-server-v2-24
   workspaces:

--- a/pipelineruns/feast/.tekton/odh-feature-server-v2-24-push.yaml
+++ b/pipelineruns/feast/.tekton/odh-feature-server-v2-24-push.yaml
@@ -56,7 +56,7 @@ spec:
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/ilab-on-ocp/.tekton/odh-ml-pipelines-runtime-generic-v2-24-push.yaml
+++ b/pipelineruns/ilab-on-ocp/.tekton/odh-ml-pipelines-runtime-generic-v2-24-push.yaml
@@ -47,7 +47,7 @@ spec:
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/ilab-on-ocp/.tekton/odh-ml-pipelines-runtime-generic-v2-24-push.yaml
+++ b/pipelineruns/ilab-on-ocp/.tekton/odh-ml-pipelines-runtime-generic-v2-24-push.yaml
@@ -48,6 +48,9 @@ spec:
     value: true
   - name: build-image-index
     value: false
+  - name: build-platforms
+    value:
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:
@@ -56,7 +59,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-ml-pipelines-runtime-generic-v2-24
   workspaces:

--- a/pipelineruns/kubeflow/.tekton/odh-kf-notebook-controller-v2-24-push.yaml
+++ b/pipelineruns/kubeflow/.tekton/odh-kf-notebook-controller-v2-24-push.yaml
@@ -45,7 +45,7 @@ spec:
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/kubeflow/.tekton/odh-kf-notebook-controller-v2-24-push.yaml
+++ b/pipelineruns/kubeflow/.tekton/odh-kf-notebook-controller-v2-24-push.yaml
@@ -46,6 +46,9 @@ spec:
     value: true
   - name: build-image-index
     value: false
+  - name: build-platforms
+    value:
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:
@@ -54,7 +57,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-kf-notebook-controller-v2-24
   workspaces:

--- a/pipelineruns/kubeflow/.tekton/odh-notebook-controller-v2-24-push.yaml
+++ b/pipelineruns/kubeflow/.tekton/odh-notebook-controller-v2-24-push.yaml
@@ -46,6 +46,9 @@ spec:
     value: true
   - name: build-image-index
     value: false
+  - name: build-platforms
+    value:
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:
@@ -54,7 +57,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-notebook-controller-v2-24
   workspaces:

--- a/pipelineruns/kubeflow/.tekton/odh-notebook-controller-v2-24-push.yaml
+++ b/pipelineruns/kubeflow/.tekton/odh-notebook-controller-v2-24-push.yaml
@@ -45,7 +45,7 @@ spec:
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/kuberay/.tekton/odh-kuberay-operator-controller-v2-24-push.yaml
+++ b/pipelineruns/kuberay/.tekton/odh-kuberay-operator-controller-v2-24-push.yaml
@@ -46,6 +46,9 @@ spec:
     value: true
   - name: build-image-index
     value: false
+  - name: build-platforms
+    value:
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:
@@ -54,7 +57,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-kuberay-operator-controller-v2-24
   workspaces:

--- a/pipelineruns/kuberay/.tekton/odh-kuberay-operator-controller-v2-24-push.yaml
+++ b/pipelineruns/kuberay/.tekton/odh-kuberay-operator-controller-v2-24-push.yaml
@@ -45,7 +45,7 @@ spec:
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/kueue/.tekton/odh-kueue-controller-v2-24-push.yaml
+++ b/pipelineruns/kueue/.tekton/odh-kueue-controller-v2-24-push.yaml
@@ -45,7 +45,7 @@ spec:
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/kueue/.tekton/odh-kueue-controller-v2-24-push.yaml
+++ b/pipelineruns/kueue/.tekton/odh-kueue-controller-v2-24-push.yaml
@@ -46,6 +46,9 @@ spec:
     value: true
   - name: build-image-index
     value: false
+  - name: build-platforms
+    value:
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:
@@ -54,7 +57,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-kueue-controller-v2-24
   workspaces:

--- a/pipelineruns/llama-stack-k8s-operator/.tekton/odh-llama-stack-k8s-operator-v2-24-push.yaml
+++ b/pipelineruns/llama-stack-k8s-operator/.tekton/odh-llama-stack-k8s-operator-v2-24-push.yaml
@@ -47,6 +47,9 @@ spec:
     value: true
   - name: build-image-index
     value: false
+  - name: build-platforms
+    value:
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:
@@ -55,7 +58,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-llama-stack-k8s-operator-v2-24
   workspaces:

--- a/pipelineruns/llama-stack-k8s-operator/.tekton/odh-llama-stack-k8s-operator-v2-24-push.yaml
+++ b/pipelineruns/llama-stack-k8s-operator/.tekton/odh-llama-stack-k8s-operator-v2-24-push.yaml
@@ -46,7 +46,7 @@ spec:
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/llm-d-inference-scheduler/.tekton/odh-llm-d-inference-scheduler-v2-24-push.yaml
+++ b/pipelineruns/llm-d-inference-scheduler/.tekton/odh-llm-d-inference-scheduler-v2-24-push.yaml
@@ -45,7 +45,10 @@ spec:
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: false
+    value: true
+  - name: build-platforms
+    value:
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:
@@ -54,7 +57,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-llm-d-inference-scheduler-v2-24
   workspaces:

--- a/pipelineruns/llm-d-routing-sidecar/.tekton/odh-llm-d-routing-sidecar-v2-24-push.yaml
+++ b/pipelineruns/llm-d-routing-sidecar/.tekton/odh-llm-d-routing-sidecar-v2-24-push.yaml
@@ -45,7 +45,10 @@ spec:
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: false
+    value: true
+  - name: build-platforms
+    value:
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:
@@ -54,7 +57,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-llm-d-routing-sidecar-v2-24
   workspaces:

--- a/pipelineruns/lm-evaluation-harness/.tekton/ta-lmes-job-v2-24-push.yaml
+++ b/pipelineruns/lm-evaluation-harness/.tekton/ta-lmes-job-v2-24-push.yaml
@@ -38,7 +38,7 @@ spec:
   - name: build-source-image
     value: false
   - name: build-image-index
-    value: false
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/lm-evaluation-harness/.tekton/ta-lmes-job-v2-24-push.yaml
+++ b/pipelineruns/lm-evaluation-harness/.tekton/ta-lmes-job-v2-24-push.yaml
@@ -39,6 +39,9 @@ spec:
     value: false
   - name: build-image-index
     value: false
+  - name: build-platforms
+    value:
+    - linux/x86_64
   - name: rebuild
     value: true
   - name: skip-checks
@@ -68,7 +71,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-ta-lmes-job-v2-24
   workspaces:

--- a/pipelineruns/ml-metadata/.tekton/odh-mlmd-grpc-server-v2-24-push.yaml
+++ b/pipelineruns/ml-metadata/.tekton/odh-mlmd-grpc-server-v2-24-push.yaml
@@ -50,7 +50,7 @@ spec:
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/ml-metadata/.tekton/odh-mlmd-grpc-server-v2-24-push.yaml
+++ b/pipelineruns/ml-metadata/.tekton/odh-mlmd-grpc-server-v2-24-push.yaml
@@ -51,6 +51,9 @@ spec:
     value: true
   - name: build-image-index
     value: false
+  - name: build-platforms
+    value:
+    - linux/x86_64
   taskRunSpecs:
     - pipelineTaskName: build-container
       stepSpecs:
@@ -70,7 +73,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-mlmd-grpc-server-v2-24
   workspaces:

--- a/pipelineruns/model-registry-operator/.tekton/odh-model-registry-operator-v2-24-push.yaml
+++ b/pipelineruns/model-registry-operator/.tekton/odh-model-registry-operator-v2-24-push.yaml
@@ -46,6 +46,9 @@ spec:
     value: true
   - name: build-image-index
     value: false
+  - name: build-platforms
+    value:
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:
@@ -54,7 +57,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-model-registry-operator-v2-24
   workspaces:

--- a/pipelineruns/model-registry-operator/.tekton/odh-model-registry-operator-v2-24-push.yaml
+++ b/pipelineruns/model-registry-operator/.tekton/odh-model-registry-operator-v2-24-push.yaml
@@ -45,7 +45,7 @@ spec:
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/model-registry/.tekton/odh-model-registry-v2-24-push.yaml
+++ b/pipelineruns/model-registry/.tekton/odh-model-registry-v2-24-push.yaml
@@ -46,6 +46,9 @@ spec:
     value: true
   - name: build-image-index
     value: false
+  - name: build-platforms
+    value:
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:
@@ -54,7 +57,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-model-registry-v2-24
   workspaces:

--- a/pipelineruns/model-registry/.tekton/odh-model-registry-v2-24-push.yaml
+++ b/pipelineruns/model-registry/.tekton/odh-model-registry-v2-24-push.yaml
@@ -45,7 +45,7 @@ spec:
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/modelmesh-runtime-adapter/.tekton/odh-modelmesh-runtime-adapter-v2-24-push.yaml
+++ b/pipelineruns/modelmesh-runtime-adapter/.tekton/odh-modelmesh-runtime-adapter-v2-24-push.yaml
@@ -47,6 +47,9 @@ spec:
     value: true
   - name: build-image-index
     value: false
+  - name: build-platforms
+    value:
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:
@@ -55,7 +58,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-modelmesh-runtime-adapter-v2-24
   workspaces:

--- a/pipelineruns/modelmesh-runtime-adapter/.tekton/odh-modelmesh-runtime-adapter-v2-24-push.yaml
+++ b/pipelineruns/modelmesh-runtime-adapter/.tekton/odh-modelmesh-runtime-adapter-v2-24-push.yaml
@@ -46,7 +46,7 @@ spec:
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/modelmesh-serving/.tekton/odh-modelmesh-serving-controller-v2-24-push.yaml
+++ b/pipelineruns/modelmesh-serving/.tekton/odh-modelmesh-serving-controller-v2-24-push.yaml
@@ -45,7 +45,7 @@ spec:
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/modelmesh-serving/.tekton/odh-modelmesh-serving-controller-v2-24-push.yaml
+++ b/pipelineruns/modelmesh-serving/.tekton/odh-modelmesh-serving-controller-v2-24-push.yaml
@@ -46,6 +46,9 @@ spec:
     value: true
   - name: build-image-index
     value: false
+  - name: build-platforms
+    value:
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:
@@ -54,7 +57,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-modelmesh-serving-controller-v2-24
   workspaces:

--- a/pipelineruns/modelmesh/.tekton/odh-modelmesh-v2-24-push.yaml
+++ b/pipelineruns/modelmesh/.tekton/odh-modelmesh-v2-24-push.yaml
@@ -49,7 +49,7 @@ spec:
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/modelmesh/.tekton/odh-modelmesh-v2-24-push.yaml
+++ b/pipelineruns/modelmesh/.tekton/odh-modelmesh-v2-24-push.yaml
@@ -50,6 +50,9 @@ spec:
     value: true
   - name: build-image-index
     value: false
+  - name: build-platforms
+    value:
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:
@@ -58,7 +61,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-modelmesh-v2-24
   workspaces:

--- a/pipelineruns/rest-proxy/.tekton/odh-mm-rest-proxy-v2-24-push.yaml
+++ b/pipelineruns/rest-proxy/.tekton/odh-mm-rest-proxy-v2-24-push.yaml
@@ -40,7 +40,7 @@ spec:
   - name: hermetic
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: prefetch-input
     value: |
       {"type": "gomod", "path": "."}

--- a/pipelineruns/rest-proxy/.tekton/odh-mm-rest-proxy-v2-24-push.yaml
+++ b/pipelineruns/rest-proxy/.tekton/odh-mm-rest-proxy-v2-24-push.yaml
@@ -39,6 +39,8 @@ spec:
     value: .
   - name: hermetic
     value: true
+  - name: build-image-index
+    value: false
   - name: prefetch-input
     value: |
       {"type": "gomod", "path": "."}
@@ -50,7 +52,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-mm-rest-proxy-v2-24
   workspaces:

--- a/pipelineruns/training-operator/.tekton/odh-training-operator-v2-24-push.yaml
+++ b/pipelineruns/training-operator/.tekton/odh-training-operator-v2-24-push.yaml
@@ -45,7 +45,7 @@ spec:
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/training-operator/.tekton/odh-training-operator-v2-24-push.yaml
+++ b/pipelineruns/training-operator/.tekton/odh-training-operator-v2-24-push.yaml
@@ -46,6 +46,9 @@ spec:
     value: true
   - name: build-image-index
     value: false
+  - name: build-platforms
+    value:
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:
@@ -54,7 +57,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-training-operator-v2-24
   workspaces:

--- a/pipelineruns/trustyai-explainability/.tekton/odh-trustyai-service-v2-24-push.yaml
+++ b/pipelineruns/trustyai-explainability/.tekton/odh-trustyai-service-v2-24-push.yaml
@@ -39,6 +39,11 @@ spec:
     value: .
   - name: hermetic
     value: true
+  - name: build-image-index
+    value: false
+  - name: build-platforms
+    value:
+    - linux/x86_64
   - name: prefetch-input
     value: |
       [{"path": ".", "type": "rpm"}, {"path": ".", "type": "generic"}]
@@ -50,7 +55,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-trustyai-service-v2-24
   workspaces:

--- a/pipelineruns/trustyai-explainability/.tekton/odh-trustyai-service-v2-24-push.yaml
+++ b/pipelineruns/trustyai-explainability/.tekton/odh-trustyai-service-v2-24-push.yaml
@@ -40,7 +40,7 @@ spec:
   - name: hermetic
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/trustyai-service-operator/.tekton/odh-trustyai-service-operator-v2-24-push.yaml
+++ b/pipelineruns/trustyai-service-operator/.tekton/odh-trustyai-service-operator-v2-24-push.yaml
@@ -40,7 +40,7 @@ spec:
   - name: hermetic
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/trustyai-service-operator/.tekton/odh-trustyai-service-operator-v2-24-push.yaml
+++ b/pipelineruns/trustyai-service-operator/.tekton/odh-trustyai-service-operator-v2-24-push.yaml
@@ -39,6 +39,11 @@ spec:
     value: .
   - name: hermetic
     value: true
+  - name: build-image-index
+    value: false
+  - name: build-platforms
+    value:
+    - linux/x86_64
   - name: prefetch-input
     value: |
       {"type": "gomod", "path": "."}
@@ -50,7 +55,7 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-trustyai-service-operator-v2-24
   workspaces:


### PR DESCRIPTION
part of:
- https://issues.redhat.com/browse/RHOAIENG-27351
- https://issues.redhat.com/browse/RHOAIENG-28846

this PR changes all single-arch pipelines to multi-arch pipelines.

switch all pipelines to be multi-arch (use linux/x86_64 for build platform and set build-image-index to false)
when adding a 2nd platform - set build-image-index to true

in this PR we are enabling the different components to start working towards ARM support in their code, code dependencies and Dockerfiles/Containerfiles.
once ready, an addition of ARM build platform can be made, to enable ARM builds.

reference: https://konflux.pages.redhat.com/docs/users/getting-started/multi-platform-builds.html#multi-platform-build-vms-for-amd64-and-arm64