### PR TITLE
add pull-request pipelineruns to main

### DIFF
--- a/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-argoexec-pull-request.yaml
+++ b/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-argoexec-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-data-science-pipelines-argo-argoexec
     pipelines.appstudio.openshift.io/type: build
   name: odh-data-science-pipelines-argo-argoexec-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-data-science-pipelines-argo-argoexec
   - name: output-image
-    value: quay.io/rhoai/odh-data-science-pipelines-argo-argoexec-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-data-science-pipelines-argo-argoexec-{{revision}}
   - name: dockerfile
     value: argo-argoexec/Dockerfile.konflux
   - name: path-context

--- a/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-workflowcontroller-pull-request.yaml
+++ b/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-workflowcontroller-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-data-science-pipelines-argo-workflowcontroller
     pipelines.appstudio.openshift.io/type: build
   name: odh-data-science-pipelines-argo-workflowcontroller-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-data-science-pipelines-argo-workflowcontroller
   - name: output-image
-    value: quay.io/rhoai/odh-data-science-pipelines-argo-workflowcontroller-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-data-science-pipelines-argo-workflowcontroller-{{revision}}
   - name: dockerfile
     value: argo-workflowcontroller/Dockerfile.konflux
   - name: path-context

--- a/pipelineruns/codeflare-operator/.tekton/odh-codeflare-operator-pull-request.yaml
+++ b/pipelineruns/codeflare-operator/.tekton/odh-codeflare-operator-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-codeflare-operator
     pipelines.appstudio.openshift.io/type: build
   name: odh-codeflare-operator-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-codeflare-operator
   - name: output-image
-    value: quay.io/rhoai/odh-codeflare-operator-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-codeflare-operator-{{revision}}
   - name: dockerfile
     value: Dockerfile.konflux
   - name: path-context

--- a/pipelineruns/data-science-pipelines-operator/.tekton/odh-data-science-pipelines-operator-controller-pull-request.yaml
+++ b/pipelineruns/data-science-pipelines-operator/.tekton/odh-data-science-pipelines-operator-controller-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-data-science-pipelines-operator-controller
     pipelines.appstudio.openshift.io/type: build
   name: odh-data-science-pipelines-operator-controller-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-data-science-pipelines-operator-controller
   - name: output-image
-    value: quay.io/rhoai/odh-data-science-pipelines-operator-controller-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-data-science-pipelines-operator-controller-{{revision}}
   - name: dockerfile
     value: Dockerfile.konflux
   - name: path-context

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-api-server-v2-pull-request.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-api-server-v2-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-ml-pipelines-api-server-v2
     pipelines.appstudio.openshift.io/type: build
   name: odh-ml-pipelines-api-server-v2-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-ml-pipelines-api-server-v2
   - name: output-image
-    value: quay.io/rhoai/odh-ml-pipelines-api-server-v2-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-ml-pipelines-api-server-v2-{{revision}}
   - name: dockerfile
     value: backend/Dockerfile.konflux.api
   - name: path-context

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-driver-pull-request.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-driver-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-ml-pipelines-driver
     pipelines.appstudio.openshift.io/type: build
   name: odh-ml-pipelines-driver-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-ml-pipelines-driver
   - name: output-image
-    value: quay.io/rhoai/odh-ml-pipelines-driver-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-ml-pipelines-driver-{{revision}}
   - name: dockerfile
     value: backend/Dockerfile.konflux.driver
   - name: path-context

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-launcher-pull-request.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-launcher-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-ml-pipelines-launcher
     pipelines.appstudio.openshift.io/type: build
   name: odh-ml-pipelines-launcher-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-ml-pipelines-launcher
   - name: output-image
-    value: quay.io/rhoai/odh-ml-pipelines-launcher-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-ml-pipelines-launcher-{{revision}}
   - name: dockerfile
     value: backend/Dockerfile.konflux.launcher
   - name: path-context

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-persistenceagent-v2-pull-request.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-persistenceagent-v2-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-ml-pipelines-persistenceagent-v2
     pipelines.appstudio.openshift.io/type: build
   name: odh-ml-pipelines-persistenceagent-v2-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-ml-pipelines-persistenceagent-v2
   - name: output-image
-    value: quay.io/rhoai/odh-ml-pipelines-persistenceagent-v2-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-ml-pipelines-persistenceagent-v2-{{revision}}
   - name: dockerfile
     value: backend/Dockerfile.konflux.persistenceagent
   - name: path-context

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-scheduledworkflow-v2-pull-request.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-scheduledworkflow-v2-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-ml-pipelines-scheduledworkflow-v2
     pipelines.appstudio.openshift.io/type: build
   name: odh-ml-pipelines-scheduledworkflow-v2-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-ml-pipelines-scheduledworkflow-v2
   - name: output-image
-    value: quay.io/rhoai/odh-ml-pipelines-scheduledworkflow-v2-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-ml-pipelines-scheduledworkflow-v2-{{revision}}
   - name: dockerfile
     value: backend/Dockerfile.konflux.scheduledworkflow
   - name: path-context

--- a/pipelineruns/feast/.tekton/odh-feast-operator-pull-request.yaml
+++ b/pipelineruns/feast/.tekton/odh-feast-operator-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-feast-operator
     pipelines.appstudio.openshift.io/type: build
   name: odh-feast-operator-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-feast-operator
   - name: output-image
-    value: quay.io/rhoai/odh-feast-operator-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-feast-operator-{{revision}}
   - name: dockerfile
     value: Dockerfiles/Dockerfile.feast-operator.konflux
   - name: path-context

--- a/pipelineruns/feast/.tekton/odh-feature-server-pull-request.yaml
+++ b/pipelineruns/feast/.tekton/odh-feature-server-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-feature-server
     pipelines.appstudio.openshift.io/type: build
   name: odh-feature-server-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-feature-server
   - name: output-image
-    value: quay.io/rhoai/odh-feature-server-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-feature-server-{{revision}}
   - name: dockerfile
     value: Dockerfiles/Dockerfile.feature-server.konflux
   - name: path-context

--- a/pipelineruns/fms-guardrails-orchestrator/.tekton/odh-fms-guardrails-orchestrator-pull-request.yaml
+++ b/pipelineruns/fms-guardrails-orchestrator/.tekton/odh-fms-guardrails-orchestrator-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-fms-guardrails-orchestrator
     pipelines.appstudio.openshift.io/type: build
   name: odh-fms-guardrails-orchestrator-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-fms-guardrails-orchestrator
   - name: output-image
-    value: quay.io/rhoai/odh-fms-guardrails-orchestrator-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-fms-guardrails-orchestrator-{{revision}}
   - name: dockerfile
     value: Dockerfile.konflux
   - name: path-context

--- a/pipelineruns/guardrails-detectors/.tekton/odh-built-in-detector-pull-request.yaml
+++ b/pipelineruns/guardrails-detectors/.tekton/odh-built-in-detector-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-built-in-detector
     pipelines.appstudio.openshift.io/type: build
   name: odh-built-in-detector-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-built-in-detector
   - name: output-image
-    value: quay.io/rhoai/odh-built-in-detector-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-built-in-detector-{{revision}}
   - name: dockerfile
     value: Dockerfile.konflux.builtIn
   - name: path-context

--- a/pipelineruns/ilab-on-ocp/.tekton/odh-ml-pipelines-runtime-generic-pull-request.yaml
+++ b/pipelineruns/ilab-on-ocp/.tekton/odh-ml-pipelines-runtime-generic-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-ml-pipelines-runtime-generic
     pipelines.appstudio.openshift.io/type: build
   name: odh-ml-pipelines-runtime-generic-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-ml-pipelines-runtime-generic
   - name: output-image
-    value: quay.io/rhoai/odh-ml-pipelines-runtime-generic-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-ml-pipelines-runtime-generic-{{revision}}
   - name: dockerfile
     value: Dockerfile.konflux
   - name: path-context

--- a/pipelineruns/kserve/.tekton/odh-kserve-agent-pull-request.yaml
+++ b/pipelineruns/kserve/.tekton/odh-kserve-agent-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-kserve-agent
     pipelines.appstudio.openshift.io/type: build
   name: odh-kserve-agent-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-kserve-agent
   - name: output-image
-    value: quay.io/rhoai/odh-kserve-agent-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-kserve-agent-{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/kserve/.tekton/odh-kserve-controller-pull-request.yaml
+++ b/pipelineruns/kserve/.tekton/odh-kserve-controller-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-kserve-controller
     pipelines.appstudio.openshift.io/type: build
   name: odh-kserve-controller-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-kserve-controller
   - name: output-image
-    value: quay.io/rhoai/odh-kserve-controller-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-kserve-controller-{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/kserve/.tekton/odh-kserve-router-pull-request.yaml
+++ b/pipelineruns/kserve/.tekton/odh-kserve-router-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-kserve-router
     pipelines.appstudio.openshift.io/type: build
   name: odh-kserve-router-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-kserve-router
   - name: output-image
-    value: quay.io/rhoai/odh-kserve-router-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-kserve-router-{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/kserve/.tekton/odh-kserve-storage-initializer-pull-request.yaml
+++ b/pipelineruns/kserve/.tekton/odh-kserve-storage-initializer-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-kserve-storage-initializer
     pipelines.appstudio.openshift.io/type: build
   name: odh-kserve-storage-initializer-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-kserve-storage-initializer
   - name: output-image
-    value: quay.io/rhoai/odh-kserve-storage-initializer-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-kserve-storage-initializer-{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/kubeflow/.tekton/odh-kf-notebook-controller-pull-request.yaml
+++ b/pipelineruns/kubeflow/.tekton/odh-kf-notebook-controller-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-kf-notebook-controller
     pipelines.appstudio.openshift.io/type: build
   name: odh-kf-notebook-controller-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-kf-notebook-controller
   - name: output-image
-    value: quay.io/rhoai/odh-kf-notebook-controller-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-kf-notebook-controller-{{revision}}
   - name: dockerfile
     value: notebook-controller/Dockerfile.konflux
   - name: path-context

--- a/pipelineruns/kubeflow/.tekton/odh-notebook-controller-pull-request.yaml
+++ b/pipelineruns/kubeflow/.tekton/odh-notebook-controller-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-notebook-controller
     pipelines.appstudio.openshift.io/type: build
   name: odh-notebook-controller-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-notebook-controller
   - name: output-image
-    value: quay.io/rhoai/odh-notebook-controller-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-notebook-controller-{{revision}}
   - name: dockerfile
     value: odh-notebook-controller/Dockerfile.konflux
   - name: path-context

--- a/pipelineruns/kuberay/.tekton/odh-kuberay-operator-controller-pull-request.yaml
+++ b/pipelineruns/kuberay/.tekton/odh-kuberay-operator-controller-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-kuberay-operator-controller
     pipelines.appstudio.openshift.io/type: build
   name: odh-kuberay-operator-controller-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-kuberay-operator-controller
   - name: output-image
-    value: quay.io/rhoai/odh-kuberay-operator-controller-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-kuberay-operator-controller-{{revision}}
   - name: dockerfile
     value: ./ray-operator/Dockerfile.konflux
   - name: path-context

--- a/pipelineruns/kueue/.tekton/odh-kueue-controller-pull-request.yaml
+++ b/pipelineruns/kueue/.tekton/odh-kueue-controller-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-kueue-controller
     pipelines.appstudio.openshift.io/type: build
   name: odh-kueue-controller-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-kueue-controller
   - name: output-image
-    value: quay.io/rhoai/odh-kueue-controller-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-kueue-controller-{{revision}}
   - name: dockerfile
     value: Dockerfile.konflux
   - name: path-context

--- a/pipelineruns/llama-stack-k8s-operator/.tekton/odh-llama-stack-k8s-operator-pull-request.yaml
+++ b/pipelineruns/llama-stack-k8s-operator/.tekton/odh-llama-stack-k8s-operator-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-llama-stack-k8s-operator
     pipelines.appstudio.openshift.io/type: build
   name: odh-llama-stack-k8s-operator-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-llama-stack-k8s-operator
   - name: output-image
-    value: quay.io/rhoai/odh-llama-stack-k8s-operator-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-llama-stack-k8s-operator-{{revision}}
   - name: dockerfile
     value: Dockerfile.konflux
   - name: path-context

--- a/pipelineruns/llm-d-inference-scheduler/.tekton/odh-llm-d-inference-scheduler-pull-request.yaml
+++ b/pipelineruns/llm-d-inference-scheduler/.tekton/odh-llm-d-inference-scheduler-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-llm-d-inference-scheduler
     pipelines.appstudio.openshift.io/type: build
   name: odh-llm-d-inference-scheduler-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-llm-d-inference-scheduler
   - name: output-image
-    value: quay.io/rhoai/odh-llm-d-inference-scheduler-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-llm-d-inference-scheduler-{{revision}}
   - name: dockerfile
     value: Dockerfile.konflux
   - name: path-context

--- a/pipelineruns/llm-d-routing-sidecar/.tekton/odh-llm-d-routing-sidecar-pull-request.yaml
+++ b/pipelineruns/llm-d-routing-sidecar/.tekton/odh-llm-d-routing-sidecar-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-llm-d-routing-sidecar
     pipelines.appstudio.openshift.io/type: build
   name: odh-llm-d-routing-sidecar-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-llm-d-routing-sidecar
   - name: output-image
-    value: quay.io/rhoai/odh-llm-d-routing-sidecar-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-llm-d-routing-sidecar-{{revision}}
   - name: dockerfile
     value: Dockerfile.konflux
   - name: path-context

--- a/pipelineruns/lm-evaluation-harness/.tekton/odh-ta-lmes-job-pull-request.yaml
+++ b/pipelineruns/lm-evaluation-harness/.tekton/odh-ta-lmes-job-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-ta-lmes-job
     pipelines.appstudio.openshift.io/type: build
   name: odh-ta-lmes-job-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-ta-lmes-job
   - name: output-image
-    value: quay.io/rhoai/odh-ta-lmes-job-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-ta-lmes-job-{{revision}}
   - name: dockerfile
     value: Dockerfile.konflux.lmes-job
   - name: path-context

--- a/pipelineruns/ml-metadata/.tekton/odh-mlmd-grpc-server-pull-request.yaml
+++ b/pipelineruns/ml-metadata/.tekton/odh-mlmd-grpc-server-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-mlmd-grpc-server
     pipelines.appstudio.openshift.io/type: build
   name: odh-mlmd-grpc-server-on-pull-request
   namespace: rhoai-tenant
@@ -31,7 +31,7 @@ spec:
     value:
     - version=on-pr-{{revision}}
   - name: output-image
-    value: quay.io/rhoai/odh-mlmd-grpc-server-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-mlmd-grpc-server-{{revision}}
   - name: dockerfile
     value: ml_metadata/tools/docker_server/Dockerfile.konflux
   - name: path-context

--- a/pipelineruns/model-registry-operator/.tekton/odh-model-registry-operator-pull-request.yaml
+++ b/pipelineruns/model-registry-operator/.tekton/odh-model-registry-operator-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-model-registry-operator
     pipelines.appstudio.openshift.io/type: build
   name: odh-model-registry-operator-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-model-registry-operator
   - name: output-image
-    value: quay.io/rhoai/odh-model-registry-operator-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-model-registry-operator-{{revision}}
   - name: dockerfile
     value: Dockerfile.konflux
   - name: path-context

--- a/pipelineruns/model-registry/.tekton/odh-model-registry-pull-request.yaml
+++ b/pipelineruns/model-registry/.tekton/odh-model-registry-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-model-registry
     pipelines.appstudio.openshift.io/type: build
   name: odh-model-registry-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-model-registry
   - name: output-image
-    value: quay.io/rhoai/odh-model-registry-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-model-registry-{{revision}}
   - name: dockerfile
     value: Dockerfile.konflux
   - name: path-context

--- a/pipelineruns/modelmesh-runtime-adapter/.tekton/odh-modelmesh-runtime-adapter-pull-request.yaml
+++ b/pipelineruns/modelmesh-runtime-adapter/.tekton/odh-modelmesh-runtime-adapter-pull-request.yaml
@@ -13,7 +13,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-modelmesh-runtime-adapter
     pipelines.appstudio.openshift.io/type: build
   name: odh-modelmesh-runtime-adapter-on-pull-request
   namespace: rhoai-tenant
@@ -31,7 +31,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-model-serving-runtime-adapter
   - name: output-image
-    value: quay.io/rhoai/odh-modelmesh-runtime-adapter-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-modelmesh-runtime-adapter-{{revision}}
   - name: dockerfile
     value: Dockerfile.konflux
   - name: path-context

--- a/pipelineruns/modelmesh-serving/.tekton/odh-modelmesh-serving-controller-pull-request.yaml
+++ b/pipelineruns/modelmesh-serving/.tekton/odh-modelmesh-serving-controller-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-modelmesh-serving-controller
     pipelines.appstudio.openshift.io/type: build
   name: odh-modelmesh-serving-controller-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-modelmesh-serving-controller
   - name: output-image
-    value: quay.io/rhoai/odh-modelmesh-serving-controller-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-modelmesh-serving-controller-{{revision}}
   - name: dockerfile
     value: Dockerfile.konflux
   - name: path-context

--- a/pipelineruns/modelmesh/.tekton/odh-modelmesh-pull-request.yaml
+++ b/pipelineruns/modelmesh/.tekton/odh-modelmesh-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-modelmesh
     pipelines.appstudio.openshift.io/type: build
   name: odh-modelmesh-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-modelmesh
   - name: output-image
-    value: quay.io/rhoai/odh-modelmesh-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-modelmesh-{{revision}}
   - name: dockerfile
     value: Dockerfile.konflux
   - name: path-context

--- a/pipelineruns/must-gather/.tekton/odh-must-gather-pull-request.yaml
+++ b/pipelineruns/must-gather/.tekton/odh-must-gather-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-must-gather
     pipelines.appstudio.openshift.io/type: build
   name: odh-must-gather-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-must-gather
   - name: output-image
-    value: quay.io/rhoai/odh-must-gather-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-must-gather-{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/odh-model-controller/.tekton/odh-model-controller-pull-request.yaml
+++ b/pipelineruns/odh-model-controller/.tekton/odh-model-controller-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-model-controller
     pipelines.appstudio.openshift.io/type: build
   name: odh-model-controller-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-model-controller
   - name: output-image
-    value: quay.io/rhoai/odh-model-controller-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-model-controller-{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/rest-proxy/.tekton/odh-mm-rest-proxy-pull-request.yaml
+++ b/pipelineruns/rest-proxy/.tekton/odh-mm-rest-proxy-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-mm-rest-proxy
     pipelines.appstudio.openshift.io/type: build
   name: odh-mm-rest-proxy-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-mm-rest-proxy
   - name: output-image
-    value: quay.io/rhoai/odh-mm-rest-proxy-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-mm-rest-proxy-{{revision}}
   - name: dockerfile
     value: Dockerfile.konflux
   - name: path-context

--- a/pipelineruns/rhods-operator/.tekton/odh-operator-pull-request.yaml
+++ b/pipelineruns/rhods-operator/.tekton/odh-operator-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-operator
     pipelines.appstudio.openshift.io/type: build
   name: odh-operator-on-pull-request
   namespace: rhoai-tenant
@@ -32,7 +32,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-operator
   - name: output-image
-    value: quay.io/rhoai/odh-rhel9-operator:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-operator-{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/training-operator/.tekton/odh-training-operator-pull-request.yaml
+++ b/pipelineruns/training-operator/.tekton/odh-training-operator-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-training-operator
     pipelines.appstudio.openshift.io/type: build
   name: odh-training-operator-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-training-operator
   - name: output-image
-    value: quay.io/rhoai/odh-training-operator-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-training-operator-{{revision}}
   - name: dockerfile
     value: build/images/training-operator/Dockerfile.konflux
   - name: path-context

--- a/pipelineruns/trustyai-explainability/.tekton/odh-trustyai-service-pull-request.yaml
+++ b/pipelineruns/trustyai-explainability/.tekton/odh-trustyai-service-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-trustyai-service
     pipelines.appstudio.openshift.io/type: build
   name: odh-trustyai-service-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-trustyai-service
   - name: output-image
-    value: quay.io/rhoai/odh-trustyai-service-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-trustyai-service-{{revision}}
   - name: dockerfile
     value: Dockerfile.konflux
   - name: path-context

--- a/pipelineruns/trustyai-service-operator/.tekton/odh-ta-lmes-driver-pull-request.yaml
+++ b/pipelineruns/trustyai-service-operator/.tekton/odh-ta-lmes-driver-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-ta-lmes-driver
     pipelines.appstudio.openshift.io/type: build
   name: odh-ta-lmes-driver-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-ta-lmes-driver
   - name: output-image
-    value: quay.io/rhoai/odh-ta-lmes-driver-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-ta-lmes-driver-{{revision}}
   - name: dockerfile
     value: Dockerfile.konflux.driver
   - name: path-context

--- a/pipelineruns/trustyai-service-operator/.tekton/odh-trustyai-service-operator-pull-request.yaml
+++ b/pipelineruns/trustyai-service-operator/.tekton/odh-trustyai-service-operator-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-trustyai-service-operator
     pipelines.appstudio.openshift.io/type: build
   name: odh-trustyai-service-operator-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-trustyai-service-operator
   - name: output-image
-    value: quay.io/rhoai/odh-trustyai-service-operator-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-trustyai-service-operator-{{revision}}
   - name: dockerfile
     value: Dockerfile.konflux
   - name: path-context

--- a/pipelineruns/vllm-cpu/.tekton/vllm-cpu-pull-request.yaml
+++ b/pipelineruns/vllm-cpu/.tekton/vllm-cpu-pull-request.yaml
@@ -11,10 +11,9 @@ metadata:
     pipelinesascode.tekton.dev/on-label: "[build-all]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-vllm-cpu
     pipelines.appstudio.openshift.io/type: build
   name: vllm-cpu-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +29,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rhoai-tenant/pull-request-pipelines:vllm-cpu-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:vllm-cpu-{{revision}}
   - name: s390x-dockerfile
     value: Dockerfile.s390x.ubi
   - name: ppc64le-dockerfile

--- a/pipelineruns/vllm-orchestrator-gateway/.tekton/odh-trustyai-vllm-orchestrator-gateway-pull-request.yaml
+++ b/pipelineruns/vllm-orchestrator-gateway/.tekton/odh-trustyai-vllm-orchestrator-gateway-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-odh-trustyai-vllm-orchestrator-gateway
     pipelines.appstudio.openshift.io/type: build
   name: odh-trustyai-vllm-orchestrator-gateway-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +30,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-trustyai-vllm-orchestrator-gateway
   - name: output-image
-    value: quay.io/rhoai/odh-trustyai-vllm-orchestrator-gateway-rhel9:on-pr-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-trustyai-vllm-orchestrator-gateway-{{revision}}
   - name: dockerfile
     value: Dockerfile.konflux
   - name: path-context

--- a/pipelineruns/vllm-rocm/.tekton/vllm-rocm-pull-request.yaml
+++ b/pipelineruns/vllm-rocm/.tekton/vllm-rocm-pull-request.yaml
@@ -11,10 +11,9 @@ metadata:
     pipelinesascode.tekton.dev/on-label: "[build-all]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-vllm-rocm
     pipelines.appstudio.openshift.io/type: build
   name: vllm-rocm-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +29,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rhoai-tenant/pull-request-pipelines:vllm-rocm-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:vllm-rocm-{{revision}}
   - name: additional-tags
     value:
     - '{{target_branch}}-rocm-{{revision}}'

--- a/pipelineruns/vllm/.tekton/vllm-cuda-pull-request.yaml
+++ b/pipelineruns/vllm/.tekton/vllm-cuda-pull-request.yaml
@@ -11,10 +11,9 @@ metadata:
     pipelinesascode.tekton.dev/on-label: "[build-all]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines
+    appstudio.openshift.io/component: pull-request-pipelines-vllm-cuda
     pipelines.appstudio.openshift.io/type: build
   name: vllm-cuda-on-pull-request
   namespace: rhoai-tenant
@@ -30,7 +29,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rhoai-tenant/pull-request-pipelines:vllm-cuda-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:vllm-cuda-{{revision}}
   - name: dockerfile
     value: Dockerfile.ubi
   - name: path-context


### PR DESCRIPTION
part of https://issues.redhat.com/browse/RHOAIENG-31585

depends on:
- #245

this PR adds pull-request pipelineruns for the main branch, to provide a platform for changes to be tested by our pipelines before they get merged and shipped to release branches.

the konflux application/component for all pipelineruns is `automation/pull-request-pipelines`

this is a "shift left" exercise, which is this case strongly supports the multiarch effort.