### PR TITLE
add odh-dashboard pipelinerun to main as a poc for pull-request pipelines

### DIFF
--- a/pipelineruns/README.md.in
+++ b/pipelineruns/README.md.in
@@ -1,0 +1,39 @@
+# ⚠️ Do Not Modify Files in the `.tekton/` Directory Directly
+
+The `.tekton/` directory in each component repository is **automatically synchronized** from [`konflux-central`](https://github.com/red-hat-data-services/konflux-central) using automation. Any edits made directly to Tekton files in the component repositories will be **overwritten** by the next sync.
+
+All Tekton file updates **must be made in the `konflux-central` repository**.
+
+## ✅ How to Make Changes
+
+To modify the pipelines for `$repo_name` in the `$branch` branch:
+
+- Clone the [`konflux-central`](https://github.com/red-hat-data-services/konflux-central) repository.
+
+```bash
+git clone git@github.com:red-hat-data-services/konflux-central.git
+cd konflux-central
+```
+
+- Check out the branch
+
+```bash
+git checkout $branch
+```
+
+- Navigate to the Tekton files for your component(s).
+
+```bash
+cd pipelineruns/$repo_name/.tekton
+```
+
+- Make the required changes to the Tekton YAML files.
+
+- Commit and push your changes.
+
+```bash
+git commit -am "Update pipelinerun for $repo_name ($branch)"
+git push origin $branch
+```
+
+- Once pushed, automation will automatically sync your updates to the corresponding component repository.

--- a/pipelineruns/odh-dashboard/.tekton/odh-dashboard-pull-request.yaml
+++ b/pipelineruns/odh-dashboard/.tekton/odh-dashboard-pull-request.yaml
@@ -1,0 +1,74 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/odh-dashboard?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+  labels:
+    appstudio.openshift.io/application: automation
+    appstudio.openshift.io/component: pull-request-pipelines
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-dashboard-on-pull-request
+  namespace: rhoai-tenant
+spec:
+  timeouts:
+    pipeline: 8h
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: additional-tags
+    value:
+    - 'pr-{{pull_request_number}}-into-{{target_branch}}'
+  - name: additional-labels
+    value:
+    - version=on-pr-{{revision}}
+    - io.openshift.tags=odh-dashboard
+  - name: output-image
+    value: quay.io/rhoai/odh-dashboard-rhel9:on-pr-{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux-m2xlarge/arm64
+  - name: image-expires-after
+    value: 5d
+  - name: dockerfile
+    value: Dockerfile.konflux
+  - name: path-context
+    value: .
+  - name: hermetic
+    value: true
+  - name: prefetch-input
+    value: |
+      [
+        {"type": "npm", "path": "."}, 
+        {"type": "npm", "path": "frontend"}, 
+        {"type": "npm", "path": "backend"}
+      ]
+  - name: build-image-index
+    value: true
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ target_branch }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-pull-request-pipelines
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
part of https://issues.redhat.com/browse/RHOAIENG-31585

split from #321 

in this PR we add a single pull-request pipeline to main for odh-dashboard.

from https://github.com/red-hat-data-services/konflux-central/pull/321#pullrequestreview-3093302454:
> Once we merge that, try out some pr pipelines in odh-dashboard and work out any kinks we find, we can PR the rest of the component repos