### PR TITLE
(feat): Enable ARM builds for ilab-on-ocp

### DIFF
--- a/pipelineruns/ilab-on-ocp/.tekton/odh-ml-pipelines-runtime-generic-pull-request.yaml
+++ b/pipelineruns/ilab-on-ocp/.tekton/odh-ml-pipelines-runtime-generic-pull-request.yaml
@@ -50,6 +50,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux-m2xlarge/arm64
   - name: image-expires-after
     value: 5d
   pipelineRef:


### PR DESCRIPTION
Depends on: https://github.com/red-hat-data-services/ilab-on-ocp/pull/246