### PR TITLE
(feat): Enable ARM builds for trustyai-explainability

### DIFF
--- a/pipelineruns/trustyai-explainability/.tekton/odh-trustyai-service-pull-request.yaml
+++ b/pipelineruns/trustyai-explainability/.tekton/odh-trustyai-service-pull-request.yaml
@@ -42,6 +42,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux-m2xlarge/arm64
   - name: image-expires-after
     value: 5d
   - name: prefetch-input


### PR DESCRIPTION
Depends on: https://github.com/red-hat-data-services/trustyai-explainability/pull/554