### PR TITLE
move vllm, vllm-rocm build args to an argfile

### DIFF
--- a/pipelineruns/vllm-rocm/.tekton/vllm-rocm-pull-request.yaml
+++ b/pipelineruns/vllm-rocm/.tekton/vllm-rocm-pull-request.yaml
@@ -48,9 +48,8 @@ spec:
     value: true
   - name: skip-checks
     value: true
-  - name: build-args
-    value:
-    - max_jobs=48
+  - name: build-args-file
+    value: argfile.conf
   - name: fetch-git-tags
     value: true
   - name: clone-depth

--- a/pipelineruns/vllm-rocm/.tekton/vllm-rocm-v2-24-push.yaml
+++ b/pipelineruns/vllm-rocm/.tekton/vllm-rocm-v2-24-push.yaml
@@ -47,9 +47,8 @@ spec:
     value: true
   - name: skip-checks
     value: true
-  - name: build-args
-    value:
-    - max_jobs=48
+  - name: build-args-file
+    value: argfile.conf
   - name: fetch-git-tags
     value: true
   - name: clone-depth

--- a/pipelineruns/vllm/.tekton/vllm-cuda-pull-request.yaml
+++ b/pipelineruns/vllm/.tekton/vllm-cuda-pull-request.yaml
@@ -45,11 +45,8 @@ spec:
     value: true
   - name: skip-checks
     value: true
-  - name: build-args
-    value:
-    - max_jobs=6
-    - nvcc_threads=2
-    - VLLM_VERSION=0.9.0.1
+  - name: build-args-file
+    value: argfile.conf
   - name: fetch-git-tags
     value: true
   - name: clone-depth

--- a/pipelineruns/vllm/.tekton/vllm-cuda-v2-24-push.yaml
+++ b/pipelineruns/vllm/.tekton/vllm-cuda-v2-24-push.yaml
@@ -47,11 +47,8 @@ spec:
     value: true
   - name: skip-checks
     value: true
-  - name: build-args
-    value:
-    - max_jobs=6
-    - nvcc_threads=2
-    - VLLM_VERSION=0.9.0.1
+  - name: build-args-file
+    value: argfile.conf
   - name: fetch-git-tags
     value: true
   - name: clone-depth


### PR DESCRIPTION
in support of https://issues.redhat.com/browse/RHOAIENG-32161

and https://issues.redhat.com/browse/RHOAIENG-32162


