### PR TITLE
Enable trustyai pipelinerun for ppc64le architecture

### DIFF
--- a/pipelineruns/trustyai-explainability/.tekton/odh-trustyai-service-pull-request.yaml
+++ b/pipelineruns/trustyai-explainability/.tekton/odh-trustyai-service-pull-request.yaml
@@ -43,6 +43,7 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+    - linux/ppc64le
   - name: image-expires-after
     value: 5d
   - name: prefetch-input

--- a/pipelineruns/trustyai-service-operator/.tekton/odh-ta-lmes-driver-pull-request.yaml
+++ b/pipelineruns/trustyai-service-operator/.tekton/odh-ta-lmes-driver-pull-request.yaml
@@ -43,6 +43,7 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+    - linux/ppc64le
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/pipelineruns/trustyai-service-operator/.tekton/odh-trustyai-service-operator-pull-request.yaml
+++ b/pipelineruns/trustyai-service-operator/.tekton/odh-trustyai-service-operator-pull-request.yaml
@@ -43,6 +43,7 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+    - linux/ppc64le
   - name: image-expires-after
     value: 5d
   - name: prefetch-input

--- a/pipelineruns/vllm-orchestrator-gateway/.tekton/odh-trustyai-vllm-orchestrator-gateway-pull-request.yaml
+++ b/pipelineruns/vllm-orchestrator-gateway/.tekton/odh-trustyai-vllm-orchestrator-gateway-pull-request.yaml
@@ -43,6 +43,7 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+    - linux/ppc64le
   - name: image-expires-after
     value: 5d
   pipelineRef:


### PR DESCRIPTION
Enabling pipelinerun for
- odh-trustyai-service-operator
- odh-trustyai-service
- odh-ta-lmes-driver
- odh-trustyai-vllm-orchestrator-gateway