### PR TITLE
Enable trustyai pipelinerun for s390x architecture

### DIFF
--- a/pipelineruns/fms-guardrails-orchestrator/.tekton/odh-fms-guardrails-orchestrator-pull-request.yaml
+++ b/pipelineruns/fms-guardrails-orchestrator/.tekton/odh-fms-guardrails-orchestrator-pull-request.yaml
@@ -44,6 +44,7 @@ spec:
     - linux/x86_64
     - linux/ppc64le
     - linux-m2xlarge/arm64
+    - linux/s390x
   - name: image-expires-after
     value: 5d
   taskRunSpecs:

--- a/pipelineruns/guardrails-detectors/.tekton/odh-built-in-detector-pull-request.yaml
+++ b/pipelineruns/guardrails-detectors/.tekton/odh-built-in-detector-pull-request.yaml
@@ -44,6 +44,7 @@ spec:
     - linux/x86_64
     - linux/ppc64le
     - linux-m2xlarge/arm64
+    - linux/s390x
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/pipelineruns/guardrails-detectors/.tekton/odh-guardrails-detector-huggingface-runtime-pull-request.yaml
+++ b/pipelineruns/guardrails-detectors/.tekton/odh-guardrails-detector-huggingface-runtime-pull-request.yaml
@@ -44,6 +44,7 @@ spec:
     - linux/x86_64
     - linux/ppc64le
     - linux-m2xlarge/arm64
+    - linux/s390x
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/pipelineruns/lm-evaluation-harness/.tekton/odh-ta-lmes-job-pull-request.yaml
+++ b/pipelineruns/lm-evaluation-harness/.tekton/odh-ta-lmes-job-pull-request.yaml
@@ -44,6 +44,7 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+    - linux/s390x
   - name: image-expires-after
     value: 5d
   taskRunSpecs:

--- a/pipelineruns/trustyai-explainability/.tekton/odh-trustyai-service-pull-request.yaml
+++ b/pipelineruns/trustyai-explainability/.tekton/odh-trustyai-service-pull-request.yaml
@@ -44,6 +44,7 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+    - linux/s390x
   - name: image-expires-after
     value: 5d
   - name: prefetch-input

--- a/pipelineruns/trustyai-service-operator/.tekton/odh-ta-lmes-driver-pull-request.yaml
+++ b/pipelineruns/trustyai-service-operator/.tekton/odh-ta-lmes-driver-pull-request.yaml
@@ -44,6 +44,7 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+    - linux/s390x
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/pipelineruns/trustyai-service-operator/.tekton/odh-trustyai-service-operator-pull-request.yaml
+++ b/pipelineruns/trustyai-service-operator/.tekton/odh-trustyai-service-operator-pull-request.yaml
@@ -44,6 +44,7 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+    - linux/s390x
   - name: image-expires-after
     value: 5d
   - name: prefetch-input

--- a/pipelineruns/vllm-orchestrator-gateway/.tekton/odh-trustyai-vllm-orchestrator-gateway-pull-request.yaml
+++ b/pipelineruns/vllm-orchestrator-gateway/.tekton/odh-trustyai-vllm-orchestrator-gateway-pull-request.yaml
@@ -44,6 +44,7 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+    - linux/s390x
   - name: image-expires-after
     value: 5d
   pipelineRef:


### PR DESCRIPTION
Enabling pipelinerun for

- odh-trustyai-service-operator
- odh-trustyai-service
- odh-ta-lmes-driver
- odh-trustyai-vllm-orchestrator-gateway
- odh-fms-guardrails-orchestrator
- odh-built-in-detector
- odh-guardrails-detector-huggingface-runtime
- odh-ta-lmes-job
