### PR TITLE
Fixing the guardrails-detectors pipelineruns

### DIFF
--- a/pipelineruns/guardrails-detectors/.tekton/odh-built-in-detector-pull-request.yaml
+++ b/pipelineruns/guardrails-detectors/.tekton/odh-built-in-detector-pull-request.yaml
@@ -57,7 +57,7 @@ spec:
     - name: pathInRepo
       value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-pull-request-pipelines
+    serviceAccountName: build-pipeline-pull-request-pipelines-odh-built-in-detector
   workspaces:
   - name: git-auth
     secret:

--- a/pipelineruns/guardrails-detectors/.tekton/odh-guardrails-detector-huggingface-runtime-pull-request.yaml
+++ b/pipelineruns/guardrails-detectors/.tekton/odh-guardrails-detector-huggingface-runtime-pull-request.yaml
@@ -7,14 +7,14 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux guardrails-detector-huggingface-runtime"
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux guardrails-detector-hf-runtime"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: pull-request-pipelines-odh-guardrails-detector-huggingface-runtime
+    appstudio.openshift.io/component: pull-request-pipelines-odh-guardrails-detector-hf-runtime
     pipelines.appstudio.openshift.io/type: build
-  name: odh-guardrails-detector-huggingface-runtime-on-pull-request
+  name: odh-guardrails-detector-hf-runtime-on-pull-request
   namespace: rhoai-tenant
 spec:
   params:
@@ -57,7 +57,7 @@ spec:
     - name: pathInRepo
       value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-pull-request-pipelines
+    serviceAccountName: build-pipeline-pull-request-pipelines-odh-guardrails-detector-hf-runtime
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
This PR includes: 
- Re-naming the component `odh-guardrails-detector-huggingface-runtime` to `pull-request-pipelines-odh-guardrails-detector-hf-runtime` because label must be no more than 63 characters.
- Renaming the appropriate serviceAccountNames