### PR TITLE
Add Build Args for Notebooks

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-datascience-cpu-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-datascience-cpu-py312-pull-request.yaml
@@ -33,6 +33,8 @@ spec:
     - io.openshift.tags=odh-pipeline-runtime-datascience-cpu-py312
   - name: dockerfile
     value: runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+  - name: build-args-file
+    value: runtimes/datascience/ubi9-python-3.12/build-args/cpu.conf
   - name: path-context
     value: .
   - name: hermetic

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-minimal-cpu-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-minimal-cpu-py312-pull-request.yaml
@@ -33,6 +33,8 @@ spec:
     - io.openshift.tags=odh-pipeline-runtime-minimal-cpu-py312
   - name: dockerfile
     value: runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
+  - name: build-args-file
+    value: runtimes/minimal/build-args/cpu.conf
   - name: path-context
     value: .
   - name: hermetic

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml
@@ -33,6 +33,8 @@ spec:
     - io.openshift.tags=odh-workbench-jupyter-datascience-cpu-py312
   - name: dockerfile
     value: jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+  - name: build-args-file
+    value: jupyter/datascience/ubi9-python-3.12/build-args/cpu.conf
   - name: path-context
     value: .
   - name: hermetic

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml
@@ -33,6 +33,8 @@ spec:
     - io.openshift.tags=odh-workbench-jupyter-minimal-cpu-py312
   - name: dockerfile
     value: jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
+  - name: build-args-file
+    value: jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
   - name: path-context
     value: .
   - name: hermetic

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
@@ -33,6 +33,8 @@ spec:
     - io.openshift.tags=odh-workbench-jupyter-trustyai-cpu-py312
   - name: dockerfile
     value: jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
+  - name: build-args-file
+    value: jupyter/trustyai/ubi9-python-3.12/build-args/cpu.conf
   - name: path-context
     value: .
   - name: hermetic


### PR DESCRIPTION
Add Build Args to fix Dockerfile issue while building through Konflux

Error: 
`Error: determining starting point for build: no FROM statement found`
Fix:
update with the BASE_IMAGE arg passing
` - name: build-args-file
    value: jupyter/datascience/ubi9-python-3.12/build-args/cpu.conf`


