### PR TITLE
enable pull/push pipelines for datascience images on ppc64le

### DIFF
--- a/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-argoexec-v2-25-pull-request.yaml
+++ b/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-argoexec-v2-25-pull-request.yaml
@@ -48,6 +48,7 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+    - linux/ppc64le
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-argoexec-v2-25-push.yaml
+++ b/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-argoexec-v2-25-push.yaml
@@ -51,6 +51,7 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+    - linux/ppc64le
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-workflowcontroller-v2-25-pull-request.yaml
+++ b/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-workflowcontroller-v2-25-pull-request.yaml
@@ -48,6 +48,7 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+    - linux/ppc64le
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-workflowcontroller-v2-25-push.yaml
+++ b/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-workflowcontroller-v2-25-push.yaml
@@ -50,6 +50,7 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+    - linux/ppc64le
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/data-science-pipelines-operator/.tekton/odh-data-science-pipelines-operator-controller-v2-25-pull-request.yaml
+++ b/pipelineruns/data-science-pipelines-operator/.tekton/odh-data-science-pipelines-operator-controller-v2-25-pull-request.yaml
@@ -48,6 +48,7 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+    - linux/ppc64le
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/pipelineruns/data-science-pipelines-operator/.tekton/odh-data-science-pipelines-operator-controller-v2-25-push.yaml
+++ b/pipelineruns/data-science-pipelines-operator/.tekton/odh-data-science-pipelines-operator-controller-v2-25-push.yaml
@@ -51,6 +51,7 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+    - linux/ppc64le
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-api-server-v2-v2-25-pull-request.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-api-server-v2-v2-25-pull-request.yaml
@@ -48,6 +48,7 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+    - linux/ppc64le
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-api-server-v2-v2-25-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-api-server-v2-v2-25-push.yaml
@@ -51,6 +51,7 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+    - linux/ppc64le
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-driver-v2-25-pull-request.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-driver-v2-25-pull-request.yaml
@@ -48,6 +48,7 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+    - linux/ppc64le
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-driver-v2-25-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-driver-v2-25-push.yaml
@@ -51,6 +51,7 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+    - linux/ppc64le
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-launcher-v2-25-pull-request.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-launcher-v2-25-pull-request.yaml
@@ -48,6 +48,7 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+    - linux/ppc64le
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-launcher-v2-25-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-launcher-v2-25-push.yaml
@@ -51,6 +51,7 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+    - linux/ppc64le
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-persistenceagent-v2-v2-25-pull-request.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-persistenceagent-v2-v2-25-pull-request.yaml
@@ -48,6 +48,7 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+    - linux/ppc64le
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-persistenceagent-v2-v2-25-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-persistenceagent-v2-v2-25-push.yaml
@@ -51,6 +51,7 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+    - linux/ppc64le
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-scheduledworkflow-v2-v2-25-pull-request.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-scheduledworkflow-v2-v2-25-pull-request.yaml
@@ -48,6 +48,7 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+    - linux/ppc64le
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-scheduledworkflow-v2-v2-25-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-scheduledworkflow-v2-v2-25-push.yaml
@@ -51,6 +51,7 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+    - linux/ppc64le
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
Enabling pull and push pipelines for datascience pipeline images on IBM Power.