### PR TITLE
fix: resolve missing service account in guardrails-detectors pull request pipeline

### DIFF
--- a/pipelineruns/guardrails-detectors/.tekton/odh-built-in-detector-pull-request.yaml
+++ b/pipelineruns/guardrails-detectors/.tekton/odh-built-in-detector-pull-request.yaml
@@ -59,7 +59,7 @@ spec:
     - name: pathInRepo
       value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-pull-request-pipelines-odh-built-in-detector
+    serviceAccountName: build-pipeline-pull-request-pipelines
   workspaces:
   - name: git-auth
     secret:

--- a/pipelineruns/guardrails-detectors/.tekton/odh-guardrails-detector-huggingface-runtime-pull-request.yaml
+++ b/pipelineruns/guardrails-detectors/.tekton/odh-guardrails-detector-huggingface-runtime-pull-request.yaml
@@ -57,7 +57,7 @@ spec:
     - name: pathInRepo
       value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-pull-request-pipelines-odh-guardrails-detector-hf-runtime
+    serviceAccountName: build-pipeline-pull-request-pipelines
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
Fixes PipelineRun failures caused by missing service accounts in pull request pipelines for guardrails-detectors.
