### PR TITLE
use regular VMs and other changes since we are not building from source

### DIFF
--- a/pipelineruns/vllm/.tekton/odh-vllm-cuda-v2-25-push.yaml
+++ b/pipelineruns/vllm/.tekton/odh-vllm-cuda-v2-25-push.yaml
@@ -12,7 +12,6 @@ metadata:
       event == "push"
       && target_branch == "rhoai-2.25"
       && ( !".tekton/**".pathChanged() || ".tekton/odh-vllm-cuda-v2-25-push.yaml".pathChanged() )
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-vllm-cuda-v2-25
@@ -47,15 +46,10 @@ spec:
     value: true
   - name: build-image-index
     value: true
-  - name: build-args-file
-    value: argfile.conf
-  - name: fetch-git-tags
-    value: true
-  - name: clone-depth
-    value: "2147483647"
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux/x86_64
+    - linux-m2xlarge/arm64
   taskRunSpecs:
     - pipelineTaskName: ecosystem-cert-preflight-checks
       computeResources:


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/RHOAIENG-30508

Since the vllm-cuda image is no longer built from source:

- A standard VM is sufficient (no need for a high-spec one)
- A regular repository clone can be used
- Fetching tags is no longer required

We also had a request to build it for arm platform
https://redhat-internal.slack.com/archives/C07TF3MBMMW/p1757413746267889?thread_ts=1757411802.477599&cid=C07TF3MBMMW