### PR TITLE
Add target platforms as per RHOAIENG-33925

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-v2-25-push.yaml
@@ -49,7 +49,8 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux/x86_64
+    - linux-m2xlarge/arm64
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v2-25-push.yaml
@@ -48,7 +48,8 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux/x86_64
+    - linux-m2xlarge/arm64
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v2-25-push.yaml
@@ -48,7 +48,7 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-v2-25-push.yaml
@@ -49,7 +49,7 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux/x86_64
     - linux-m2xlarge/arm64
   pipelineRef:
     resolver: git

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v2-25-push.yaml
@@ -47,7 +47,7 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v2-25-push.yaml
@@ -50,6 +50,7 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+    - linux/ppc64le
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v2-25-push.yaml
@@ -51,6 +51,7 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+    - linux/ppc64le
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cuda-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cuda-py312-v2-25-push.yaml
@@ -49,7 +49,7 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux/x86_64
     - linux-m2xlarge/arm64
   pipelineRef:
     resolver: git

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v2-25-push.yaml
@@ -48,7 +48,7 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-v2-25-push.yaml
@@ -53,7 +53,8 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux/x86_64
+    - linux-m2xlarge/arm64
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v2-25-push.yaml
@@ -54,7 +54,8 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux/x86_64
+    - linux-m2xlarge/arm64
   timeouts:
     pipeline: 8h
     tasks: 4h

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v2-25-push.yaml
@@ -52,7 +52,7 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v2-25-push.yaml
@@ -53,7 +53,7 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux/x86_64
     - linux-m2xlarge/arm64
   pipelineRef:
     resolver: git

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v2-25-push.yaml
@@ -52,7 +52,7 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux/x86_64
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-v2-25-push.yaml
@@ -53,7 +53,9 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux/x86_64
+    - linux-m2xlarge/arm64
+    - linux/ppc64le
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/RHOAIENG-33925

As per the supported platforms listed [here](https://github.com/red-hat-data-services/notebooks/pull/1523#issuecomment-3271414392), updating the workbench pipelines to build for all target architectures. Builds will primarily use local platforms, since we [no longer need beefier remote VMs](https://redhat-internal.slack.com/archives/C07TF3MBMMW/p1757518575495799?thread_ts=1757435260.729159&cid=C07TF3MBMMW) becuase the components are already pre-built in the AIPCC base image instead of being built entirely from source.