### PR TITLE
Enable pull/push pipelines for TrustyAI components for 2.25 on s390x

### DIFF
--- a/pipelineruns/fms-guardrails-orchestrator/.tekton/odh-fms-guardrails-orchestrator-v2-25-pull-request.yaml
+++ b/pipelineruns/fms-guardrails-orchestrator/.tekton/odh-fms-guardrails-orchestrator-v2-25-pull-request.yaml
@@ -44,6 +44,7 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+    - linux/s390x
   - name: image-expires-after
     value: 5d
   taskRunSpecs:

--- a/pipelineruns/fms-guardrails-orchestrator/.tekton/odh-fms-guardrails-orchestrator-v2-25-push.yaml
+++ b/pipelineruns/fms-guardrails-orchestrator/.tekton/odh-fms-guardrails-orchestrator-v2-25-push.yaml
@@ -47,6 +47,7 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+    - linux/s390x
   taskRunSpecs:
   - pipelineTaskName: build-images
     computeResources:

--- a/pipelineruns/guardrails-detectors/.tekton/odh-built-in-detector-v2-25-pull-request.yaml
+++ b/pipelineruns/guardrails-detectors/.tekton/odh-built-in-detector-v2-25-pull-request.yaml
@@ -44,6 +44,7 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+    - linux/s390x
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/pipelineruns/guardrails-detectors/.tekton/odh-built-in-detector-v2-25-push.yaml
+++ b/pipelineruns/guardrails-detectors/.tekton/odh-built-in-detector-v2-25-push.yaml
@@ -47,6 +47,7 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+    - linux/s390x
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/guardrails-detectors/.tekton/odh-guardrails-detector-huggingface-runtime-v2-25-push.yaml
+++ b/pipelineruns/guardrails-detectors/.tekton/odh-guardrails-detector-huggingface-runtime-v2-25-push.yaml
@@ -48,6 +48,7 @@ spec:
     - linux/x86_64
     - linux/ppc64le
     - linux-m2xlarge/arm64
+    - linux/s390x
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/lm-evaluation-harness/.tekton/odh-ta-lmes-job-v2-25-pull-request.yaml
+++ b/pipelineruns/lm-evaluation-harness/.tekton/odh-ta-lmes-job-v2-25-pull-request.yaml
@@ -44,6 +44,7 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+    - linux/s390x
   - name: image-expires-after
     value: 5d
   taskRunSpecs:

--- a/pipelineruns/lm-evaluation-harness/.tekton/odh-ta-lmes-job-v2-25-push.yaml
+++ b/pipelineruns/lm-evaluation-harness/.tekton/odh-ta-lmes-job-v2-25-push.yaml
@@ -47,6 +47,7 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+    - linux/s390x
   taskRunSpecs:
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:

--- a/pipelineruns/trustyai-explainability/.tekton/odh-trustyai-service-v2-25-pull-request.yaml
+++ b/pipelineruns/trustyai-explainability/.tekton/odh-trustyai-service-v2-25-pull-request.yaml
@@ -44,6 +44,7 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+    - linux/s390x
   - name: image-expires-after
     value: 5d
   - name: prefetch-input

--- a/pipelineruns/trustyai-explainability/.tekton/odh-trustyai-service-v2-25-push.yaml
+++ b/pipelineruns/trustyai-explainability/.tekton/odh-trustyai-service-v2-25-push.yaml
@@ -47,6 +47,7 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+    - linux/s390x
   - name: prefetch-input
     value: |
       [{"path": ".", "type": "rpm"}, {"path": ".", "type": "generic"}]

--- a/pipelineruns/trustyai-service-operator/.tekton/odh-ta-lmes-driver-v2-25-pull-request.yaml
+++ b/pipelineruns/trustyai-service-operator/.tekton/odh-ta-lmes-driver-v2-25-pull-request.yaml
@@ -44,6 +44,7 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+    - linux/s390x
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/pipelineruns/trustyai-service-operator/.tekton/odh-ta-lmes-driver-v2-25-push.yaml
+++ b/pipelineruns/trustyai-service-operator/.tekton/odh-ta-lmes-driver-v2-25-push.yaml
@@ -47,6 +47,7 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+    - linux/s390x
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/trustyai-service-operator/.tekton/odh-trustyai-service-operator-v2-25-pull-request.yaml
+++ b/pipelineruns/trustyai-service-operator/.tekton/odh-trustyai-service-operator-v2-25-pull-request.yaml
@@ -44,6 +44,7 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+    - linux/s390x
   - name: image-expires-after
     value: 5d
   - name: prefetch-input

--- a/pipelineruns/trustyai-service-operator/.tekton/odh-trustyai-service-operator-v2-25-push.yaml
+++ b/pipelineruns/trustyai-service-operator/.tekton/odh-trustyai-service-operator-v2-25-push.yaml
@@ -47,6 +47,7 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+    - linux/s390x
   - name: prefetch-input
     value: |
       {"type": "gomod", "path": "."}

--- a/pipelineruns/vllm-orchestrator-gateway/.tekton/odh-trustyai-vllm-orchestrator-gateway-v2-25-pull-request.yaml
+++ b/pipelineruns/vllm-orchestrator-gateway/.tekton/odh-trustyai-vllm-orchestrator-gateway-v2-25-pull-request.yaml
@@ -44,6 +44,7 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+    - linux/s390x
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/pipelineruns/vllm-orchestrator-gateway/.tekton/odh-trustyai-vllm-orchestrator-gateway-v2-25-push.yaml
+++ b/pipelineruns/vllm-orchestrator-gateway/.tekton/odh-trustyai-vllm-orchestrator-gateway-v2-25-push.yaml
@@ -47,6 +47,7 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+    - linux/s390x
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
Enable pull/push pipelines for TrustyAI components for 2.25 for s390x