### PR TITLE
use arger konflux machine for codeserver builds

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py311-v2-24-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py311-v2-24-push.yaml
@@ -45,7 +45,7 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-extra-fast/amd64
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v2-24-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v2-24-push.yaml
@@ -45,7 +45,7 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-extra-fast/amd64
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
codeserver building process takes 2h+ on regular
x86 machines vs. 35min on extra-fast

part of https://issues.redhat.com/browse/RHOAIENG-33414