### PR TITLE
llama-stack-provider-trustyai-garak arm64 disk++

### DIFF
--- a/pipelineruns/llama-stack-provider-trustyai-garak/.tekton/odh-llama-stack-provider-trustyai-garak-v2-25-push.yaml
+++ b/pipelineruns/llama-stack-provider-trustyai-garak/.tekton/odh-llama-stack-provider-trustyai-garak-v2-25-push.yaml
@@ -53,7 +53,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux-m2xlarge/arm64
+    - linux-d160-m2xlarge/arm64
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
arm64 build [here](https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhoai-tenant/applications/rhoai-v2-25/pipelineruns/odh-llama-stack-provider-trustyai-garak-v2-25-on-push-4ktjt) failing with "no space left on device", so I'm hoping that this instance type with more disk will help solve it.