### PR TITLE
disable optional sast coverity check

### DIFF
--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -506,7 +506,7 @@ spec:
         value: task
       resolver: bundles
     when:
-    - input: $(params.skip-checks)
+    - input: "true"
       operator: in
       values:
       - "false"
@@ -661,6 +661,8 @@ spec:
     - apply-tags
     - push-dockerfile
     - rpms-signature-scan
+    - sast-coverity-check
+    - coverity-availability-check
     taskSpec:
       steps:
       - name: noop


### PR DESCRIPTION
The SAST Coverity check is currently optional and significantly increases build time. It is being temporarily disabled to speed up the build process and will need to be re-enabled once it becomes a mandatory requirement.