### PR TITLE
Remove s390x label for codeserver and trustyai

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-pull-request.yaml
@@ -46,7 +46,6 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
-    - linux/s390x
   - name: image-expires-after
     value: 5d
   - name: enable-slack-failure-notification

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
@@ -45,7 +45,6 @@ spec:
     value:
     - linux-extra-fast/amd64
     - linux-m2xlarge/arm64
-    - linux/s390x
   - name: image-expires-after
     value: 5d
   - name: enable-slack-failure-notification


### PR DESCRIPTION
As per discussion https://redhat-internal.slack.com/archives/C09B6R3Q0KU/p1758198358736259?thread_ts=1757439783.679909&cid=C09B6R3Q0KU

Remove s390x label for Codeserver and Trustyai as they we're initially planned for 2.25 but as they are not ready so will be planned for 2.26 release.