### PR TITLE
disable fips-check task for faster ci and nightly builds

### DIFF
--- a/pipelines/fbc-fragment-build.yaml
+++ b/pipelines/fbc-fragment-build.yaml
@@ -333,7 +333,7 @@ spec:
         value: task
       resolver: bundles
     when:
-    - input: $(params.skip-checks)
+    - input: "true"
       operator: in
       values:
       - "false"


### PR DESCRIPTION
Disbale FIPS check in CI and nightly builds until https://issues.redhat.com/browse/KONFLUX-9956 is resolved.

References: 

https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1757081445209489?thread_ts=1756796917.205629&cid=C04PZ7H0VA8

https://redhat-internal.slack.com/archives/C04NY86M4EM/p1757929237457849?thread_ts=1757519292.755079&cid=C04NY86M4EM

 


