### PR TITLE
Fix prefetch-input config in rhods-operator

### DIFF
--- a/pipelineruns/rhods-operator/.tekton/odh-operator-v3-0-push.yaml
+++ b/pipelineruns/rhods-operator/.tekton/odh-operator-v3-0-push.yaml
@@ -50,7 +50,7 @@ spec:
     value: true
   - name: prefetch-input
     value: |
-      [{"type": "gomod", "path": "."}, , {"type": "rpm", "path": "."}]
+      [{"type": "gomod", "path": "."}, {"type": "rpm", "path": "."}]
   - name: build-image-index
     value: true
   pipelineRef:

--- a/pipelineruns/rhods-operator/.tekton/odh-operator-v3-0-scheduled.yaml
+++ b/pipelineruns/rhods-operator/.tekton/odh-operator-v3-0-scheduled.yaml
@@ -49,7 +49,7 @@ spec:
     value: true
   - name: prefetch-input
     value: |
-      [{"type": "gomod", "path": "."}, , {"type": "rpm", "path": "."}]
+      [{"type": "gomod", "path": "."}, {"type": "rpm", "path": "."}]
   - name: build-image-index
     value: true
   pipelineRef:


### PR DESCRIPTION
I broke it, sorry. It's not possible for us currently to test the builds on main of the rhods operator with PR jobs, so I wasn't able to test it.

This is a follow up to #619 