### PR TITLE
Enable ppc64le and s390x platforms

### DIFF
--- a/pipelineruns/odh-dashboard/.tekton/odh-mod-arch-model-registry-v2-25-push.yaml
+++ b/pipelineruns/odh-dashboard/.tekton/odh-mod-arch-model-registry-v2-25-push.yaml
@@ -44,6 +44,8 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
     - linux-m2xlarge/arm64
   pipelineRef:
     resolver: git


### PR DESCRIPTION
We don't see multi-arch image here https://quay.io/repository/rhoai/odh-mod-arch-model-registry-rhel9?tab=tags. So enable this image for power and z, this PR is created.