### PR TITLE
enable push pipeline for ppc64le runtime-generic image

### DIFF
--- a/pipelineruns/ilab-on-ocp/.tekton/odh-ml-pipelines-runtime-generic-v2-25-push.yaml
+++ b/pipelineruns/ilab-on-ocp/.tekton/odh-ml-pipelines-runtime-generic-v2-25-push.yaml
@@ -53,6 +53,7 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+    - linux/ppc64le
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
Updating push pipeline for runtime-generic image to add linux/ppc64le platform. 