### PR TITLE
[rhoai-2.25] pipelineruns(notebooks): cuda images should be amd64 only

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v2-25-push.yaml
@@ -54,7 +54,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux-m2xlarge/arm64
+    - linux-d160-m4xlarge/arm64
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
https://redhat-internal.slack.com/archives/C09B6R3Q0KU/p1758617481473879?thread_ts=1757439783.679909&cid=C09B6R3Q0KU
* https://github.com/red-hat-data-services/konflux-central/pull/583