### PR TITLE
[rhoai-3.0] pipelineruns(notebooks): datascience on arm running out of disk space, using `linux-d160-m4xlarge/arm64`

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v3-0-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v3-0-push.yaml
@@ -54,7 +54,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux-m2xlarge/arm64
+    - linux-d160-m4xlarge/arm64
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
* https://github.com/red-hat-data-services/konflux-central/pull/661
* https://github.com/red-hat-data-services/konflux-central/pull/583