### PR TITLE
Enable ppc64le architecture

### DIFF
--- a/pipelineruns/vllm-cpu/.tekton/odh-vllm-cpu-v3-0-push.yaml
+++ b/pipelineruns/vllm-cpu/.tekton/odh-vllm-cpu-v3-0-push.yaml
@@ -54,7 +54,7 @@ spec:
   - name: build-platforms
     value:
     - linux/s390x
-    #- linux/ppc64le
+    - linux/ppc64le
   taskRunSpecs:
     - pipelineTaskName: ecosystem-cert-preflight-checks
       computeResources:


### PR DESCRIPTION
This will enable rhoai-3.0 branch to build/push image for ppc64le platform

I'm not sure what's causing this issue, but it needs to be fixed wherever it's being copied (source) during automatic generation.