### PR TITLE
disable s390x builds for odh-kueue-controller

### DIFF
--- a/pipelineruns/kueue/.tekton/odh-kueue-controller-v2-24-push.yaml
+++ b/pipelineruns/kueue/.tekton/odh-kueue-controller-v2-24-push.yaml
@@ -51,7 +51,6 @@ spec:
     value:
     - linux/x86_64
     - linux/ppc64le
-    - linux/s390x
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
The decision has been made to not build s390x
images for odh-kueue-controller
in rhoai-2.24. It's been moved to rhoai-2.25.

https://redhat-internal.slack.com/archives/C07KPDHBR4J/p1755691723804839 https://issues.redhat.com/browse/RHOAIENG-31697