### PR TITLE
add ppc64le builds to feature server

### DIFF
--- a/pipelineruns/feast/.tekton/odh-feature-server-v2-25-push.yaml
+++ b/pipelineruns/feast/.tekton/odh-feature-server-v2-25-push.yaml
@@ -61,6 +61,7 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+    - linux/ppc64le
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
As per the list of components that should be built for Power for rhoai-2.25:
https://docs.google.com/spreadsheets/d/1R-Vc1ZKTyKOEYFTLmRlPnPqCVY5jbNvmrMEFUJrEnR4/edit?gid=1203748168#gid=1203748168