### PR TITLE
[rhoai-2.25] Remove ppc64le arch from 2.25

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v2-25-push.yaml
@@ -50,7 +50,6 @@ spec:
     value:
     - linux-extra-fast/amd64
     - linux-m2xlarge/arm64
-    - linux/ppc64le
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
Removing ppc64le arch to unblock 2.25 RC build, until we fix the issue. 

related to: https://issues.redhat.com/browse/RHAIENG-1238