### PR TITLE
Re-add arm64 to trustyai workbench build

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-v2-25-push.yaml
@@ -54,6 +54,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux-m2xlarge/arm64
     - linux/ppc64le
   pipelineRef:
     resolver: git


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/RHOAIENG-34086

This was removed recently because it was thought that it wasn't currently possible to build it for Arm. It is, it just needed a dependency fix.

That fix is proposed here:
https://github.com/red-hat-data-services/notebooks/pull/1614

Once a decision has been made on whether to include this fix in 2.25 or not, both this PR and that notebooks PR should be merged in the correct order. I think the component change first, then this one.