### PR TITLE
Upgrade codeserver pipeline with bigger machines 

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-pull-request.yaml
@@ -46,8 +46,8 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
-    - linux-m2xlarge/arm64
+    - linux-d160-m4xlarge/amd64
+    - linux-d160-m4xlarge/arm64
     - linux/ppc64le
     - linux/s390x
   - name: image-expires-after


### PR DESCRIPTION
Upgrade codeserver pipeline with bigger machines to avoid flaky errors, as the old was small for the build workload.
[rhoai-3.4] follow up PR https://github.com/red-hat-data-services/konflux-central/pull/1413 