### PR TITLE
[rhoai-3.4] Upgrade codeserver pipeline with bigger machines

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-4-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-4-push.yaml
@@ -49,8 +49,8 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
-    - linux-m2xlarge/arm64
+    - linux-d160-m4xlarge/amd64
+    - linux-d160-m4xlarge/arm64
     - linux/ppc64le
     - linux/s390x
   pipelineRef:


### PR DESCRIPTION
Upgrade codeserver pipeline with bigger machines to avoid flaky errors, as the old was small for the build workload.
