### PR TITLE
fix: revert incorrect Dockerfile name change

### DIFF
--- a/pipelineruns/pipelines-components/.tekton/odh-automl-v3-4-push.yaml
+++ b/pipelineruns/pipelines-components/.tekton/odh-automl-v3-4-push.yaml
@@ -10,9 +10,9 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.4"
-      && ( !".tekton/**".pathChanged() 
-        || ".tekton/odh-automl-v3-4-push.yaml".pathChanged() 
-        || "Docker.konflux.automl".pathChanged() )
+      && ( !".tekton/**".pathChanged()
+        || ".tekton/odh-automl-v3-4-push.yaml".pathChanged()
+        || "Dockerfile.konflux.automl".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-4
     appstudio.openshift.io/component: odh-automl-v3-4
@@ -41,7 +41,7 @@ spec:
     - linux-m2xlarge/arm64
     - linux/ppc64le
   - name: dockerfile
-    value: Docker.konflux.automl
+    value: Dockerfile.konflux.automl
   - name: path-context
     value: .
   # TODO: Enable hermetic builds once yarn/npm prefetching is supported.


### PR DESCRIPTION
The Dockerfile should be named "Dockerfile.konflux.automl" not "Docker.konflux.automl". Reverting the incorrect change from previous commit.