### PR TITLE
llm-d-kv-cache --> llm-d-uds-tokenizer rename

### DIFF
--- a/pipelineruns/llm-d-kv-cache/.tekton/odh-llm-d-uds-tokenizer-v3-4-push.yaml
+++ b/pipelineruns/llm-d-kv-cache/.tekton/odh-llm-d-uds-tokenizer-v3-4-push.yaml
@@ -9,13 +9,13 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "rhoai-3.4" && ( "services/uds_tokenizer/**".pathChanged() || ".tekton/odh-llm-d-kv-cache-v3-4-push.yaml".pathChanged()
+      == "rhoai-3.4" && ( "services/uds_tokenizer/**".pathChanged() || ".tekton/odh-llm-d-uds-tokenizer-v3-4-push.yaml".pathChanged()
       )
   labels:
     appstudio.openshift.io/application: rhoai-v3-4
-    appstudio.openshift.io/component: odh-llm-d-kv-cache-v3-4
+    appstudio.openshift.io/component: odh-llm-d-uds-tokenizer-v3-4
     pipelines.appstudio.openshift.io/type: build
-  name: odh-llm-d-kv-cache-v3-4-on-push
+  name: odh-llm-d-uds-tokenizer-v3-4-on-push
   namespace: rhoai-tenant
 spec:
   params:
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/rhoai/odh-llm-d-kv-cache-rhel9:{{target_branch}}
+    value: quay.io/rhoai/odh-llm-d-uds-tokenizer-rhel9:{{target_branch}}
   - name: rhoai-version
     value: "3.4.0"
   - name: additional-tags
@@ -54,7 +54,7 @@ spec:
     - name: pathInRepo
       value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-llm-d-kv-cache-v3-4
+    serviceAccountName: build-pipeline-odh-llm-d-uds-tokenizer-v3-4
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
Rename `llm-d-kv-cache` - incorrect name, that is the go submodule that runs inside of the scheduler - to the `llm-d-uds-tokenizer`