### PR TITLE
chore(RHOAIENG-57205): re-enable EvalHub multi-arch build

### DIFF
--- a/pipelineruns/eval-hub/.tekton/odh-eval-hub-pull-request.yaml
+++ b/pipelineruns/eval-hub/.tekton/odh-eval-hub-pull-request.yaml
@@ -39,6 +39,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux-m2xlarge/arm64
   - name: dockerfile
     value: Dockerfile.konflux
   - name: path-context


### PR DESCRIPTION
Implements [RHOAIENG-57205](https://redhat.atlassian.net/browse/RHOAIENG-57205)

Dockerfile.konflux multi-arch support in https://github.com/red-hat-data-services/eval-hub/blob/main/Dockerfile.konflux