### PR TITLE
chore(RHOAIENG-57205): re-enable EvalHub multi-arch build (3.4)

### DIFF
--- a/pipelineruns/eval-hub/.tekton/odh-eval-hub-v3-4-push.yaml
+++ b/pipelineruns/eval-hub/.tekton/odh-eval-hub-v3-4-push.yaml
@@ -50,6 +50,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux-m2xlarge/arm64
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
Implements [RHOAIENG-57205](https://redhat.atlassian.net/browse/RHOAIENG-57205)

Dockerfile.konflux multi-arch support in https://github.com/red-hat-data-services/eval-hub/blob/main/Dockerfile.konflux