### PR TITLE
Add requirements-ga.txt to CUDA universal training image prefetch

### DIFF
--- a/pipelineruns/distributed-workloads/.tekton/odh-th06-cuda130-torch291-py312-v3-4-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th06-cuda130-torch291-py312-v3-4-push.yaml
@@ -49,7 +49,7 @@ spec:
     - linux-extra-fast/amd64
     - linux-d160-m8xlarge/arm64
   - name: prefetch-input
-    value: '[{"type": "pip", "path": "images/universal/training/th06-cuda130-torch291-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64,aarch64", "os": "linux"}}]'
+    value: '[{"type": "pip", "path": "images/universal/training/th06-cuda130-torch291-py312", "requirements_files": ["requirements.txt", "requirements-ga.txt"], "binary": {"arch": "x86_64,aarch64", "os": "linux"}}]'
   - name: build-args
     value: ["DOWNSTREAM=true"]
   pipelineRef:


### PR DESCRIPTION
**Summary**
 - Updates the CUDA universal training image PipelineRun to include requirements-ga.txt in the dependency prefetch configuration, aligning it with the CPU image configuration.
Changes
 - Updated odh-th06-cuda130-torch291-py312-v3-4-push.yaml to include requirements-ga.txt in the prefetch-input parameter

**Details**
The universal training images for RHOAI 3.4 have the following requirements file configurations:
 - CPU image: requirements.txt + requirements-ga.txt (already configured)
 - CUDA image: requirements.txt + requirements-ga.txt (updated in this PR)
 - ROCm image: requirements.txt only (no change needed)
This ensures that the Cachi2 prefetch task pulls in both requirements files during hermetic builds for CUDA images, matching the CPU image behavior.

**Testing**
This change will be validated when:
1. A push to rhoai-3.4 branch modifies files in images/universal/training/th06-cuda130-torch291-py312/
2. The PipelineRun triggers and prefetches dependencies from both requirements files
3. The hermetic build completes successfully with all dependencies available
