### PR TITLE
[RHOAIENG-57742] Revert temporary embargo changes on rhoai-3.3

### DIFF
--- a/pipelineruns/RHOAI-Build-Config/.tekton/odh-operator-bundle-v3-3-push.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/odh-operator-bundle-v3-3-push.yaml
@@ -7,11 +7,10 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     build.appstudio.openshift.io/build-nudge-files: "catalog/catalog-patch.yaml"
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      "non-existent-file.non-existent-ext".pathChanged()
+    pipelinesascode.tekton.dev/on-cel-expression: '"non-existent-file.non-existent-ext".pathChanged()
       && event == "push" && target_branch == "rhoai-3.3" && ( "bundle/**".pathChanged()
       || ".tekton/odh-operator-bundle-v3-3-push.yaml".pathChanged() ) && !"bundle/bundle-patch.yaml".pathChanged()
-      && !".github/workflows/**".pathChanged()
+      && !".github/workflows/**".pathChanged()'
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-operator-bundle-v3-3
@@ -43,8 +42,6 @@ spec:
     value: false
   - name: rhoai-version
     value: "3.3.2"
-  - name: disable-slack-notifications
-    value: 'true'
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/RHOAI-Build-Config/.tekton/odh-operator-bundle-v3-3-push.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/odh-operator-bundle-v3-3-push.yaml
@@ -7,10 +7,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     build.appstudio.openshift.io/build-nudge-files: "catalog/catalog-patch.yaml"
-    pipelinesascode.tekton.dev/on-cel-expression: '"non-existent-file.non-existent-ext".pathChanged()
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      "non-existent-file.non-existent-ext".pathChanged()
       && event == "push" && target_branch == "rhoai-3.3" && ( "bundle/**".pathChanged()
       || ".tekton/odh-operator-bundle-v3-3-push.yaml".pathChanged() ) && !"bundle/bundle-patch.yaml".pathChanged()
-      && !".github/workflows/**".pathChanged()'
+      && !".github/workflows/**".pathChanged()
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-operator-bundle-v3-3

--- a/pipelineruns/RHOAI-Build-Config/.tekton/odh-operator-bundle-v3-3-scheduled.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/odh-operator-bundle-v3-3-scheduled.yaml
@@ -7,8 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     build.appstudio.openshift.io/build-nudge-files: "schedule/catalog-github-trigger.txt"
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" && target_branch == "rhoai-3.3" &&  "schedule/bundle-tekton-trigger.txt".pathChanged()
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "rhoai-3.3" &&  "schedule/bundle-tekton-trigger.txt".pathChanged()
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-operator-bundle-v3-3
@@ -22,7 +21,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: additional-tags
-    value:
+    value: 
     - '{{target_branch}}-{{revision}}'
     - '{{target_branch}}-nightly'
   - name: output-image
@@ -41,8 +40,6 @@ spec:
     value: false
   - name: rhoai-version
     value: "3.3.2"
-  - name: disable-slack-notifications
-    value: 'true'
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/RHOAI-Build-Config/.tekton/odh-operator-bundle-v3-3-scheduled.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/odh-operator-bundle-v3-3-scheduled.yaml
@@ -7,7 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     build.appstudio.openshift.io/build-nudge-files: "schedule/catalog-github-trigger.txt"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "rhoai-3.3" &&  "schedule/bundle-tekton-trigger.txt".pathChanged()
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" && target_branch == "rhoai-3.3" &&  "schedule/bundle-tekton-trigger.txt".pathChanged()
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-operator-bundle-v3-3

--- a/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v3-3-push.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v3-3-push.yaml
@@ -6,10 +6,11 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: '"non-existent-file.non-existent-ext".pathChanged()
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      "non-existent-file.non-existent-ext".pathChanged()
       && event == "push" && target_branch == "rhoai-3.3" && ( "catalog/**".pathChanged()
       || ".tekton/rhoai-fbc-fragment-v3-3-push.yaml".pathChanged() ) && !"catalog/catalog-patch.yaml".pathChanged()
-      && !".github/workflows/**".pathChanged()'
+      && !".github/workflows/**".pathChanged()
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: rhoai-fbc-fragment-v3-3

--- a/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v3-3-push.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v3-3-push.yaml
@@ -6,11 +6,10 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      "non-existent-file.non-existent-ext".pathChanged()
+    pipelinesascode.tekton.dev/on-cel-expression: '"non-existent-file.non-existent-ext".pathChanged()
       && event == "push" && target_branch == "rhoai-3.3" && ( "catalog/**".pathChanged()
       || ".tekton/rhoai-fbc-fragment-v3-3-push.yaml".pathChanged() ) && !"catalog/catalog-patch.yaml".pathChanged()
-      && !".github/workflows/**".pathChanged()
+      && !".github/workflows/**".pathChanged()'
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: rhoai-fbc-fragment-v3-3
@@ -49,8 +48,6 @@ spec:
     value: "ci"
   - name: rhoai-version
     value: "3.3.2"
-  - name: disable-slack-notifications
-    value: 'true'
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v3-3-scheduled.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v3-3-scheduled.yaml
@@ -6,8 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" && target_branch == "rhoai-3.3" && "schedule/catalog-tekton-trigger.txt".pathChanged()
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "rhoai-3.3" && "schedule/catalog-tekton-trigger.txt".pathChanged()
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: rhoai-fbc-fragment-v3-3
@@ -51,8 +50,6 @@ spec:
     value: "https://github.com/red-hat-data-services/conforma-reporter/actions/workflows/conforma-reporter.yaml"
   - name: smoke_url
     value: "https://github.com/red-hat-data-services/conforma-reporter/actions/workflows/smoke-trigger.yaml"
-  - name: disable-slack-notifications
-    value: 'true'
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v3-3-scheduled.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v3-3-scheduled.yaml
@@ -53,8 +53,6 @@ spec:
     value: "https://github.com/red-hat-data-services/conforma-reporter/actions/workflows/smoke-trigger.yaml"
   - name: disable-slack-notifications
     value: 'true'
-  - name: skip-fips
-    value: 'true'
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v3-3-scheduled.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v3-3-scheduled.yaml
@@ -6,7 +6,8 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "rhoai-3.3" && "schedule/catalog-tekton-trigger.txt".pathChanged()
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" && target_branch == "rhoai-3.3" && "schedule/catalog-tekton-trigger.txt".pathChanged()
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: rhoai-fbc-fragment-v3-3

--- a/pipelineruns/rhods-operator/.tekton/odh-operator-v3-3-push.yaml
+++ b/pipelineruns/rhods-operator/.tekton/odh-operator-v3-3-push.yaml
@@ -8,7 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     build.appstudio.openshift.io/build-nudge-files: "bundle/bundle-patch.yaml"
-    pipelinesascode.tekton.dev/on-cel-expression: 'false'
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" && target_branch == "rhoai-3.3" && !"bundle/**".pathChanged()
+      && !"Dockerfiles/bundle.Dockerfile".pathChanged() && (!"build/**".pathChanged()
+      || "build/operands-map.yaml".pathChanged() || ".tekton/odh-operator-v3-3-push.yaml".pathChanged()
+      ) && !".github/workflows/**".pathChanged()
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-operator-v3-3


### PR DESCRIPTION
## Description

Reverts the temporary "disable builds" PRs that were applied during the embargo period:

- **Revert #1821** — "Disable builds for rhoai-3.3" (skip-fips)
- **Revert #1812** — "Disable builds for rhoai-3.3" (cel-expression disable + slack notifications)

This restores the operator build cel-expressions and removes temporary `disable-slack-notifications` and `skip-fips` parameters for the rhoai-3.3 branch.

Note: The RHOAI-Build-Config pipelinerun files (odh-operator-bundle, rhoai-fbc-fragment push) were originally created with the `non-existent-file` disable condition in PR #1807 — that is a separate concern and not addressed by this revert.

**JIRA:** [RHOAIENG-57742](https://issues.redhat.com/browse/RHOAIENG-57742)
**Parent:** [RHOAIENG-57438](https://issues.redhat.com/browse/RHOAIENG-57438)

---
🤖 Generated with [Claude Code](https://claude.ai/code) Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>