### PR TITLE
[RHOAIENG-57739] Revert temporary embargo changes on rhoai-2.16

### DIFF
--- a/pipelineruns/RHOAI-Build-Config/.tekton/odh-operator-bundle-v2-16-push.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/odh-operator-bundle-v2-16-push.yaml
@@ -7,10 +7,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     build.appstudio.openshift.io/build-nudge-files: "catalog/catalog-patch.yaml"
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" && target_branch
+    pipelinesascode.tekton.dev/on-cel-expression: 'event == "push" && target_branch
       == "rhoai-2.16" && ( "bundle/**".pathChanged() || ".tekton/odh-operator-bundle-v2-16-push.yaml".pathChanged()
-      ) && !"bundle/bundle-patch.yaml".pathChanged() && !".github/workflows/**".pathChanged()
+      ) && !"bundle/bundle-patch.yaml".pathChanged() && !".github/workflows/**".pathChanged()'
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: rhoai-v2-16
@@ -43,8 +42,6 @@ spec:
     value: false
   - name: rhoai-version
     value: "2.16.5"
-  - name: disable-slack-notifications
-    value: 'true'
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/RHOAI-Build-Config/.tekton/odh-operator-bundle-v2-16-push.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/odh-operator-bundle-v2-16-push.yaml
@@ -7,9 +7,10 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     build.appstudio.openshift.io/build-nudge-files: "catalog/catalog-patch.yaml"
-    pipelinesascode.tekton.dev/on-cel-expression: 'event == "push" && target_branch
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" && target_branch
       == "rhoai-2.16" && ( "bundle/**".pathChanged() || ".tekton/odh-operator-bundle-v2-16-push.yaml".pathChanged()
-      ) && !"bundle/bundle-patch.yaml".pathChanged() && !".github/workflows/**".pathChanged()'
+      ) && !"bundle/bundle-patch.yaml".pathChanged() && !".github/workflows/**".pathChanged()
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: rhoai-v2-16

--- a/pipelineruns/RHOAI-Build-Config/.tekton/odh-operator-bundle-v2-16-scheduled.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/odh-operator-bundle-v2-16-scheduled.yaml
@@ -7,7 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     build.appstudio.openshift.io/build-nudge-files: schedule/catalog-github-trigger.txt
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "rhoai-2.16" &&  "schedule/bundle-tekton-trigger.txt".pathChanged()
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" && target_branch == "rhoai-2.16" &&  "schedule/bundle-tekton-trigger.txt".pathChanged()
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: rhoai-v2-16

--- a/pipelineruns/RHOAI-Build-Config/.tekton/odh-operator-bundle-v2-16-scheduled.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/odh-operator-bundle-v2-16-scheduled.yaml
@@ -7,8 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     build.appstudio.openshift.io/build-nudge-files: schedule/catalog-github-trigger.txt
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" && target_branch == "rhoai-2.16" &&  "schedule/bundle-tekton-trigger.txt".pathChanged()
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "rhoai-2.16" &&  "schedule/bundle-tekton-trigger.txt".pathChanged()
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: rhoai-v2-16
@@ -23,7 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: additional-tags
-    value:
+    value: 
     - '{{target_branch}}-{{revision}}'
     - '{{target_branch}}-nightly'
   - name: output-image
@@ -42,8 +41,6 @@ spec:
     value: false
   - name: rhoai-version
     value: "2.16.5"
-  - name: disable-slack-notifications
-    value: 'true'
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v2-16-push.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v2-16-push.yaml
@@ -6,9 +6,10 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: 'event == "push" && target_branch
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" && target_branch
       == "rhoai-2.16" && ( "catalog/**".pathChanged() || ".tekton/rhoai-fbc-fragment-v2-16-push.yaml".pathChanged()
-      ) && !"catalog/catalog-patch.yaml".pathChanged() && !".github/workflows/**".pathChanged()'
+      ) && !"catalog/catalog-patch.yaml".pathChanged() && !".github/workflows/**".pathChanged()
   labels:
     appstudio.openshift.io/application: rhoai-v2-16
     appstudio.openshift.io/component: rhoai-fbc-fragment-v2-16

--- a/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v2-16-push.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v2-16-push.yaml
@@ -6,10 +6,9 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" && target_branch
+    pipelinesascode.tekton.dev/on-cel-expression: 'event == "push" && target_branch
       == "rhoai-2.16" && ( "catalog/**".pathChanged() || ".tekton/rhoai-fbc-fragment-v2-16-push.yaml".pathChanged()
-      ) && !"catalog/catalog-patch.yaml".pathChanged() && !".github/workflows/**".pathChanged()
+      ) && !"catalog/catalog-patch.yaml".pathChanged() && !".github/workflows/**".pathChanged()'
   labels:
     appstudio.openshift.io/application: rhoai-v2-16
     appstudio.openshift.io/component: rhoai-fbc-fragment-v2-16
@@ -51,8 +50,6 @@ spec:
     value: "true"
   - name: ALWAYS_BUILD_INDEX
     value: "true"
-  - name: disable-slack-notifications
-    value: 'true'
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v2-16-scheduled.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v2-16-scheduled.yaml
@@ -6,7 +6,8 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "rhoai-2.16" && "schedule/catalog-tekton-trigger.txt".pathChanged()
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" && target_branch == "rhoai-2.16" && "schedule/catalog-tekton-trigger.txt".pathChanged()
   labels:
     appstudio.openshift.io/application: rhoai-v2-16
     appstudio.openshift.io/component: rhoai-fbc-fragment-v2-16

--- a/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v2-16-scheduled.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v2-16-scheduled.yaml
@@ -6,8 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" && target_branch == "rhoai-2.16" && "schedule/catalog-tekton-trigger.txt".pathChanged()
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "rhoai-2.16" && "schedule/catalog-tekton-trigger.txt".pathChanged()
   labels:
     appstudio.openshift.io/application: rhoai-v2-16
     appstudio.openshift.io/component: rhoai-fbc-fragment-v2-16
@@ -54,8 +53,6 @@ spec:
     value: "true"
   - name: ALWAYS_BUILD_INDEX
     value: "true"
-  - name: disable-slack-notifications
-    value: 'true'
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v2-16-scheduled.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v2-16-scheduled.yaml
@@ -56,8 +56,6 @@ spec:
     value: "true"
   - name: disable-slack-notifications
     value: 'true'
-  - name: skip-fips
-    value: 'true'
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/rhods-operator/.tekton/odh-operator-v2-16-push.yaml
+++ b/pipelineruns/rhods-operator/.tekton/odh-operator-v2-16-push.yaml
@@ -8,7 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     build.appstudio.openshift.io/build-nudge-files: "bundle/bundle-patch.yaml"
-    pipelinesascode.tekton.dev/on-cel-expression: 'false'
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" && target_branch == "rhoai-2.16" && !"bundle/**".pathChanged()
+      && !"Dockerfiles/bundle.Dockerfile".pathChanged() && (!"build/**".pathChanged()
+      || "build/operands-map.yaml".pathChanged() || ".tekton/odh-operator-v2-16-push.yaml".pathChanged()
+      ) && !".github/workflows/**".pathChanged()
   labels:
     appstudio.openshift.io/application: rhoai-v2-16
     appstudio.openshift.io/component: odh-operator-v2-16


### PR DESCRIPTION
## Description

Reverts the temporary "disable builds" PRs that were applied during the embargo period:

- **Revert #1818** — "Disable builds for rhoai-2.16" (skip-fips)
- **Revert #1809** — "Disable builds for rhoai-2.16" (cel-expression disable + slack notifications)

Also normalizes all `on-cel-expression` values to use YAML block scalar (`|`) style.

This restores the operator build cel-expressions and removes temporary `disable-slack-notifications` and `skip-fips` parameters for the rhoai-2.16 branch.

**JIRA:** [RHOAIENG-57739](https://issues.redhat.com/browse/RHOAIENG-57739)
**Parent:** [RHOAIENG-57438](https://issues.redhat.com/browse/RHOAIENG-57438)

---
🤖 Generated with [Claude Code](https://claude.ai/code) Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>