### PR TITLE
[RHOAIENG-57743] Revert temporary embargo changes on main

### DIFF
--- a/renovate/custom-renovate.json5
+++ b/renovate/custom-renovate.json5
@@ -3,10 +3,9 @@
   "extends": ["config:recommended"],
   "branchPrefix": "renovate/",
   "baseBranches": [
-    //"rhoai-2.16",
-    //"rhoai-2.25",
-    //"rhoai-3.2",
-    //"rhoai-3.3",
+    "rhoai-2.16",
+    "rhoai-2.25",
+    "rhoai-3.3",
     "rhoai-3.4",
     "rhoai-3.4-ea.1",
     "rhoai-3.4-ea.2"


### PR DESCRIPTION
## Description

Reverts the temporary embargo PR:

- **Revert #1841** — "temporarily disable RBC renovate on some branches"

This re-enables Renovate on the `rhoai-2.16`, `rhoai-2.25`, and `rhoai-3.3` branches in the custom renovate config.

Note: PR #1841 also added a commented-out `rhoai-3.2` entry that was not in the original config. This revert removes it. If `rhoai-3.2` should be added to `baseBranches`, that should be done as a separate change.

**JIRA:** [RHOAIENG-57743](https://issues.redhat.com/browse/RHOAIENG-57743)
**Parent:** [RHOAIENG-57438](https://issues.redhat.com/browse/RHOAIENG-57438)

---
🤖 Generated with [Claude Code](https://claude.ai/code) Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>