### PR TITLE
fix issue occurring with long commit messages

### DIFF
--- a/.github/workflows/sync-pipelineruns.yml
+++ b/.github/workflows/sync-pipelineruns.yml
@@ -247,6 +247,8 @@ jobs:
           cp "source/${{ env.PIPELINERUNS_DIR }}/README.md" "target/.tekton/README.md"
 
       - name: Commit Changes
+        env:
+          GH_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           cd source
           konflux_central_commit=$(git rev-parse --short HEAD)
@@ -269,7 +271,7 @@ jobs:
             git commit -m "sync pipelineruns with konflux-central - ${konflux_central_commit}, triggered_by: ${JOB_URL}"          
           fi
 
-          echo "Commit Message: ${{ github.event.head_commit.message }}"
+          echo -n "Commit Message: $GH_COMMIT_MESSAGE"
 
           # Skip commit if dry run is enabled or commit message contains '[skip-sync]'
           if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.dry_run }}" == "true" ]]; then


### PR DESCRIPTION
## Summary
- Cherry-pick of #1895 into `rhoai-3.4`
- Fixes an issue where long commit messages could break the sync-pipelineruns workflow by moving the commit message into an environment variable instead of inline expansion

## Test plan
- [ ] Verify the sync-pipelineruns workflow runs successfully on rhoai-3.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)