### PR TITLE
fix issue occurring with long commit messages

### DIFF
--- a/.github/workflows/sync-pipelineruns.yml
+++ b/.github/workflows/sync-pipelineruns.yml
@@ -251,6 +251,8 @@ jobs:
           cp "source/${{ env.PIPELINERUNS_DIR }}/README.md" "target/.tekton/README.md"
 
       - name: Commit Changes
+        env:
+          GH_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           cd source
           konflux_central_commit=$(git rev-parse --short HEAD)
@@ -273,6 +275,7 @@ jobs:
             git commit -m "sync pipelineruns with konflux-central - ${konflux_central_commit}" -m "Triggered by: ${JOB_URL}"
           fi
 
+          echo -n "Commit Message: $GH_COMMIT_MESSAGE"
           if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.dry_run }}" == "true" ]]; then
             echo "'dry_run' input is true. Skipping push."
           else


### PR DESCRIPTION
## Summary
- Cherry-pick of #1895 into `main`
- Fixes an issue occurring with long commit messages in the sync-pipelineruns workflow by storing `github.event.head_commit.message` in an environment variable (`GH_COMMIT_MESSAGE`) instead of using inline expression interpolation, which can break with special characters or multi-line messages

## Test plan
- [ ] Verify the sync-pipelineruns workflow runs correctly on `main` with a commit that has a long message