### PR TITLE
fix: update prefetch-input paths from component-local to repo-root

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml
@@ -59,9 +59,9 @@ spec:
     value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   - name: prefetch-input
     value:
-    - path: jupyter/pytorch+llmcompressor/ubi9-python-3.12/prefetch-input/mongocli
+    - path: prefetch-input/mongocli
       type: gomod
-    - path: jupyter/datascience/ubi9-python-3.12/prefetch-input/rhds
+    - path: prefetch-input/rhds
       type: rpm
     - path: jupyter/datascience/ubi9-python-3.12
       type: pip

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml
@@ -60,7 +60,7 @@ spec:
     value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   - name: prefetch-input
     value:
-    - path: jupyter/minimal/ubi9-python-3.12/prefetch-input/rhds
+    - path: prefetch-input/rhds
       type: rpm
     - path: jupyter/minimal/ubi9-python-3.12
       type: pip

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cuda-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cuda-py312-pull-request.yaml
@@ -58,7 +58,7 @@ spec:
     value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   - name: prefetch-input
     value:
-    - path: jupyter/minimal/ubi9-python-3.12/prefetch-input/rhds
+    - path: prefetch-input/rhds
       type: rpm
     - path: jupyter/minimal/ubi9-python-3.12
       type: pip

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-pull-request.yaml
@@ -57,7 +57,7 @@ spec:
     value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   - name: prefetch-input
     value:
-    - path: jupyter/minimal/ubi9-python-3.12/prefetch-input/rhds
+    - path: prefetch-input/rhds
       type: rpm
     - path: jupyter/minimal/ubi9-python-3.12
       type: pip


### PR DESCRIPTION
## Summary
- Updated prefetch-input paths in notebook pull-request pipelineruns from component-local symlink paths to repo-root paths
- The upstream notebooks repo (opendatahub-io/notebooks, commit c2c0a07) removed component-local `prefetch-input` symlinks, breaking Konflux builds with: `Value error, package path does not exist (or is not a directory): jupyter/pytorch+llmcompressor/ubi9-python-3.12/prefetch-input/mongocli`
- Affects 4 files: datascience-cpu, minimal-cpu, minimal-cuda, minimal-rocm

## Test plan
- [ ] Trigger a PR build on red-hat-data-services/notebooks — the `prefetch-dependencies` task should no longer fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)