### PR TITLE
[rhoai-3.4] fix: update prefetch-input paths from component-local to repo-root

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-wb-jupyter-pytorch-llmcompressor-cuda-py312-v3-4-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-wb-jupyter-pytorch-llmcompressor-cuda-py312-v3-4-push.yaml
@@ -58,9 +58,9 @@ spec:
     value: "rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6"
   - name: prefetch-input
     value:
-    - path: jupyter/pytorch+llmcompressor/ubi9-python-3.12/prefetch-input/mongocli
+    - path: prefetch-input/mongocli
       type: gomod
-    - path: jupyter/pytorch+llmcompressor/ubi9-python-3.12/prefetch-input/rhds
+    - path: prefetch-input/rhds
       type: rpm
     - path: jupyter/pytorch+llmcompressor/ubi9-python-3.12
       type: pip

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v3-4-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v3-4-push.yaml
@@ -12,7 +12,7 @@ metadata:
       event == "push"
       && target_branch == "rhoai-3.4"
       && !("manifests/base/params-latest.env".pathChanged())
-      && ( ".tekton/odh-workbench-jupyter-datascience-cpu-py312-v3-4-push.yaml".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() || "jupyter/datascience/ubi9-python-3.12/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf".pathChanged() || "jupyter/datascience/ubi9-python-3.12/prefetch-input/rhds/**".pathChanged() || "jupyter/pytorch+llmcompressor/ubi9-python-3.12/prefetch-input/mongocli/**".pathChanged() )
+      && ( ".tekton/odh-workbench-jupyter-datascience-cpu-py312-v3-4-push.yaml".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() || "jupyter/datascience/ubi9-python-3.12/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf".pathChanged() || "prefetch-input/rhds/**".pathChanged() || "prefetch-input/mongocli/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-4
     appstudio.openshift.io/component: odh-workbench-jupyter-datascience-cpu-py312-v3-4
@@ -62,9 +62,9 @@ spec:
     value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   - name: prefetch-input
     value:
-    - path: jupyter/pytorch+llmcompressor/ubi9-python-3.12/prefetch-input/mongocli
+    - path: prefetch-input/mongocli
       type: gomod
-    - path: jupyter/datascience/ubi9-python-3.12/prefetch-input/rhds
+    - path: prefetch-input/rhds
       type: rpm
     - path: jupyter/datascience/ubi9-python-3.12
       type: pip

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cpu-py312-v3-4-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cpu-py312-v3-4-push.yaml
@@ -62,7 +62,7 @@ spec:
     value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   - name: prefetch-input
     value:
-    - path: jupyter/minimal/ubi9-python-3.12/prefetch-input/rhds
+    - path: prefetch-input/rhds
       type: rpm
     - path: jupyter/minimal/ubi9-python-3.12
       type: pip

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cuda-py312-v3-4-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cuda-py312-v3-4-push.yaml
@@ -60,7 +60,7 @@ spec:
     value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   - name: prefetch-input
     value:
-    - path: jupyter/minimal/ubi9-python-3.12/prefetch-input/rhds
+    - path: prefetch-input/rhds
       type: rpm
     - path: jupyter/minimal/ubi9-python-3.12
       type: pip

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v3-4-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v3-4-push.yaml
@@ -59,7 +59,7 @@ spec:
     value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   - name: prefetch-input
     value:
-    - path: jupyter/minimal/ubi9-python-3.12/prefetch-input/rhds
+    - path: prefetch-input/rhds
       type: rpm
     - path: jupyter/minimal/ubi9-python-3.12
       type: pip


### PR DESCRIPTION
## Summary
- Updated prefetch-input paths in notebook push pipelineruns from component-local symlink paths to repo-root paths
- The upstream notebooks repo removed component-local `prefetch-input` symlinks, breaking Konflux builds with: `Value error, package path does not exist (or is not a directory): jupyter/pytorch+llmcompressor/ubi9-python-3.12/prefetch-input/mongocli`
- Affects 5 files: pytorch-llmcompressor-cuda, datascience-cpu, minimal-cpu, minimal-cuda, minimal-rocm
- Also updates the CEL expression in the datascience push pipeline to reference the new paths

## Test plan
- [ ] After merge, push builds on rhoai-3.4 should no longer fail in `prefetch-dependencies`

🤖 Generated with [Claude Code](https://claude.com/claude-code)