### PR TITLE
chore: retrigger odh-pipeline-runtime-minimal-cpu-py312 for rhoai-2.25

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-minimal-cpu-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-minimal-cpu-py312-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-17 08:03:47
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}


### PR DESCRIPTION
## Summary
- Manual retrigger of `odh-pipeline-runtime-minimal-cpu-py312-v2-25` Konflux build by updating the datetime comment in the push PipelineRun YAML.

## Test plan
- [ ] Verify Konflux pipeline triggers after merge