### PR TITLE
Fix validation comment posting for fork PRs (rhoai-3.4)

### DIFF
--- a/.github/workflows/post-validation-comment.yml
+++ b/.github/workflows/post-validation-comment.yml
@@ -1,0 +1,54 @@
+# Posts PipelineRun validation results as a PR comment.
+# Runs as a privileged workflow triggered by workflow_run, so it has write
+# access even when the triggering PR comes from a fork.
+# See docs/validate-pipelineruns.md for details.
+name: Post Validation Comment
+
+on:
+  workflow_run:
+    workflows: ["Validate PipelineRuns"]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+  actions: read
+
+jobs:
+  post-comment:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Download validation comment artifact
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: validation-comment
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Post or update PR comment
+        if: steps.download.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [[ ! -f validation-comment.md ]]; then
+            echo "No validation comment file generated, skipping."
+            exit 0
+          fi
+
+          PR_NUMBER=$(cat pr-number.txt)
+          MARKER="<!-- pipelinerun-validation-comment -->"
+
+          # Find existing comment by marker
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --paginate --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" | head -1)
+
+          if [[ -n "$COMMENT_ID" ]]; then
+            gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
+              --method PATCH \
+              --field body=@validation-comment.md
+          else
+            gh pr comment "${PR_NUMBER}" --body-file validation-comment.md
+          fi

--- a/.github/workflows/validate-pipelineruns.yml
+++ b/.github/workflows/validate-pipelineruns.yml
@@ -69,27 +69,16 @@ jobs:
             --validation-comment-file validation-comment.md \
             ${{ steps.detect-branch.outputs.branch && format('--branch {0}', steps.detect-branch.outputs.branch) || '' }}
 
-      - name: Post or update PR comment
+      - name: Save PR number
         if: always() && github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
-        run: |
-          if [[ ! -f validation-comment.md ]]; then
-            echo "No validation comment file generated, skipping."
-            exit 0
-          fi
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
 
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-          MARKER="<!-- pipelinerun-validation-comment -->"
-
-          # Find existing comment by marker
-          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-            --paginate --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" | head -1)
-
-          if [[ -n "$COMMENT_ID" ]]; then
-            gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
-              --method PATCH \
-              --field body=@validation-comment.md
-          else
-            gh pr comment "${PR_NUMBER}" --body-file validation-comment.md
-          fi
+      - name: Upload validation comment artifact
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: validation-comment
+          path: |
+            validation-comment.md
+            pr-number.txt
+          if-no-files-found: ignore

--- a/docs/validate-pipelineruns.md
+++ b/docs/validate-pipelineruns.md
@@ -16,7 +16,8 @@ errors before they are merged and synced to component repositories.
 |------|---------|
 | `script/test_validate_pipelineruns.py` | Pytest-based validation checks |
 | `script/conftest.py` | Pytest configuration, CLI options, file discovery |
-| `.github/workflows/validate-pipelineruns.yml` | GitHub Actions workflow definition |
+| `.github/workflows/validate-pipelineruns.yml` | GitHub Actions workflow — runs validation and uploads results as artifact |
+| `.github/workflows/post-validation-comment.yml` | GitHub Actions workflow — posts validation results as a PR comment |
 | `docs/validate-pipelineruns.md` | This documentation |
 
 ## PipelineRun Types
@@ -210,11 +211,25 @@ For PRs targeting release branches (e.g., `rhoai-3.4`), the workflow
 passes `--branch <target>` to enable branch-specific checks (checks 4
 and 5). PRs targeting `main` do not pass `--branch`.
 
-### PR Comment
+### PR Comment (Two-Workflow Pattern)
 
-The workflow always posts (or updates) a summary comment on pull
-requests. On success the comment shows a green header with pass/skip
-counts. On failure the comment includes:
+Posting PR comments uses a two-workflow pattern so that it works for
+both fork and non-fork PRs. GitHub restricts the `GITHUB_TOKEN` for
+`pull_request` workflows triggered by forks to read-only, which
+prevents posting comments directly.
+
+1. **`validate-pipelineruns.yml`** (`pull_request` trigger) — runs the
+   validation checks and uploads the generated comment markdown and PR
+   number as a `validation-comment` artifact.
+2. **`post-validation-comment.yml`** (`workflow_run` trigger) — runs
+   after the validation workflow completes, downloads the artifact, and
+   posts or updates the PR comment. Because `workflow_run` always runs
+   in the context of the base repository, it has write access regardless
+   of whether the PR came from a fork.
+
+The comment always shows a summary on pull requests. On success the
+comment shows a green header with pass/skip counts. On failure the
+comment includes:
 
 - **Failures grouped by check name** — each check name links to its
   definition in the test source file.


### PR DESCRIPTION
## Summary

Cherry-pick of #1937 to rhoai-3.4.

Fixes [RHOAIENG-58935](https://redhat.atlassian.net/browse/RHOAIENG-58935): PipelineRun validator workflow fails when a PR is submitted from a forked repository. Splits PR comment posting into a two-workflow artifact-based pattern so it works regardless of fork origin.

See #1937 for full details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)