### PR TITLE
Fix post-validation-comment: use gh api instead of gh pr comment

### DIFF
--- a/.github/workflows/post-validation-comment.yml
+++ b/.github/workflows/post-validation-comment.yml
@@ -50,5 +50,6 @@ jobs:
               --method PATCH \
               --field body=@validation-comment.md
           else
-            gh pr comment "${PR_NUMBER}" --body-file validation-comment.md
+            gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+              --field body=@validation-comment.md
           fi


### PR DESCRIPTION
## Summary

- Fixes the `post-validation-comment.yml` workflow failing with `fatal: not a git repository` ([run](https://github.com/red-hat-data-services/konflux-central/actions/runs/24670299311/job/72138934243))
- `gh pr comment` requires a git repo context, but this workflow only downloads an artifact — no checkout step. Replaced with `gh api` which works without a repo.
- Follow-up to #1937 (RHOAIENG-58935)

## Test plan

- [ ] PR #1940 should validate that the full two-workflow pattern works end-to-end once this is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)