### PR TITLE
fix dockerfile image sha (ecosystem-cert-preflight-checks failure on main)

### DIFF
--- a/.tekton/multi-arch-container-build-pull-request.yaml
+++ b/.tekton/multi-arch-container-build-pull-request.yaml
@@ -46,6 +46,8 @@ spec:
     - linux/ppc64le
     - linux/s390x
     - linux/arm64
+  - name: skip-checks
+    value: "false"
   - name: enable-slack-failure-notification
     value: "false"
   # - name: prefetch-input

--- a/.tekton/multi-arch-container-build-pull-request.yaml
+++ b/.tekton/multi-arch-container-build-pull-request.yaml
@@ -46,8 +46,6 @@ spec:
     - linux/ppc64le
     - linux/s390x
     - linux/arm64
-  - name: skip-checks
-    value: "false"
   - name: enable-slack-failure-notification
     value: "false"
   # - name: prefetch-input

--- a/canary-build/Dockerfile.konflux
+++ b/canary-build/Dockerfile.konflux
@@ -1,1 +1,1 @@
-FROM registry.redhat.io/ubi8/python-312:1@sha256:3d9deabef276ff7a713f0d0f2387463eb96845170b86056fab42acf461baa827
+FROM registry.redhat.io/ubi8/python-312:1@sha256:e63aeb262a7fd3d61df594617fd677e7f6935b00be48a523da01a11883584a98


### PR DESCRIPTION
## Summary
- Enables `skip-checks: "false"` in the multi-arch canary pipeline to demonstrate that `ecosystem-cert-preflight-checks` is currently failing
- This task has been hardcoded to skip on `rhoai-3.4` since Sep 2025 (PRs #584, #597) but is gated by `skip-checks` on `main`
- No pipeline or task changes — only the canary PipelineRun is modified

## Context
The `ecosystem-cert-preflight-checks` task was disabled on rhoai-3.0 era branches and the skip has been carried forward. This PR exists solely to show the failure.

**Do not merge** — close after reviewing the pipeline run results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)