### PR TITLE
chore: point smoke-trigger workflow at rhods-devops-infra

### DIFF
--- a/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v3-2-scheduled.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v3-2-scheduled.yaml
@@ -50,7 +50,7 @@ spec:
   - name: workflow_url
     value: "https://github.com/red-hat-data-services/conforma-reporter/actions/workflows/conforma-reporter.yaml"
   - name: smoke_url
-    value: "https://github.com/red-hat-data-services/conforma-reporter/actions/workflows/smoke-trigger.yaml"
+    value: "https://github.com/red-hat-data-services/rhods-devops-infra/actions/workflows/smoke-trigger.yaml"
   pipelineRef:
     resolver: git
     params:

--- a/pipelines/fbc-fragment-build.yaml
+++ b/pipelines/fbc-fragment-build.yaml
@@ -113,7 +113,7 @@ spec:
   - name: smoke_url
     type: string
     description: "smoke url of the workflow to trigger"
-    default: "https://github.com/red-hat-data-services/conforma-reporter/actions/workflows/smoke-trigger.yaml"
+    default: "https://github.com/red-hat-data-services/rhods-devops-infra/actions/workflows/smoke-trigger.yaml"
   - name: buildah-format
     default: oci
     type: string
@@ -761,7 +761,7 @@ spec:
           set -e
 
           OWNER="red-hat-data-services"
-          REPO="conforma-reporter"
+          REPO="rhods-devops-infra"
           WORKFLOW_FILE="smoke-trigger.yaml"
 
           echo "Target branch is: '$TARGET_BRANCH'"


### PR DESCRIPTION
The smoke-trigger GitHub Actions workflow now lives in red-hat-data-services/rhods-devops-infra.

This updates the FBC pipeline default `smoke_url` and the `trigger-smoke` task to dispatch that repository instead of conforma-reporter. The Conforma reporter workflow trigger is unchanged.

On release branches, scheduled PipelineRun parameters that override `smoke_url` are updated as well.

Made with [Cursor](https://cursor.com)