### PR TITLE
Add FIPS check-payload task to multi-arch pipeline (rhoai-3.4)

### DIFF
--- a/.tekton/odh-dashboard-pull-request.yaml
+++ b/.tekton/odh-dashboard-pull-request.yaml
@@ -1,0 +1,75 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/odh-dashboard?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+  labels:
+    appstudio.openshift.io/application: automation
+    appstudio.openshift.io/component: pull-request-pipelines-odh-dashboard
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-dashboard-on-pull-request
+  namespace: rhoai-tenant
+spec:
+  timeouts:
+    pipeline: 8h
+  params:
+  - name: git-url
+    value: 'https://github.com/red-hat-data-services/odh-dashboard'
+  - name: revision
+    value: rhoai-3.4
+  - name: additional-tags
+    value:
+    - 'pr-{{pull_request_number}}-into-{{target_branch}}'
+  - name: rhoai-version
+    value: "3.4.0"
+  - name: output-image
+    value: quay.io/rhoai/pull-request-pipelines:odh-dashboard-{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux-m2xlarge/arm64
+  - name: dockerfile
+    value: Dockerfile.konflux
+  - name: path-context
+    value: .
+  - name: hermetic
+    value: true
+  - name: prefetch-input
+    value: |
+      [
+        {
+          "type": "npm",
+          "path": "."
+        }
+      ]
+  - name: build-source-image
+    value: true
+  - name: build-image-index
+    value: true
+  - name: image-expires-after
+    value: 5d
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ revision }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-pull-request-pipelines
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/rhods-operator-pull-request.yaml
+++ b/.tekton/rhods-operator-pull-request.yaml
@@ -1,0 +1,79 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/rhods-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+  labels:
+    appstudio.openshift.io/application: automation
+    appstudio.openshift.io/component: pull-request-pipelines-rhods-operator
+    pipelines.appstudio.openshift.io/type: build
+  name: rhods-operator-on-pull-request
+  namespace: rhoai-tenant
+spec:
+  timeouts:
+    pipeline: 4h
+  params:
+  - name: git-url
+    value: 'https://github.com/red-hat-data-services/rhods-operator'
+  - name: revision
+    value: rhoai-3.4
+  - name: additional-tags
+    value:
+    - 'pr-{{pull_request_number}}-into-{{target_branch}}'
+  - name: rhoai-version
+    value: "3.4.0"
+  - name: output-image
+    value: quay.io/rhoai/pull-request-pipelines:rhods-operator-{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux-m2xlarge/arm64
+  - name: dockerfile
+    value: Dockerfiles/Dockerfile.konflux
+  - name: path-context
+    value: .
+  - name: hermetic
+    value: true
+  - name: prefetch-input
+    value: |
+      [
+        {
+          "type": "gomod",
+          "path": "."
+        },
+        {
+          "type": "rpm",
+          "path": "."
+        }
+      ]
+  - name: build-source-image
+    value: true
+  - name: build-image-index
+    value: true
+  - name: image-expires-after
+    value: 5d
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ revision }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-pull-request-pipelines
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -121,6 +121,10 @@ spec:
     description: Disable all slack notifications
     name: disable-slack-notifications
     type: string
+  - name: fips-check-blocking
+    default: "true"
+    type: string
+    description: When true, a FIPS check-payload failure will fail the pipeline
   results:
   - description: ""
     name: IMAGE_URL
@@ -626,6 +630,85 @@ spec:
       - name: kind
         value: task
       resolver: bundles
+  - name: fips-check
+    matrix:
+      params:
+      - name: image-platform
+        value:
+        - $(params.build-platforms)
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: blocking
+      value: $(params.fips-check-blocking)
+    runAfter:
+    - build-image-index
+    taskSpec:
+      params:
+      - name: image-platform
+        type: string
+      - name: image-url
+        type: string
+      - name: image-digest
+        type: string
+      - name: blocking
+        type: string
+        default: "true"
+      results:
+      - name: TEST_OUTPUT
+        description: FIPS check-payload test output
+      steps:
+      - name: prepare-image-list
+        image: quay.io/konflux-ci/konflux-test:v1.4.50@sha256:8b9c7be18bef49f60ac9926830174072cc2010c620c7b3d0a5bb53ba02fcf71d
+        env:
+        - name: IMAGE_PLATFORM
+          value: $(params.image-platform)
+        - name: IMAGE_URL
+          value: $(params.image-url)
+        - name: IMAGE_DIGEST
+          value: $(params.image-digest)
+        script: |
+          ARCH="${IMAGE_PLATFORM#*/}"
+          if [ "${ARCH}" = "x86_64" ]; then ARCH="amd64"; fi
+          case "${ARCH}" in
+            amd64|ppc64le|arm64|s390x) ;;
+            *) ARCH="amd64" ;;
+          esac
+          IMAGE_WITHOUT_TAG=$(echo "${IMAGE_URL}" | sed 's/\(.*\):.*/\1/')
+          PLATFORM_DIGEST=$(skopeo inspect --raw "docker://${IMAGE_WITHOUT_TAG}@${IMAGE_DIGEST}" | jq -r ".manifests[] | select(.platform.architecture == \"${ARCH}\") | .digest")
+          if [ -z "${PLATFORM_DIGEST}" ]; then
+            echo "Could not find digest for architecture ${ARCH} in ${IMAGE_URL}@${IMAGE_DIGEST}"
+            exit 1
+          fi
+          printf '%s' "${IMAGE_WITHOUT_TAG}@${PLATFORM_DIGEST}" > /tekton/home/unique_related_images.txt
+      - name: run-fips-check
+        ref:
+          resolver: git
+          params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
+      - name: evaluate-result
+        image: quay.io/rhoai-konflux/alpine:latest
+        env:
+        - name: TEST_OUTPUT
+          value: $(steps.run-fips-check.results.TEST_OUTPUT)
+        - name: BLOCKING
+          value: $(params.blocking)
+        script: |
+          printf '%s' "${TEST_OUTPUT}" > $(results.TEST_OUTPUT.path)
+          if echo "${TEST_OUTPUT}" | grep -qE '"result":"(FAILURE|ERROR)"'; then
+            if [ "${BLOCKING}" = "true" ]; then
+              echo "FIPS check failed and blocking is enabled"
+              exit 1
+            fi
+            echo "FIPS check failed but blocking is not enabled, continuing"
+          fi
   - name: pipeline-success-indicator
     runAfter:
     - build-source-image
@@ -641,6 +724,7 @@ spec:
     - rpms-signature-scan
     - sast-coverity-check
     - coverity-availability-check
+    - fips-check
     taskSpec:
       steps:
       - name: noop


### PR DESCRIPTION
## Summary
- Backport of #1942 to rhoai-3.4
- Adds a post-build FIPS compliance check using the `fips-operator-check-step-action` StepAction from `konflux-ci/build-definitions`
- Runs `check-payload` against each platform-specific image in parallel via matrix
- Controlled by `fips-check-blocking` param (default `true`)

## Test plan
- [x] Trigger a build via `/build-konflux` on a component using this pipeline
- [ ] Verify FIPS check runs for each platform in parallel
- [ ] Pin step action git revision to a specific commit SHA before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)