### PR TITLE
pipelines(notebooks): align odh-pipeline-runtime PR Konflux pipelines

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-minimal-cpu-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-minimal-cpu-py312-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-minimal-cpu)"
     pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-runtime, kfbuild-cpu, kfbuild-minimal, kfbuild-runtime-minimal-cpu]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
@@ -39,6 +39,8 @@ spec:
     value: runtimes/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
   - name: path-context
     value: .
+  - name: enable-cache-proxy
+    value: true
   - name: hermetic
     value: false
   - name: build-image-index
@@ -53,6 +55,17 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
+  - name: prefetch-input
+    value:
+    - path: prefetch-input/rhds
+      type: rpm
+    - path: runtimes/minimal/ubi9-python-3.12
+      type: pip
+      binary:
+        arch: "x86_64,aarch64,ppc64le,s390x"
+      requirements_files: [requirements.cpu.txt]
   pipelineRef:
     resolver: git
     params:
@@ -62,6 +75,18 @@ spec:
       value: '{{ target_branch }}'
     - name: pathInRepo
       value: pipelines/multi-arch-container-build.yaml
+  timeouts:
+    pipeline: 8h
+    tasks: 4h
+  taskRunSpecs:
+    - pipelineTaskName: prefetch-dependencies
+      computeResources:
+        requests:
+          cpu: '3'
+          memory: 8Gi
+        limits:
+          cpu: '3'
+          memory: 8Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-pull-request-pipelines
   workspaces:

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-pytorch-cuda)"
     pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-runtime, kfbuild-pytorch, kfbuild-cuda, kfbuild-runtime-pytorch-cuda]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
@@ -39,6 +39,8 @@ spec:
     value: runtimes/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
   - name: path-context
     value: .
+  - name: enable-cache-proxy
+    value: true
   - name: hermetic
     value: false
   - name: build-image-index
@@ -50,6 +52,17 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
+  - name: prefetch-input
+    value:
+    - path: prefetch-input/rhds
+      type: rpm
+    - path: runtimes/pytorch/ubi9-python-3.12
+      type: pip
+      binary:
+        arch: "x86_64"
+      requirements_files: [requirements.cuda.txt]
   pipelineRef:
     resolver: git
     params:
@@ -63,6 +76,14 @@ spec:
     pipeline: 8h
     tasks: 4h
   taskRunSpecs:
+    - pipelineTaskName: prefetch-dependencies
+      computeResources:
+        requests:
+          cpu: '3'
+          memory: 8Gi
+        limits:
+          cpu: '3'
+          memory: 8Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       computeResources:
         requests:

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-pull-request.yaml
@@ -8,15 +8,15 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-datascience-cpu)"
-    pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-runtime, kfbuild-cpu, kfbuild-datascience, kfbuild-runtime-datascience-cpu]"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-pytorch-llmcompressor-cuda)"
+    pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-runtime, kfbuild-pytorch, kfbuild-cuda, kfbuild-llmcompressor, kfbuild-runtime-pytorch-llmcompressor-cuda]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:
     appstudio.openshift.io/application: automation
     appstudio.openshift.io/component: pull-request-pipelines-notebooks
     pipelines.appstudio.openshift.io/type: build
-  name: odh-pipeline-runtime-datascience-cpu-py312-on-pull-request-97305
+  name: odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-on-pull-request-77104
   namespace: rhoai-tenant
 spec:
   params:
@@ -32,11 +32,11 @@ spec:
   - name: additional-labels
     value:
     - version=on-pr-{{revision}}
-    - io.openshift.tags=odh-pipeline-runtime-datascience-cpu-py312
+    - io.openshift.tags=odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312
   - name: dockerfile
-    value: runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+    value: runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
   - name: build-args-file
-    value: runtimes/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
+    value: runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
   - name: path-context
     value: .
   - name: enable-cache-proxy
@@ -47,10 +47,7 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux/x86_64
-    - linux-m2xlarge/arm64
-    - linux/ppc64le
-    - linux/s390x
+    - linux-extra-fast/amd64
   - name: image-expires-after
     value: 5d
   - name: enable-slack-failure-notification
@@ -61,11 +58,11 @@ spec:
     value:
     - path: prefetch-input/rhds
       type: rpm
-    - path: runtimes/datascience/ubi9-python-3.12
+    - path: runtimes/pytorch+llmcompressor/ubi9-python-3.12
       type: pip
       binary:
-        arch: "x86_64,aarch64,ppc64le,s390x"
-      requirements_files: [requirements.cpu.txt]
+        arch: "x86_64"
+      requirements_files: [requirements.cuda.txt]
   pipelineRef:
     resolver: git
     params:
@@ -87,6 +84,22 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 16Gi
+        limits:
+          cpu: '16'
+          memory: 32Gi
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 16Gi
+        limits:
+          cpu: '16'
+          memory: 32Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-pull-request-pipelines
   workspaces:

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-pytorch-rocm)"
     pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-runtime, kfbuild-pytorch, kfbuild-rocm, kfbuild-runtime-pytorch-rocm]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
@@ -39,6 +39,8 @@ spec:
     value: runtimes/rocm-pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
   - name: path-context
     value: .
+  - name: enable-cache-proxy
+    value: true
   - name: hermetic
     value: false
   - name: build-image-index
@@ -50,6 +52,17 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
+  - name: prefetch-input
+    value:
+    - path: prefetch-input/rhds
+      type: rpm
+    - path: runtimes/rocm-pytorch/ubi9-python-3.12
+      type: pip
+      binary:
+        arch: "x86_64"
+      requirements_files: [requirements.rocm.txt]
   pipelineRef:
     resolver: git
     params:
@@ -63,6 +76,14 @@ spec:
     pipeline: 8h
     tasks: 4h
   taskRunSpecs:
+    - pipelineTaskName: prefetch-dependencies
+      computeResources:
+        requests:
+          cpu: '3'
+          memory: 8Gi
+        limits:
+          cpu: '3'
+          memory: 8Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       computeResources:
         requests:

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-tensorflow-cuda)"
     pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-runtime, kfbuild-tensorflow, kfbuild-cuda, kfbuild-runtime-tensorflow-cuda]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
@@ -39,6 +39,8 @@ spec:
     value: runtimes/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
   - name: path-context
     value: .
+  - name: enable-cache-proxy
+    value: true
   - name: hermetic
     value: false
   - name: build-image-index
@@ -51,6 +53,17 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
+  - name: prefetch-input
+    value:
+    - path: prefetch-input/rhds
+      type: rpm
+    - path: runtimes/tensorflow/ubi9-python-3.12
+      type: pip
+      binary:
+        arch: "x86_64,aarch64"
+      requirements_files: [requirements.cuda.txt]
   pipelineRef:
     resolver: git
     params:
@@ -64,6 +77,14 @@ spec:
     pipeline: 8h
     tasks: 4h
   taskRunSpecs:
+    - pipelineTaskName: prefetch-dependencies
+      computeResources:
+        requests:
+          cpu: '3'
+          memory: 8Gi
+        limits:
+          cpu: '3'
+          memory: 8Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       computeResources:
         requests:

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-pull-request.yaml
@@ -8,15 +8,15 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-datascience-cpu)"
-    pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-runtime, kfbuild-cpu, kfbuild-datascience, kfbuild-runtime-datascience-cpu]"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-tensorflow-rocm)"
+    pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-runtime, kfbuild-tensorflow, kfbuild-rocm, kfbuild-runtime-tensorflow-rocm]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:
     appstudio.openshift.io/application: automation
     appstudio.openshift.io/component: pull-request-pipelines-notebooks
     pipelines.appstudio.openshift.io/type: build
-  name: odh-pipeline-runtime-datascience-cpu-py312-on-pull-request-97305
+  name: odh-pipeline-runtime-tensorflow-rocm-py312-on-pull-request-53829
   namespace: rhoai-tenant
 spec:
   params:
@@ -32,11 +32,11 @@ spec:
   - name: additional-labels
     value:
     - version=on-pr-{{revision}}
-    - io.openshift.tags=odh-pipeline-runtime-datascience-cpu-py312
+    - io.openshift.tags=odh-pipeline-runtime-tensorflow-rocm-py312
   - name: dockerfile
-    value: runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+    value: runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
   - name: build-args-file
-    value: runtimes/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
+    value: runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
   - name: path-context
     value: .
   - name: enable-cache-proxy
@@ -47,10 +47,7 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux/x86_64
-    - linux-m2xlarge/arm64
-    - linux/ppc64le
-    - linux/s390x
+    - linux-extra-fast/amd64
   - name: image-expires-after
     value: 5d
   - name: enable-slack-failure-notification
@@ -61,11 +58,11 @@ spec:
     value:
     - path: prefetch-input/rhds
       type: rpm
-    - path: runtimes/datascience/ubi9-python-3.12
+    - path: runtimes/rocm-tensorflow/ubi9-python-3.12
       type: pip
       binary:
-        arch: "x86_64,aarch64,ppc64le,s390x"
-      requirements_files: [requirements.cpu.txt]
+        arch: "x86_64"
+      requirements_files: [requirements.rocm.txt]
   pipelineRef:
     resolver: git
     params:
@@ -87,6 +84,22 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 16Gi
+        limits:
+          cpu: '16'
+          memory: 32Gi
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 16Gi
+        limits:
+          cpu: '16'
+          memory: 32Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-pull-request-pipelines
   workspaces:


### PR DESCRIPTION
Bring all odh-pipeline-runtime-* pull-request PipelineRuns in line with the workbench pattern: enable-cache-proxy, rhel-subscription-activation-key, prefetch-input (prefetch-input/rhds rpm plus pip prefetch per image path and requirements file), hermetic builds disabled (hermetic: false), prefetch-dependencies task sizing (and timeouts where missing on CPU runtimes). Add PipelineRuns for runtimes that had no PR coverage: pytorch+llmcompressor CUDA and rocm-tensorflow. Extend pipelinesascode.tekton.dev/on-comment on each of the seven runtime pipelines to accept /build-konflux plus a dedicated /build-runtime-* comment so runtime images can be triggered without overlapping workbench-specific commands.