### PR TITLE
Enable Renovate for odh-ai-second-demo

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -41,6 +41,7 @@
       targetFilePath: "renovate.json"
     - name: "red-hat-data-services/kube-auth-proxy"
       targetFilePath: ".github/renovate.json5"
+    - name: "rhoai-rhtap/odh-ai-second-demo"
 
 - renovate-config: "renovate/custom-renovate-distribution.json"
   sync-repositories:


### PR DESCRIPTION
Adds 'rhoai-rhtap/odh-ai-second-demo' to the default Renovate distribution in config.yaml.

## Details

| Field | Value |
|-------|-------|
| Component repo | `https://github.com/rhoai-rhtap/odh-ai-second-demo` |
| Renovate entry | `rhoai-rhtap/odh-ai-second-demo` |
| Distribution | `renovate/default-renovate-distribution.json` |

**Jira:** https://redhat.atlassian.net/browse/RHODS-14227