### PR TITLE
Add odh-kserve-localmodel-controller-v3-5-ea-1 PipelineRun for kserve

### DIFF
--- a/pipelineruns/kserve/.tekton/odh-kserve-localmodel-controller-v3-5-ea-1-push.yaml
+++ b/pipelineruns/kserve/.tekton/odh-kserve-localmodel-controller-v3-5-ea-1-push.yaml
@@ -1,0 +1,65 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/kserve?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push"
+      && target_branch == "rhoai-3.5-ea.1"
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-kserve-localmodel-controller-v3-5-ea-1-push.yaml".pathChanged() )
+  labels:
+    appstudio.openshift.io/application: rhoai-v3-5-ea-1
+    appstudio.openshift.io/component: odh-kserve-localmodel-controller-v3-5-ea-1
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-kserve-localmodel-controller-v3-5-ea-1-on-push
+  namespace: rhoai-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: additional-tags
+    value:
+    - '{{target_branch}}-{{revision}}'
+  - name: output-image
+    value: quay.io/rhoai/odh-kserve-localmodel-controller-rhel9:{{target_branch}}
+  - name: rhoai-version
+    value: "3.5.0-ea.1"
+  - name: dockerfile
+    value: Dockerfiles/localmodel.Dockerfile.konflux
+  - name: path-context
+    value: .
+  - name: hermetic
+    value: false
+  - name: build-source-image
+    value: true
+  - name: build-image-index
+    value: true
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux-m2xlarge/arm64
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ target_branch }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-kserve-localmodel-controller-v3-5-ea-1
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Adds Tekton PipelineRun YAML for component 'odh-kserve-localmodel-controller'.

## Details

| Field | Value |
|-------|-------|
| Component | `odh-kserve-localmodel-controller` |
| Version | `3.5-ea-1` |
| Branch | `rhoai-3.5-ea.1` |
| Source repo | `https://github.com/red-hat-data-services/kserve` |
| File | `pipelineruns/kserve/.tekton/odh-kserve-localmodel-controller-v3-5-ea-1-push.yaml` |
| Platforms | linux/x86_64 linux/ppc64le linux/s390x linux-m2xlarge/arm64 |

**Jira:** https://redhat.atlassian.net/browse/RHOAIENG-56375