### PR TITLE
Skip FIPS check for nightly FBC builds (rhoai-2.25)

### DIFF
--- a/pipelines/fbc-fragment-build.yaml
+++ b/pipelines/fbc-fragment-build.yaml
@@ -381,10 +381,6 @@ spec:
         value: task
       resolver: bundles
     when:
-    - input: $(params.build-type)
-      operator: in
-      values:
-      - 'nightly'
     - input: $(params.skip-fips)
       operator: in
       values:


### PR DESCRIPTION
## Summary
- Remove `build-type` when condition on `fbc-fips-check-oci-ta` task so FIPS check is skipped for all FBC builds including nightly
- Follows up on #2007 which skipped FIPS for RC/stage builds

## Test plan
- [ ] Verify nightly FBC pipeline runs skip `fbc-fips-check-oci-ta`