### PR TITLE
Set skip-fips default to true in FBC pipeline (rhoai-2.25)

### DIFF
--- a/pipelines/fbc-fragment-build.yaml
+++ b/pipelines/fbc-fragment-build.yaml
@@ -31,7 +31,7 @@ spec:
     description: Skip checks against built image
     name: skip-checks
     type: string
-  - default: "false"
+  - default: "true"
     description: Skip FIPS check
     name: skip-fips
     type: string


### PR DESCRIPTION
## Summary
- The previous PR (#2009) removed the `build-type` when condition but the `skip-fips` when condition still allowed `fbc-fips-check-oci-ta` to run since `skip-fips` defaults to `"false"`
- This sets `skip-fips` default to `"true"` so the task is actually skipped

## Test plan
- [ ] Verify FBC pipeline runs skip `fbc-fips-check-oci-ta`