### PR TITLE
chore: retrigger konflux builds for all v2.25 components

### DIFF
--- a/pipelineruns/RHOAI-Build-Config/.tekton/odh-operator-bundle-v2-25-push.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/odh-operator-bundle-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/RHOAI-Build-Config?rev={{revision}}

--- a/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v2-25-push.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/RHOAI-Build-Config?rev={{revision}}

--- a/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-argoexec-v2-25-push.yaml
+++ b/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-argoexec-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/argo-workflows?rev={{revision}}

--- a/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-workflowcontroller-v2-25-push.yaml
+++ b/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-workflowcontroller-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/argo-workflows?rev={{revision}}

--- a/pipelineruns/caikit-nlp/.tekton/odh-caikit-nlp-v2-25-push.yaml
+++ b/pipelineruns/caikit-nlp/.tekton/odh-caikit-nlp-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/caikit-nlp?rev={{revision}}

--- a/pipelineruns/caikit-tgis-serving/.tekton/odh-caikit-tgis-serving-v2-25-push.yaml
+++ b/pipelineruns/caikit-tgis-serving/.tekton/odh-caikit-tgis-serving-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/caikit-tgis-serving?rev={{revision}}

--- a/pipelineruns/codeflare-operator/.tekton/odh-codeflare-operator-v2-25-push.yaml
+++ b/pipelineruns/codeflare-operator/.tekton/odh-codeflare-operator-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/codeflare-operator?rev={{revision}}

--- a/pipelineruns/data-science-pipelines-operator/.tekton/odh-data-science-pipelines-operator-controller-v2-25-push.yaml
+++ b/pipelineruns/data-science-pipelines-operator/.tekton/odh-data-science-pipelines-operator-controller-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/data-science-pipelines-operator?rev={{revision}}

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-api-server-v2-v2-25-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-api-server-v2-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/data-science-pipelines?rev={{revision}}

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-driver-v2-25-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-driver-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/data-science-pipelines?rev={{revision}}

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-launcher-v2-25-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-launcher-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/data-science-pipelines?rev={{revision}}

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-persistenceagent-v2-v2-25-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-persistenceagent-v2-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/data-science-pipelines?rev={{revision}}

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-scheduledworkflow-v2-v2-25-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-scheduledworkflow-v2-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/data-science-pipelines?rev={{revision}}

--- a/pipelineruns/distributed-workloads/.tekton/odh-training-cuda121-torch24-py311-v2-25-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-training-cuda121-torch24-py311-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/distributed-workloads?rev={{revision}}

--- a/pipelineruns/distributed-workloads/.tekton/odh-training-cuda124-torch25-py311-v2-25-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-training-cuda124-torch25-py311-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/distributed-workloads?rev={{revision}}

--- a/pipelineruns/distributed-workloads/.tekton/odh-training-rocm62-torch24-py311-v2-25-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-training-rocm62-torch24-py311-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/distributed-workloads?rev={{revision}}

--- a/pipelineruns/distributed-workloads/.tekton/odh-training-rocm62-torch25-py311-v2-25-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-training-rocm62-torch25-py311-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/distributed-workloads?rev={{revision}}

--- a/pipelineruns/feast/.tekton/odh-feast-operator-v2-25-push.yaml
+++ b/pipelineruns/feast/.tekton/odh-feast-operator-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/feast?rev={{revision}}

--- a/pipelineruns/feast/.tekton/odh-feature-server-v2-25-push.yaml
+++ b/pipelineruns/feast/.tekton/odh-feature-server-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/feast?rev={{revision}}

--- a/pipelineruns/fms-guardrails-orchestrator/.tekton/odh-fms-guardrails-orchestrator-v2-25-push.yaml
+++ b/pipelineruns/fms-guardrails-orchestrator/.tekton/odh-fms-guardrails-orchestrator-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/fms-guardrails-orchestrator?rev={{revision}}

--- a/pipelineruns/guardrails-detectors/.tekton/odh-built-in-detector-v2-25-push.yaml
+++ b/pipelineruns/guardrails-detectors/.tekton/odh-built-in-detector-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/guardrails-detectors?rev={{revision}}

--- a/pipelineruns/guardrails-detectors/.tekton/odh-guardrails-detector-huggingface-runtime-v2-25-push.yaml
+++ b/pipelineruns/guardrails-detectors/.tekton/odh-guardrails-detector-huggingface-runtime-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/guardrails-detectors?rev={{revision}}

--- a/pipelineruns/ilab-on-ocp/.tekton/odh-ml-pipelines-runtime-generic-v2-25-push.yaml
+++ b/pipelineruns/ilab-on-ocp/.tekton/odh-ml-pipelines-runtime-generic-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/ilab-on-ocp?rev={{revision}}

--- a/pipelineruns/kserve/.tekton/odh-kserve-agent-v2-25-push.yaml
+++ b/pipelineruns/kserve/.tekton/odh-kserve-agent-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/kserve?rev={{revision}}

--- a/pipelineruns/kserve/.tekton/odh-kserve-controller-v2-25-push.yaml
+++ b/pipelineruns/kserve/.tekton/odh-kserve-controller-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/kserve?rev={{revision}}

--- a/pipelineruns/kserve/.tekton/odh-kserve-router-v2-25-push.yaml
+++ b/pipelineruns/kserve/.tekton/odh-kserve-router-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/kserve?rev={{revision}}

--- a/pipelineruns/kserve/.tekton/odh-kserve-storage-initializer-v2-25-push.yaml
+++ b/pipelineruns/kserve/.tekton/odh-kserve-storage-initializer-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/kserve?rev={{revision}}

--- a/pipelineruns/kubeflow/.tekton/odh-kf-notebook-controller-v2-25-push.yaml
+++ b/pipelineruns/kubeflow/.tekton/odh-kf-notebook-controller-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/kubeflow?rev={{revision}}

--- a/pipelineruns/kubeflow/.tekton/odh-notebook-controller-v2-25-push.yaml
+++ b/pipelineruns/kubeflow/.tekton/odh-notebook-controller-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/kubeflow?rev={{revision}}

--- a/pipelineruns/kuberay/.tekton/odh-kuberay-operator-controller-v2-25-push.yaml
+++ b/pipelineruns/kuberay/.tekton/odh-kuberay-operator-controller-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/kuberay?rev={{revision}}

--- a/pipelineruns/kueue/.tekton/odh-kueue-controller-v2-25-push.yaml
+++ b/pipelineruns/kueue/.tekton/odh-kueue-controller-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/kueue?rev={{revision}}

--- a/pipelineruns/llama-stack-k8s-operator/.tekton/odh-llama-stack-k8s-operator-v2-25-push.yaml
+++ b/pipelineruns/llama-stack-k8s-operator/.tekton/odh-llama-stack-k8s-operator-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/llama-stack-k8s-operator?rev={{revision}}

--- a/pipelineruns/llm-d-inference-scheduler/.tekton/odh-llm-d-inference-scheduler-v2-25-push.yaml
+++ b/pipelineruns/llm-d-inference-scheduler/.tekton/odh-llm-d-inference-scheduler-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-16 12:00:00
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/llm-d-inference-scheduler?rev={{revision}}

--- a/pipelineruns/llm-d-routing-sidecar/.tekton/odh-llm-d-routing-sidecar-v2-25-push.yaml
+++ b/pipelineruns/llm-d-routing-sidecar/.tekton/odh-llm-d-routing-sidecar-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/llm-d-routing-sidecar?rev={{revision}}

--- a/pipelineruns/lm-evaluation-harness/.tekton/odh-ta-lmes-job-v2-25-push.yaml
+++ b/pipelineruns/lm-evaluation-harness/.tekton/odh-ta-lmes-job-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/lm-evaluation-harness?rev={{revision}}

--- a/pipelineruns/ml-metadata/.tekton/odh-mlmd-grpc-server-v2-25-push.yaml
+++ b/pipelineruns/ml-metadata/.tekton/odh-mlmd-grpc-server-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/ml-metadata?rev={{revision}}

--- a/pipelineruns/model-metadata-collection/.tekton/odh-model-metadata-collection-v2-25-push.yaml
+++ b/pipelineruns/model-metadata-collection/.tekton/odh-model-metadata-collection-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/model-metadata-collection?rev={{revision}}

--- a/pipelineruns/model-registry-operator/.tekton/odh-model-registry-operator-v2-25-push.yaml
+++ b/pipelineruns/model-registry-operator/.tekton/odh-model-registry-operator-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/model-registry-operator?rev={{revision}}

--- a/pipelineruns/model-registry/.tekton/odh-model-registry-job-async-upload-v2-25-push.yaml
+++ b/pipelineruns/model-registry/.tekton/odh-model-registry-job-async-upload-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
 #test
   annotations:

--- a/pipelineruns/model-registry/.tekton/odh-model-registry-v2-25-push.yaml
+++ b/pipelineruns/model-registry/.tekton/odh-model-registry-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/model-registry?rev={{revision}}

--- a/pipelineruns/modelmesh-runtime-adapter/.tekton/odh-modelmesh-runtime-adapter-v2-25-push.yaml
+++ b/pipelineruns/modelmesh-runtime-adapter/.tekton/odh-modelmesh-runtime-adapter-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/modelmesh-runtime-adapter?rev={{revision}}

--- a/pipelineruns/modelmesh-serving/.tekton/odh-modelmesh-serving-controller-v2-25-push.yaml
+++ b/pipelineruns/modelmesh-serving/.tekton/odh-modelmesh-serving-controller-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/modelmesh-serving?rev={{revision}}

--- a/pipelineruns/modelmesh/.tekton/odh-modelmesh-v2-25-push.yaml
+++ b/pipelineruns/modelmesh/.tekton/odh-modelmesh-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/modelmesh?rev={{revision}}

--- a/pipelineruns/must-gather/.tekton/odh-must-gather-v2-25-push.yaml
+++ b/pipelineruns/must-gather/.tekton/odh-must-gather-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/must-gather?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-datascience-cpu-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-datascience-cpu-py312-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-minimal-cpu-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-minimal-cpu-py312-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-17 08:03:47
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-16 12:00:00
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cpu-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cpu-py312-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cuda-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cuda-py312-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-16 12:00:00
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/odh-dashboard/.tekton/odh-dashboard-v2-25-push.yaml
+++ b/pipelineruns/odh-dashboard/.tekton/odh-dashboard-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/odh-dashboard?rev={{revision}}

--- a/pipelineruns/odh-dashboard/.tekton/odh-mod-arch-model-registry-v2-25-push.yaml
+++ b/pipelineruns/odh-dashboard/.tekton/odh-mod-arch-model-registry-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/odh-dashboard?rev={{revision}}

--- a/pipelineruns/odh-model-controller/.tekton/odh-model-controller-v2-25-push.yaml
+++ b/pipelineruns/odh-model-controller/.tekton/odh-model-controller-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/odh-model-controller?rev={{revision}}

--- a/pipelineruns/openvino_model_server/.tekton/odh-openvino-model-server-v2-25-push.yaml
+++ b/pipelineruns/openvino_model_server/.tekton/odh-openvino-model-server-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/openvino_model_server?rev={{revision}}

--- a/pipelineruns/rest-proxy/.tekton/odh-mm-rest-proxy-v2-25-push.yaml
+++ b/pipelineruns/rest-proxy/.tekton/odh-mm-rest-proxy-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/rest-proxy?rev={{revision}}

--- a/pipelineruns/rhods-operator/.tekton/odh-operator-v2-25-push.yaml
+++ b/pipelineruns/rhods-operator/.tekton/odh-operator-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/rhods-operator?rev={{revision}}

--- a/pipelineruns/training-operator/.tekton/odh-training-operator-v2-25-push.yaml
+++ b/pipelineruns/training-operator/.tekton/odh-training-operator-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/training-operator?rev={{revision}}

--- a/pipelineruns/trustyai-explainability/.tekton/odh-trustyai-service-v2-25-push.yaml
+++ b/pipelineruns/trustyai-explainability/.tekton/odh-trustyai-service-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/trustyai-explainability?rev={{revision}}

--- a/pipelineruns/trustyai-service-operator/.tekton/odh-ta-lmes-driver-v2-25-push.yaml
+++ b/pipelineruns/trustyai-service-operator/.tekton/odh-ta-lmes-driver-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/trustyai-service-operator?rev={{revision}}

--- a/pipelineruns/trustyai-service-operator/.tekton/odh-trustyai-service-operator-v2-25-push.yaml
+++ b/pipelineruns/trustyai-service-operator/.tekton/odh-trustyai-service-operator-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/trustyai-service-operator?rev={{revision}}

--- a/pipelineruns/vllm-cpu/.tekton/odh-vllm-cpu-v2-25-push.yaml
+++ b/pipelineruns/vllm-cpu/.tekton/odh-vllm-cpu-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/vllm-cpu?rev={{revision}}

--- a/pipelineruns/vllm-gaudi/.tekton/odh-vllm-gaudi-v2-25-push.yaml
+++ b/pipelineruns/vllm-gaudi/.tekton/odh-vllm-gaudi-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/vllm-gaudi?rev={{revision}}

--- a/pipelineruns/vllm-orchestrator-gateway/.tekton/odh-trustyai-vllm-orchestrator-gateway-v2-25-push.yaml
+++ b/pipelineruns/vllm-orchestrator-gateway/.tekton/odh-trustyai-vllm-orchestrator-gateway-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/vllm-orchestrator-gateway?rev={{revision}}

--- a/pipelineruns/vllm-rocm/.tekton/odh-vllm-rocm-v2-25-push.yaml
+++ b/pipelineruns/vllm-rocm/.tekton/odh-vllm-rocm-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/vllm-rocm?rev={{revision}}

--- a/pipelineruns/vllm/.tekton/odh-vllm-cuda-v2-25-push.yaml
+++ b/pipelineruns/vllm/.tekton/odh-vllm-cuda-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-04-15 14:16:12
+# konflux build manual retrigger - 2026-04-25 08:13:22
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/vllm?rev={{revision}}


### PR DESCRIPTION
## Summary
- Updated retrigger timestamp in 77 push pipeline YAML files for all v2.25 components
- New timestamp: `2026-04-25 08:13:22`
- Triggers fresh Konflux builds for the entire v2.25 component set

## Components (77 files)
argo-workflows, caikit-nlp, caikit-tgis-serving, codeflare-operator, data-science-pipelines, data-science-pipelines-operator, distributed-workloads, feast, fms-guardrails-orchestrator, guardrails-detectors, ilab-on-ocp, kserve, kubeflow, kuberay, kueue, llama-stack-k8s-operator, llm-d-inference-scheduler, llm-d-routing-sidecar, lm-evaluation-harness, ml-metadata, model-metadata-collection, model-registry, model-registry-operator, modelmesh, modelmesh-runtime-adapter, modelmesh-serving, must-gather, notebooks, odh-dashboard, odh-model-controller, openvino_model_server, rest-proxy, RHOAI-Build-Config, rhods-operator, training-operator, trustyai-explainability, trustyai-service-operator, vllm, vllm-cpu, vllm-gaudi, vllm-orchestrator-gateway, vllm-rocm

## Test plan
- [ ] Verify PR merges cleanly into rhoai-2.25
- [ ] Confirm Konflux pipelines trigger after merge