### PR TITLE
fix: remove TEST_OUTPUT from fips-check to resolve Conforma trust violation (rhoai-3.3)

### DIFF
--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -650,9 +650,6 @@ spec:
       - name: blocking
         type: string
         default: "true"
-      results:
-      - name: TEST_OUTPUT
-        description: FIPS check-payload test output
       steps:
       - name: prepare-image-list
         image: quay.io/konflux-ci/konflux-test:v1.4.53@sha256:724ecf16a1fc9b51a1b20c91c5125556c53d471d0d8db1648d2404e4715f204e
@@ -695,7 +692,7 @@ spec:
         - name: BLOCKING
           value: $(params.blocking)
         script: |
-          printf '%s' "${TEST_OUTPUT}" > $(results.TEST_OUTPUT.path)
+          echo "${TEST_OUTPUT}"
           if echo "${TEST_OUTPUT}" | grep -qE '"result":"(FAILURE|ERROR)"'; then
             if [ "${BLOCKING}" = "true" ]; then
               echo "FIPS check failed and blocking is enabled"


### PR DESCRIPTION
## Summary

- Remove the `results` block (`TEST_OUTPUT`) from the inline fips-check taskSpec in `pipelines/multi-arch-container-build.yaml`
- Replace `printf '%s' "${TEST_OUTPUT}" > $(results.TEST_OUTPUT.path)` with `echo "${TEST_OUTPUT}"` in the evaluate-result step

## Context

Producing a `TEST_OUTPUT` result in the inline fips-check taskSpec places the task in the Conforma trusted artifacts chain. Because the fips-check task is defined inline (not via a trusted bundle), this causes a `trusted_task.trusted` Enterprise Contract violation. Removing the result avoids the violation while preserving the existing pass/fail behavior (the step still exits non-zero when blocking is enabled and the FIPS check fails).

## Test plan

- [ ] Verify the pipeline YAML is valid (no syntax errors)
- [ ] Trigger a multi-arch build and confirm fips-check runs successfully
- [ ] Confirm no `trusted_task.trusted` Conforma violation on the resulting build

🤖 Generated with [Claude Code](https://claude.com/claude-code)