### PR TITLE
fix: remove TEST_OUTPUT from fips-check to resolve Conforma trust violation (rhoai-3.5-ea.1)

### DIFF
--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -656,9 +656,6 @@ spec:
       - name: blocking
         type: string
         default: "true"
-      results:
-      - name: TEST_OUTPUT
-        description: FIPS check-payload test output
       steps:
       - name: prepare-image-list
         image: quay.io/konflux-ci/konflux-test:v1.4.50@sha256:8b9c7be18bef49f60ac9926830174072cc2010c620c7b3d0a5bb53ba02fcf71d
@@ -701,7 +698,7 @@ spec:
         - name: BLOCKING
           value: $(params.blocking)
         script: |
-          printf '%s' "${TEST_OUTPUT}" > $(results.TEST_OUTPUT.path)
+          echo "${TEST_OUTPUT}"
           if echo "${TEST_OUTPUT}" | grep -qE '"result":"(FAILURE|ERROR)"'; then
             if [ "${BLOCKING}" = "true" ]; then
               echo "FIPS check failed and blocking is enabled"


### PR DESCRIPTION
## Summary

- Remove the `TEST_OUTPUT` result declaration from the inline `fips-check` taskSpec in `pipelines/multi-arch-container-build.yaml`
- Replace `printf '%s' "${TEST_OUTPUT}" > $(results.TEST_OUTPUT.path)` with `echo "${TEST_OUTPUT}"` so the output is still logged but not written as a task result

## Context

Declaring a `TEST_OUTPUT` result on the inline `fips-check` taskSpec places the task into the Conforma trusted artifacts chain. Because this is an inline task (not a trusted bundle), it causes a `trusted_task.trusted` policy violation during the Enterprise Contract check. Removing the result avoids the violation while preserving the FIPS check behavior and its pass/fail exit-code logic.

## Test plan

- [ ] Trigger a multi-arch build on `rhoai-3.5-ea.1` and verify the `fips-check` task still runs and logs its output
- [ ] Verify the Enterprise Contract / Conforma check no longer reports a `trusted_task.trusted` violation for `fips-check`
- [ ] Confirm that pipeline-level results (`IMAGE_URL`, `IMAGE_DIGEST`, etc.) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)