### PR TITLE
fix: remove TEST_OUTPUT from fips-check to resolve Conforma trust violation (rhoai-2.25)

### DIFF
--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -692,9 +692,6 @@ spec:
       - name: blocking
         type: string
         default: "true"
-      results:
-      - name: TEST_OUTPUT
-        description: FIPS check-payload test output
       steps:
       - name: prepare-image-list
         image: quay.io/konflux-ci/konflux-test:v1.4.53@sha256:724ecf16a1fc9b51a1b20c91c5125556c53d471d0d8db1648d2404e4715f204e
@@ -737,7 +734,7 @@ spec:
         - name: BLOCKING
           value: $(params.blocking)
         script: |
-          printf '%s' "${TEST_OUTPUT}" > $(results.TEST_OUTPUT.path)
+          echo "${TEST_OUTPUT}"
           if echo "${TEST_OUTPUT}" | grep -qE '"result":"(FAILURE|ERROR)"'; then
             if [ "${BLOCKING}" = "true" ]; then
               echo "FIPS check failed and blocking is enabled"


### PR DESCRIPTION
## Summary

- Remove the `results` block (`TEST_OUTPUT`) from the inline `fips-check` taskSpec in `pipelines/multi-arch-container-build.yaml`
- Replace `printf '%s' "${TEST_OUTPUT}" > $(results.TEST_OUTPUT.path)` with `echo "${TEST_OUTPUT}"` in the evaluate-result step so the output is still logged but no longer written to a Tekton result

## Context

Producing a `TEST_OUTPUT` result in the inline `fips-check` taskSpec places the task in the Conforma trusted artifacts chain. Because the task is defined inline (not via a trusted task bundle), this causes a `trusted_task.trusted` Enterprise Contract violation. Removing the result avoids the violation while preserving the existing FIPS check behavior and blocking logic.

## Test plan

- [ ] Trigger a multi-arch build on `rhoai-2.25` and verify the fips-check task still runs successfully
- [ ] Confirm the Conforma / Enterprise Contract `trusted_task.trusted` violation no longer occurs
- [ ] Verify that FIPS check failures still cause the pipeline to fail when `fips-check-blocking` is `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)