### PR TITLE
Forward Slack thread_id to smoke trigger for RHOAI nightlies

### DIFF
--- a/pipelines/fbc-fragment-build.yaml
+++ b/pipelines/fbc-fragment-build.yaml
@@ -650,22 +650,6 @@ spec:
       values:
       - "true"
   - name: share-fbc-details
-    params:
-    - name: message
-      value: "$(tasks.prepare-success-slack-message.results.slack-message-sucess-text)"
-    - name: secret-name
-      value: rhoai-konflux-secret
-    - name: key-name
-      value: slack-webhook
-    taskRef:
-      params:
-      - name: name
-        value: slack-webhook-notification
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:3eff579c511d6c5e846175920e8f184a87337e142bbc4c30107e76bda4a325cb
-      - name: kind
-        value: task
-      resolver: bundles
     when:
     - input: $(tasks.status)
       operator: in
@@ -676,6 +660,57 @@ spec:
       operator: notin
       values:
       - "true"
+    taskSpec:
+      steps:
+      - name: post-slack-and-trigger-smoke
+        image: quay.io/centos/centos:stream9
+        env:
+        - name: SLACK_MESSAGE
+          value: "$(tasks.prepare-success-slack-message.results.slack-message-sucess-text)"
+        - name: SLACK_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: rhoai-konflux-secret
+              key: slack-token
+        - name: SLACK_CHANNEL
+          valueFrom:
+            secretKeyRef:
+              name: rhoai-konflux-secret
+              key: slack-notification-channel
+        - name: BUILD_TYPE
+          value: "$(params.build-type)"
+        - name: TARGET_BRANCH
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['build.appstudio.redhat.com/target_branch']
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: rhods-ci
+              key: secret
+        script: |
+          #!/bin/bash
+          set -e
+
+          # Post to Slack via chat.postMessage (returns thread_ts, unlike webhooks)
+          RESPONSE=$(curl -s -X POST "https://slack.com/api/chat.postMessage" \
+            -H "Authorization: Bearer $SLACK_TOKEN" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            -d '{"channel": "'"$SLACK_CHANNEL"'", "text": "'"${SLACK_MESSAGE//\"/\\\"}"'", "unfurl_links": false}')
+
+          THREAD_TS=$(echo "$RESPONSE" | grep -oP '"ts"\s*:\s*"\K[0-9]+\.[0-9]+')
+          CHANNEL_ID=$(echo "$RESPONSE" | grep -oP '"channel"\s*:\s*"\K[^"]+')
+          echo "Slack posted (thread_ts=$THREAD_TS)"
+
+          [[ "$BUILD_TYPE" != "nightly" ]] && exit 0
+
+          # Trigger smoke tests with thread_id so Jenkins replies in the same Slack thread
+          curl -X POST "https://api.github.com/repos/red-hat-data-services/rhods-devops-infra/actions/workflows/smoke-trigger.yaml/dispatches" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{ "ref": "main", "inputs": { "target_branch": "'"$TARGET_BRANCH"'", "thread_id": "'"$THREAD_TS"'", "channel_id": "'"$CHANNEL_ID"'" } }'
+          echo "Smoke trigger dispatched with thread_id=$THREAD_TS, channel_id=$CHANNEL_ID"
   - name: trigger-conforma
     when:
     - input: $(params.build-type)
@@ -691,8 +726,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.annotations['build.appstudio.redhat.com/target_branch']
-        - name: WORKFLOW_URL
-          value: "$(params.workflow_url)"
         - name: GITHUB_TOKEN
           valueFrom:
             secretKeyRef:
@@ -714,44 +747,6 @@ spec:
           -H "Authorization: Bearer $GITHUB_TOKEN" \
           -H "Content-Type: application/json" \
           -d '{ "ref": "main", "inputs": { "version": "'"$TARGET_BRANCH"'" , "type": "nightly" } }'
-  - name: trigger-smoke
-    when:
-    - input: $(params.build-type)
-      operator: in
-      values:
-      - "nightly"
-    taskSpec:
-      steps:
-      - name: trigger-workflow
-        image: quay.io/centos/centos:stream9
-        env:
-        - name: TARGET_BRANCH
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.annotations['build.appstudio.redhat.com/target_branch']
-        - name: SMOKE_URL
-          value: "$(params.smoke_url)"
-        - name: GITHUB_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: rhods-ci
-              key: secret
-        script: |
-          #!/bin/bash
-          set -e
-
-          OWNER="red-hat-data-services"
-          REPO="rhods-devops-infra"
-          WORKFLOW_FILE="smoke-trigger.yaml"
-
-          echo "Target branch is: '$TARGET_BRANCH'"
-          echo "Triggering Conforma workflow for branch: $TARGET_BRANCH"
-
-          curl -X POST "https://api.github.com/repos/$OWNER/$REPO/actions/workflows/$WORKFLOW_FILE/dispatches" \
-          -H "Accept: application/vnd.github.v3+json" \
-          -H "Authorization: Bearer $GITHUB_TOKEN" \
-          -H "Content-Type: application/json" \
-          -d '{ "ref": "main", "inputs": { "target_branch": "'"$TARGET_BRANCH"'" } }'
   - name: trigger-disconnected-installer-helper
     when:
     - input: $(params.build-type)


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-50499

## Summary

- Replace `share-fbc-details` webhook with `chat.postMessage` API to capture `thread_ts` from the Slack response
- Absorb `trigger-smoke` into `share-fbc-details` so the smoke dispatch receives `thread_id` and `channel_id`, enabling Jenkins to reply in the same Slack thread
- Keep `trigger-conforma` as a separate `finally` task (unchanged logic, just swapped position with the removed `trigger-smoke`)

## Prerequisites

Two secrets/keys need to be provisioned in the RHOAI Konflux namespace before merging:

- **Secret** `rhoai-devops-bot-slack-token` with key `SLACK_TOKEN` — Slack Bot OAuth token (same bot used by ODH nightlies)
- **Key** `slack-notification-channel` in existing `rhoai-konflux-secret` — channel ID for RHOAI notifications

## Context

Related to [odh-konflux-central#296](https://github.com/opendatahub-io/odh-konflux-central/pull/296) which added thread forwarding for ODH nightlies. This PR applies the same pattern to RHOAI nightlies in `fbc-fragment-build.yaml`.

The core issue: `share-fbc-details` and `trigger-smoke` were both `finally` tasks (parallel), so `trigger-smoke` could never read a `thread_ts` from `share-fbc-details`. Combining them into one task makes the flow sequential: post Slack → capture thread_ts → dispatch smoke with it.