### PR TITLE
Enable odh-cli push pipeline for ppc64le

### DIFF
--- a/pipelineruns/odh-cli/.tekton/odh-cli-v3-3-push.yaml
+++ b/pipelineruns/odh-cli/.tekton/odh-cli-v3-3-push.yaml
@@ -55,6 +55,7 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+    - linux/ppc64le
   timeouts:
     pipeline: 4h
     tasks: 2h


### PR DESCRIPTION
Updating push pipeline for odh-cli image to add linux/ppc64le platform.