### PR TITLE
Enable odh-cli push pipeline for s390x

### DIFF
--- a/pipelineruns/odh-cli/.tekton/odh-cli-pull-request.yaml
+++ b/pipelineruns/odh-cli/.tekton/odh-cli-pull-request.yaml
@@ -74,6 +74,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/s390x
     - linux-m2xlarge/arm64
   - name: image-expires-after
     value: 5d


### PR DESCRIPTION
##Summary
- Add `linux/s390x` to `build-platforms` for `odh-cli` on `rhoai-3.3` so the multi-arch manifest includes s390x.

## Why
- Fixes s390x pulls failing with: no image found in manifest list for architecture "s390x".