### PR TITLE
Re-enable FIPS checks after 2.25.6 release (rhoai-2.25)

### DIFF
--- a/pipelines/fbc-fragment-build.yaml
+++ b/pipelines/fbc-fragment-build.yaml
@@ -31,7 +31,7 @@ spec:
     description: Skip checks against built image
     name: skip-checks
     type: string
-  - default: "true"
+  - default: "false"
     description: Skip FIPS check
     name: skip-fips
     type: string
@@ -381,6 +381,11 @@ spec:
         value: task
       resolver: bundles
     when:
+    - input: $(params.build-type)
+      operator: in
+      values:
+      - 'stage'
+      - 'nightly'
     - input: $(params.skip-fips)
       operator: in
       values:

--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -118,7 +118,7 @@ spec:
     name: disable-slack-notifications
     type: string
   - name: fips-check-blocking
-    default: "false"
+    default: "true"
     type: string
     description: When true, a FIPS check-payload failure will fail the pipeline
   results:


### PR DESCRIPTION
## Summary
Re-enable FIPS checks that were temporarily disabled for the urgent 2.25.6 shipment.

Reverts the following PRs:
- #2007 — Skipped FIPS check for RC/stage FBC builds
- #2009 — Skipped FIPS check for nightly FBC builds (removed `build-type` when condition)
- #2010 — Set `skip-fips` default to `"true"` in FBC pipeline
- #2011 — Set `skip-checks` to `"true"` and `fips-check-blocking` to `"false"` in multi-arch pipeline
- #2014 — Already reverted `skip-checks` back to `"false"` (no further change needed)

### Changes
- **`fbc-fragment-build.yaml`**: `skip-fips` default `"true"` → `"false"`
- **`fbc-fragment-build.yaml`**: Restored `build-type` when condition (`stage`, `nightly`) on `fbc-fips-check-oci-ta` task
- **`multi-arch-container-build.yaml`**: `fips-check-blocking` default `"false"` → `"true"`

## Test plan
- [ ] Verify RC/stage FBC pipeline runs execute `fbc-fips-check-oci-ta`
- [ ] Verify nightly FBC pipeline runs execute `fbc-fips-check-oci-ta`
- [ ] Verify multi-arch pipeline runs have FIPS check-payload as blocking