### PR TITLE
fix: update push-dockerfile-oci-ta 0.2 → 0.3 (expired task bundle)

### DIFF
--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -609,7 +609,7 @@ spec:
       - name: name
         value: push-dockerfile-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:e2fe6ce7b32629632aec979bf3ecfb3ee1f7a67bda7b5fc7e34bbb23214bb4ff
+        value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:7855471abfe87de080b914f2f3ca27c59e64f6448a7c2435e51435b764494c71
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
## Summary

- Updates `task-push-dockerfile-oci-ta` from expired version `0.2` to current `0.3`
- Digest: `sha256:e2fe6ce7...` → `sha256:7855471abfe87de080b914f2f3ca27c59e64f6448a7c2435e51435b764494c71`
- Resolves `tasks.unsupported` conforma violations across 8 RHOAI 3.4 components

## Context

The `push-dockerfile-oci-ta:0.2` Tekton task bundle has expired from the Konflux trusted task list. This causes `tasks.unsupported` conforma policy violations on every component that uses the `multi-arch-container-build` pipeline.

**Affected components** (8 total, 80+ violations):
| Component | Jira |
|-----------|------|
| odh-trustyai-service-operator-v3-4 | RHOAIENG-60510 |
| odh-ta-lmes-driver-v3-4 | RHOAIENG-60511 |
| odh-mod-arch-eval-hub-v3-4 | RHOAIENG-60512 |
| odh-th06-cuda130-torch291-py312-v3-4 | RHOAIENG-60513 |
| odh-workbench-jupyter-tensorflow-cuda-py312-v3-4 | RHOAIENG-60514 |
| odh-workbench-jupyter-pytorch-cuda-py312-v3-4 | RHOAIENG-60515 |
| odh-training-rocm64-torch29-py312-v3-4 | RHOAIENG-60516 |
| odh-pipeline-runtime-pytorch-cuda-py312-v3-4 | RHOAIENG-60517 |

## What changed

Single line change in `pipelines/multi-arch-container-build.yaml` (line 612):
```
- quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:e2fe6ce7...
+ quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:7855471a...
```

All other task bundles (`buildah-remote-oci-ta:0.9`, `apply-tags:0.3`, etc.) were verified to already have the latest digests — no changes needed.

## After merge

Components need to be rebuilt to pick up the updated pipeline. Once rebuilt, the `tasks.unsupported` violations will clear on the next conforma run.

---

*Changes identified and PR authored with AI assistance (Claude, Anthropic) by @pablofelix*