### PR TITLE
Add pull-tekton workflow for pulling .tekton/ from component repos

### DIFF
--- a/.github/workflows/pull-tekton.yml
+++ b/.github/workflows/pull-tekton.yml
@@ -1,0 +1,120 @@
+name: "Pull Tekton (creates PR, does not push directly)"
+
+run-name: "Pull .tekton/ from ${{ inputs.repository }} @ ${{ inputs.ref || github.ref_name }} (PR)"
+
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        type: choice
+        description: Select repository to pull .tekton/ from
+        options:
+          - NeMo-Guardrails
+          - ai-gateway-payload-processing
+          - argo-workflows
+          - caikit-nlp
+          - caikit-tgis-serving
+          - codeflare-operator
+          - data-science-pipelines
+          - data-science-pipelines-operator
+          - distributed-workloads
+          - eval-hub
+          - feast
+          - fms-guardrails-orchestrator
+          - guardrails-detectors
+          - ilab-on-ocp
+          - kserve
+          - kserve-autogluon-server
+          - kube-auth-proxy
+          - kube-rbac-proxy
+          - kubeflow
+          - kuberay
+          - kueue
+          - llama-stack-k8s-operator
+          - llama-stack-provider-trustyai-garak
+          - llm-d-inference-scheduler
+          - llm-d-kv-cache
+          - lm-evaluation-harness
+          - maas-billing
+          - ml-metadata
+          - mlflow
+          - model-metadata-collection
+          - model-registry
+          - model-registry-operator
+          - modelmesh
+          - modelmesh-runtime-adapter
+          - modelmesh-serving
+          - must-gather
+          - notebooks
+          - odh-cli
+          - odh-dashboard
+          - odh-model-controller
+          - pipelines-components
+          - rest-proxy
+          - rhods-operator
+          - training-operator
+          - trustyai-explainability
+          - trustyai-service-operator
+          - vllm
+          - vllm-cpu
+          - vllm-gaudi
+          - vllm-orchestrator-gateway
+          - vllm-rocm
+          - workload-variant-autoscaler
+      ref:
+        type: string
+        description: "Branch, tag, or commit SHA to pull .tekton/ from (defaults to current branch)"
+        required: false
+
+env:
+  GITHUB_ORG: "red-hat-data-services"
+
+jobs:
+  pull-tekton:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Get GitHub App User ID
+        id: get-user-id
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git
+        env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          APP_USER_ID: ${{ steps.get-user-id.outputs.user-id }}
+        run: |
+          git config --global user.name "${APP_SLUG}[bot]"
+          git config --global user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+
+      - name: Checkout ${{ github.ref_name }}
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref_name }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Checkout main (for script)
+        uses: actions/checkout@v3
+        with:
+          ref: main
+          path: main
+
+      - name: Pull .tekton/ and create PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          KONFLUX_ROOT: ${{ github.workspace }}
+          REPOSITORY: ${{ inputs.repository }}
+          REF: ${{ inputs.ref || github.ref_name }}
+          BASE_BRANCH: ${{ github.ref_name }}
+          CI_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          main/script/pull-tekton.sh "${GITHUB_ORG}/${REPOSITORY}" "${REF}"
+          main/script/pull-tekton-pr.sh

--- a/.github/workflows/update-repository-list.yml
+++ b/.github/workflows/update-repository-list.yml
@@ -14,6 +14,7 @@ permissions: write-all
 
 env:
   WORKFLOW_FILE: ".github/workflows/sync-pipelineruns.yml"
+  PULL_TEKTON_FILE: ".github/workflows/pull-tekton.yml"
   PIPELINERUNS_DIR: "pipelineruns"
 
 jobs:
@@ -58,6 +59,7 @@ jobs:
       - name: Update repository list
         run: |
           python script/update-sync-pipelinerun-workflow-repository-list.py --workflow-file ${{ github.ref_name }}/${{ env.WORKFLOW_FILE }} --pipelinerun-dir ${{ github.ref_name }}/${{ env.PIPELINERUNS_DIR }}
+          python script/update-sync-pipelinerun-workflow-repository-list.py --workflow-file ${{ github.ref_name }}/${{ env.PULL_TEKTON_FILE }} --pipelinerun-dir ${{ github.ref_name }}/${{ env.PIPELINERUNS_DIR }} --no-all
   
 
       - name: Commit Changes
@@ -69,7 +71,7 @@ jobs:
 
           set -x
           git status
-          git add ${{ env.WORKFLOW_FILE }}
+          git add ${{ env.WORKFLOW_FILE }} ${{ env.PULL_TEKTON_FILE }}
           git diff --staged
           set +x
 

--- a/docs/pull-tekton.md
+++ b/docs/pull-tekton.md
@@ -1,0 +1,103 @@
+# Pull Tekton
+
+Pull `.tekton/` pipeline definitions from a component repository back
+into konflux-central. This is the reverse of the `sync-pipelineruns`
+workflow, which pushes `.tekton/` from konflux-central out to component
+repos.
+
+Only files already tracked in `pipelineruns/<REPO>/.tekton/` are
+updated — new files in the remote `.tekton/` are ignored.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `script/pull-tekton.sh` | Fetches `.tekton/` from a remote repo and updates local files |
+| `script/pull-tekton-pr.sh` | CI helper — branches, commits, and opens a PR |
+| `.github/workflows/pull-tekton.yml` | GitHub Actions workflow wrapping both scripts |
+| `docs/pull-tekton.md` | This documentation |
+
+## Local Usage
+
+```bash
+# Pull .tekton/ from odh-dashboard at the rhoai-3.4 branch
+./script/pull-tekton.sh odh-dashboard rhoai-3.4
+
+# Explicit org
+./script/pull-tekton.sh opendatahub-io/odh-dashboard main
+
+# Pull from a specific commit SHA
+./script/pull-tekton.sh odh-dashboard abc123def
+```
+
+The script prints which files were updated or skipped and suggests a
+`git diff` command to review the changes. After reviewing, commit
+manually as usual.
+
+### Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `[ORG/]REPO` | Yes | GitHub repo name. If no org is specified, defaults to `red-hat-data-services`. |
+| `REF` | Yes | Branch, tag, or commit SHA to pull from. |
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `KONFLUX_ROOT` | Parent of script directory | Override the root directory for locating `pipelineruns/`. Used by CI when the script is checked out in a different path than the working repo. |
+
+## GitHub Actions Workflow
+
+The `pull-tekton.yml` workflow provides the same functionality via
+GitHub's UI with automatic PR creation.
+
+### Trigger
+
+`workflow_dispatch` only — select the release branch to run on, pick a
+repository, and optionally specify a ref.
+
+### Inputs
+
+| Input | Type | Required | Description |
+|-------|------|----------|-------------|
+| `repository` | choice | Yes | Component repository to pull from. Options are kept in sync by `update-repository-list.yml`. |
+| `ref` | string | No | Branch, tag, or commit SHA. Defaults to the branch the workflow is dispatched on. |
+
+### What It Does
+
+1. Checks out the selected release branch
+2. Checks out `main` to get the latest scripts
+3. Runs `pull-tekton.sh` to fetch and update `.tekton/` files
+4. Runs `pull-tekton-pr.sh` to create a PR against the release branch
+
+If no files changed, the workflow exits cleanly without creating a PR.
+
+### Repository List Sync
+
+The `repository` choice list is automatically updated by the
+`update-repository-list.yml` workflow whenever `pipelineruns/` changes.
+It invokes `script/update-sync-pipelinerun-workflow-repository-list.py`
+with `--no-all` (since pull-tekton operates on a single repo).
+
+## CI-Agnostic Design
+
+The workflow YAML is a thin wrapper — all logic lives in the shell
+scripts. GitHub Actions `${{ }}` expressions are confined to `env:`
+mappings; `run:` blocks use only shell variables. To port to another CI
+system:
+
+1. Replicate the auth and checkout steps for your platform
+2. Set the environment variables listed below
+3. Call the two scripts in sequence
+
+### Environment Variables for `pull-tekton-pr.sh`
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `REPOSITORY` | Yes | Repo name (e.g. `odh-dashboard`) |
+| `REF` | Yes | Ref that was pulled from |
+| `BASE_BRANCH` | Yes | Branch to open the PR against |
+| `GITHUB_ORG` | No | Org name (default: `red-hat-data-services`) |
+| `CI_JOB_URL` | No | Link to the CI run, included in the PR body |
+| `GH_TOKEN` | Yes | GitHub token for `gh pr create` |

--- a/script/pull-tekton-pr.sh
+++ b/script/pull-tekton-pr.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# CI helper — creates a branch, commits .tekton/ changes, and opens a PR.
+# Intended to be called after pull-tekton.sh. Requires env vars:
+#   REPOSITORY    — repo name (e.g. odh-dashboard)
+#   REF           — ref that was pulled from
+#   BASE_BRANCH   — branch to PR against
+#   GITHUB_ORG    — org name (default: red-hat-data-services)
+#   CI_JOB_URL    — link to CI run (optional)
+#
+# For local use, just run pull-tekton.sh and commit manually.
+
+: "${REPOSITORY:?REPOSITORY is required}"
+: "${REF:?REF is required}"
+: "${BASE_BRANCH:?BASE_BRANCH is required}"
+: "${GITHUB_ORG:=red-hat-data-services}"
+: "${CI_JOB_URL:=}"
+
+BRANCH="pull-tekton/${REPOSITORY}-$(date +%s)"
+git checkout -b "$BRANCH"
+git add "pipelineruns/${REPOSITORY}/.tekton"
+
+if git diff --staged --quiet; then
+  echo "No changes detected — .tekton/ is already up to date."
+  exit 0
+fi
+
+git commit -m "pull .tekton/ from ${REPOSITORY} @ ${REF}"
+git push origin "$BRANCH"
+
+BODY="Pulled \`.tekton/\` from \`${GITHUB_ORG}/${REPOSITORY}\` at ref \`${REF}\` into \`pipelineruns/${REPOSITORY}/.tekton/\`.
+
+Only files already tracked in this repo were updated."
+
+if [[ -n "$CI_JOB_URL" ]]; then
+  BODY="${BODY}
+
+Triggered by: ${CI_JOB_URL}"
+fi
+
+gh pr create \
+  --base "$BASE_BRANCH" \
+  --head "$BRANCH" \
+  --title "Pull .tekton/ from ${REPOSITORY} @ ${REF}" \
+  --body "$BODY"

--- a/script/pull-tekton.sh
+++ b/script/pull-tekton.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 [ORG/]REPO REF"
+  echo
+  echo "Pull .tekton/ from a remote repo into pipelineruns/<REPO>/.tekton/"
+  echo
+  echo "Arguments:"
+  echo "  [ORG/]REPO  GitHub repo, optionally with org (default: red-hat-data-services)"
+  echo "  REF         Branch, tag, or commit SHA to pull from"
+  exit 1
+}
+
+[[ $# -eq 2 ]] || usage
+
+ORG_REPO="$1"
+REF="$2"
+
+if [[ "$ORG_REPO" != */* ]]; then
+  ORG_REPO="red-hat-data-services/$ORG_REPO"
+fi
+REPO="${ORG_REPO#*/}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="${KONFLUX_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+TARGET_DIR="$ROOT_DIR/pipelineruns/$REPO/.tekton"
+
+if [[ ! -d "$TARGET_DIR" ]]; then
+  echo "Error: $TARGET_DIR does not exist" >&2
+  exit 1
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "Fetching .tekton/ from $ORG_REPO @ $REF ..."
+git init "$TMPDIR/repo" -q
+git -C "$TMPDIR/repo" remote add origin "https://github.com/$ORG_REPO.git"
+git -C "$TMPDIR/repo" sparse-checkout set .tekton
+git -C "$TMPDIR/repo" fetch --depth 1 origin "$REF" 2>&1
+git -C "$TMPDIR/repo" checkout FETCH_HEAD -q
+
+if [[ ! -d "$TMPDIR/repo/.tekton" ]]; then
+  echo "Error: .tekton/ not found in $ORG_REPO @ $REF" >&2
+  exit 1
+fi
+
+UPDATED=0
+for f in "$TARGET_DIR"/*; do
+  BASENAME="$(basename "$f")"
+  if [[ -f "$TMPDIR/repo/.tekton/$BASENAME" ]]; then
+    cp "$TMPDIR/repo/.tekton/$BASENAME" "$TARGET_DIR/$BASENAME"
+    echo "  updated: $BASENAME"
+    UPDATED=$((UPDATED + 1))
+  else
+    echo "  skipped: $BASENAME (not in remote .tekton/)"
+  fi
+done
+
+echo "Updated $UPDATED file(s) in $TARGET_DIR from $ORG_REPO @ $REF"
+echo
+echo "Review the changes with: git diff pipelineruns/$REPO/.tekton"

--- a/script/update-sync-pipelinerun-workflow-repository-list.py
+++ b/script/update-sync-pipelinerun-workflow-repository-list.py
@@ -25,6 +25,12 @@ def main():
         default=Path("pipelineruns"),
         help="Directory containing pipelinerun folders"
     )
+    parser.add_argument(
+        "--no-all",
+        action="store_true",
+        default=False,
+        help="Do not prepend 'all' to the options list"
+    )
 
     args = parser.parse_args()
     yaml_path = args.workflow_file
@@ -42,7 +48,8 @@ def main():
     options = sorted([
         f.name for f in pipelinerun_dir.iterdir() if f.is_dir()
     ])
-    options.insert(0, "all")  # Prepend 'all'
+    if not args.no_all:
+        options.insert(0, "all")
 
     # Load YAML with formatting
     yaml = YAML()


### PR DESCRIPTION
## Summary

- Adds a `workflow_dispatch` workflow that pulls `.tekton/` from a component repo at a given ref into `pipelineruns/<REPO>/.tekton/`, creating a PR with the changes (does not push directly to the release branch)
- Extracts all logic into shell scripts (`pull-tekton.sh`, `pull-tekton-pr.sh`) so the workflow YAML is CI-agnostic — `run:` blocks contain only shell, no `${{ }}` expressions
- Updates `update-repository-list.yml` to keep the new workflow's repository options in sync (with `--no-all` flag added to the python script)

### Cherry-pick note

Commit `16ed7eb4` (workflow files only) should be cherry-picked to release branches. The scripts and docs in the first commit only need to be on `main`.

## Test plan

- [ ] Run `./script/pull-tekton.sh odh-dashboard rhoai-3.4` locally and verify it updates only existing files
- [ ] Trigger the Pull Tekton workflow via `workflow_dispatch` on a release branch and verify it creates a PR
- [ ] Verify `update-repository-list.yml` updates both `sync-pipelineruns.yml` and `pull-tekton.yml` repo lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)