### PR TITLE
fix: resolve false Dockerfile-not-found failures in validator

### DIFF
--- a/.github/workflows/validate-pipelineruns.yml
+++ b/.github/workflows/validate-pipelineruns.yml
@@ -48,7 +48,7 @@ jobs:
           else
             target_branch="${{ github.base_ref }}"
           fi
-          if [[ "$target_branch" =~ ^rhoai-[0-9]+\.[0-9]+$ ]]; then
+          if [[ "$target_branch" =~ ^rhoai-[0-9]+\.[0-9]+([-\.].+)?$ ]]; then
             echo "branch=$target_branch" >> "$GITHUB_OUTPUT"
           else
             echo "branch=" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/validate-pipelineruns.yml
+++ b/.github/workflows/validate-pipelineruns.yml
@@ -54,6 +54,12 @@ jobs:
             echo "branch=" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Checkout validator scripts from main
+        if: github.base_ref != 'main' && github.base_ref != ''
+        run: |
+          git fetch origin main --depth=1
+          git checkout origin/main -- script/test_validate_pipelineruns.py script/conftest.py
+
       - name: Validate PipelineRuns
         id: validate
         env:

--- a/.github/workflows/validate-release-branches.yml
+++ b/.github/workflows/validate-release-branches.yml
@@ -1,0 +1,141 @@
+# Cross-branch validation: when validator scripts change on main, run them
+# against release branch pipelineruns to catch regressions before merge.
+# Update the release-branch list when branches are added or retired.
+# This workflow only exists on main.
+name: Validate Release Branches
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - 'script/test_validate_pipelineruns.py'
+      - 'script/conftest.py'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        release-branch: ['rhoai-3.4', 'rhoai-3.5-ea.1']
+    steps:
+      - name: Checkout release branch pipelineruns
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.release-branch }}
+
+      - name: Checkout validator scripts from PR
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pr-scripts
+          sparse-checkout: |
+            script/test_validate_pipelineruns.py
+            script/conftest.py
+
+      - name: Overlay PR validator scripts
+        run: |
+          cp pr-scripts/script/test_validate_pipelineruns.py script/test_validate_pipelineruns.py
+          cp pr-scripts/script/conftest.py script/conftest.py
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Generate GitHub App token
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Validate PipelineRuns
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          uv run --with pyyaml --with pytest pytest script/test_validate_pipelineruns.py \
+            --pipelinerun-dir pipelineruns/ \
+            -v \
+            --branch ${{ matrix.release-branch }} \
+            --validation-comment-file validation-comment.md
+
+      - name: Save PR number and branch
+        if: always()
+        run: |
+          echo "${{ github.event.pull_request.number }}" > pr-number.txt
+          echo "${{ matrix.release-branch }}" > release-branch.txt
+
+      - name: Upload validation comment artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-validation-${{ matrix.release-branch }}
+          path: |
+            validation-comment.md
+            pr-number.txt
+            release-branch.txt
+          if-no-files-found: ignore
+
+  post-comment:
+    needs: validate
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download all release validation artifacts
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-validation-*
+          merge-multiple: false
+
+      - name: Combine and post PR comment
+        if: steps.download.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          COMBINED="release-validation-comment.md"
+          PR_NUMBER=""
+          FOUND=false
+
+          echo "## Release Branch Validation" > "$COMBINED"
+          echo "" >> "$COMBINED"
+
+          for dir in release-validation-*/; do
+            [[ -d "$dir" ]] || continue
+            [[ -f "${dir}validation-comment.md" ]] || continue
+            FOUND=true
+            BRANCH=$(cat "${dir}release-branch.txt" 2>/dev/null || echo "unknown")
+            PR_NUMBER=$(cat "${dir}pr-number.txt" 2>/dev/null || echo "$PR_NUMBER")
+            echo "### \`${BRANCH}\`" >> "$COMBINED"
+            echo "" >> "$COMBINED"
+            # Strip top-level header and existing marker from individual comments
+            sed -e '1{/^## /d;}' -e '/<!-- pipelinerun-validation-comment -->/d' \
+              "${dir}validation-comment.md" >> "$COMBINED"
+            echo "" >> "$COMBINED"
+          done
+
+          if [[ "$FOUND" == "false" ]]; then
+            echo "No release branch validation results found."
+            exit 0
+          fi
+
+          echo "<!-- release-branch-validation-comment -->" >> "$COMBINED"
+
+          MARKER="<!-- release-branch-validation-comment -->"
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --paginate --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" | head -1)
+
+          if [[ -n "$COMMENT_ID" ]]; then
+            gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
+              --method PATCH \
+              --field body=@"$COMBINED"
+          else
+            gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+              --field body=@"$COMBINED"
+          fi

--- a/docs/validate-pipelineruns.md
+++ b/docs/validate-pipelineruns.md
@@ -83,8 +83,15 @@ Validates push/scheduled PipelineRuns target the correct branch and repository:
   versions like `v3-4-ea-2` are rejected because `v3-4` is not immediately
   followed by `-on-push`/`-on-schedule`.
 
-**Note:** Branch and version checks only run when `--branch` is passed.
-On `main`, only the repo annotation and `?rev={{revision}}` are validated.
+When `--branch` is not set (e.g., PR targets `main`), the check extracts
+the target branch from the CEL expression. If a push/scheduled PipelineRun
+targets a specific branch but `--branch` is not set, the test fails —
+push/scheduled PipelineRuns should only exist on their target branch, not
+on `main`.
+
+When `--branch` is set, the branch and version name checks run as
+described above. The repo annotation and `?rev={{revision}}` checks
+always run.
 
 ### Check 5: CEL Self-Reference (`test_cel_self_reference`)
 
@@ -153,8 +160,11 @@ Path resolution order:
 
 When `path-context` is not specified or is `.`, only option 2 is checked.
 
-For release-branch PipelineRuns (`--branch` is set), the test checks
-both the default branch and the specified branch.
+The test extracts the target branch from the PipelineRun's
+`on-cel-expression` annotation (parsing `target_branch == "<branch>"`).
+When found, the Dockerfile is checked on that branch first, then the
+default branch. The `--branch` CLI argument is also checked if it
+differs from the CEL-extracted branch.
 
 When the Dockerfile is not found, the error message lists available
 Dockerfiles in the target directory to help the user pick the correct one.
@@ -207,9 +217,9 @@ public repos (no token for private repo access).
 
 ### Branch Detection
 
-For PRs targeting release branches (e.g., `rhoai-3.4`), the workflow
-passes `--branch <target>` to enable branch-specific checks (checks 4
-and 5). PRs targeting `main` do not pass `--branch`.
+For PRs targeting release branches (e.g., `rhoai-3.4`, `rhoai-3.5-ea.1`),
+the workflow passes `--branch <target>` to enable branch-specific checks
+(checks 4 and 5). PRs targeting `main` do not pass `--branch`.
 
 ### PR Comment (Two-Workflow Pattern)
 

--- a/docs/validate-pipelineruns.md
+++ b/docs/validate-pipelineruns.md
@@ -18,6 +18,7 @@ errors before they are merged and synced to component repositories.
 | `script/conftest.py` | Pytest configuration, CLI options, file discovery |
 | `.github/workflows/validate-pipelineruns.yml` | GitHub Actions workflow — runs validation and uploads results as artifact |
 | `.github/workflows/post-validation-comment.yml` | GitHub Actions workflow — posts validation results as a PR comment |
+| `.github/workflows/validate-release-branches.yml` | GitHub Actions workflow (main only) — cross-branch validation when validator scripts change |
 | `docs/validate-pipelineruns.md` | This documentation |
 
 ## PipelineRun Types
@@ -225,6 +226,19 @@ The validator scripts (`script/test_validate_pipelineruns.py` and
 `script/conftest.py`) are always checked out from `main` on release
 branches. This means validator changes only need to be made on `main`
 and automatically apply to all release branches.
+
+### Cross-Branch Validation
+
+When a PR to `main` changes the validator scripts
+(`test_validate_pipelineruns.py` or `conftest.py`), a separate workflow
+(`validate-release-branches.yml`) runs the updated validator against
+pipelineruns from a configurable list of release branches. This catches
+regressions before they are merged and affect release branch PRs. Results
+are posted as a separate PR comment.
+
+The release branch list is maintained in the `matrix.release-branch`
+array in `validate-release-branches.yml`. Update this list when release
+branches are added or retired. This workflow only exists on `main`.
 
 ### PR Comment (Two-Workflow Pattern)
 

--- a/docs/validate-pipelineruns.md
+++ b/docs/validate-pipelineruns.md
@@ -221,6 +221,11 @@ For PRs targeting release branches (e.g., `rhoai-3.4`, `rhoai-3.5-ea.1`),
 the workflow passes `--branch <target>` to enable branch-specific checks
 (checks 4 and 5). PRs targeting `main` do not pass `--branch`.
 
+The validator scripts (`script/test_validate_pipelineruns.py` and
+`script/conftest.py`) are always checked out from `main` on release
+branches. This means validator changes only need to be made on `main`
+and automatically apply to all release branches.
+
 ### PR Comment (Two-Workflow Pattern)
 
 Posting PR comments uses a two-workflow pattern so that it works for

--- a/script/test_validate_pipelineruns.py
+++ b/script/test_validate_pipelineruns.py
@@ -61,6 +61,14 @@ def _is_helm_chart_build(data):
     return False
 
 
+def _extract_target_branch(data):
+    """Extract target branch from the pipelinerun's on-cel-expression annotation."""
+    cel_expr = data.get("metadata", {}).get("annotations", {}).get(
+        "pipelinesascode.tekton.dev/on-cel-expression", "")
+    m = re.search(r'target_branch\s*==\s*"([^"]+)"', cel_expr)
+    return m.group(1) if m else None
+
+
 def _component_dir(filepath):
     """Extract component directory name from file path."""
     parts = Path(filepath).parts
@@ -334,6 +342,15 @@ def test_branch_repo_targeting(pipelinerun_file, branch):
     assert cel_expr, "Push PipelineRun missing on-cel-expression annotation"
 
     # Branch targeting
+    if not branch:
+        cel_branch = _extract_target_branch(data)
+        if cel_branch:
+            pytest.fail(
+                f"Push/scheduled PipelineRun targets branch '{cel_branch}' "
+                f"but --branch is not set"
+            )
+        return
+
     if branch:
         branch_pattern = f'target_branch == "{branch}"'
         if branch_pattern not in cel_expr:
@@ -518,8 +535,11 @@ def test_dockerfile_path(pipelinerun_file, github_token, branch,
     else:
         candidates = [dockerfile_normalized]
 
+    cel_branch = _extract_target_branch(data)
     refs_to_check = [None]  # None = default branch
-    if branch:
+    if cel_branch:
+        refs_to_check.insert(0, cel_branch)
+    if branch and branch != cel_branch:
         refs_to_check.append(branch)
 
     for candidate in candidates:
@@ -538,7 +558,7 @@ def test_dockerfile_path(pipelinerun_file, github_token, branch,
 
     # Not found — build helpful error message
     search_dir = path_context if path_context != "." else "."
-    search_ref = branch if branch else None
+    search_ref = cel_branch or branch or None
     available = _list_dockerfiles(
         repo_full, search_dir, github_token, ref=search_ref
     )
@@ -553,8 +573,13 @@ def test_dockerfile_path(pipelinerun_file, github_token, branch,
     if path_context != ".":
         lines.append(f"  path-context: {path_context}")
     lines.append(f"  dockerfile:    {dockerfile}")
-    if branch:
-        lines.append(f"  branches checked: default, {branch}")
+    checked_branches = ["default"]
+    if cel_branch:
+        checked_branches.append(cel_branch)
+    if branch and branch != cel_branch:
+        checked_branches.append(branch)
+    if len(checked_branches) > 1:
+        lines.append(f"  branches checked: {', '.join(checked_branches)}")
     lines.append("  paths checked:")
     for c in candidates:
         lines.append(f"    - {c}")


### PR DESCRIPTION
## Summary

Fixes [RHOAIENG-60416](https://redhat.atlassian.net/browse/RHOAIENG-60416).

- **`test_dockerfile_path`**: Extract target branch from the pipelinerun's `on-cel-expression` annotation (`target_branch == "..."`) so the Dockerfile is checked on the correct branch, not just the default branch
- **`test_branch_repo_targeting`**: Fail push/scheduled pipelineruns that target a specific release branch when `--branch` is not set (catches misplaced pipelineruns on `main`)
- **Workflow regex**: Widen branch-detection regex to match EA/RC suffixes like `rhoai-3.5-ea.1`
- **Docs**: Updated checks 4 and 8 descriptions to reflect the new behavior

## Test plan

- [ ] Verify validator passes on an `rhoai-*` branch with correctly-placed push pipelineruns
- [ ] Verify validator fails on `main` if a push pipelinerun targeting a release branch is present
- [ ] Verify EA/RC branches (e.g. `rhoai-3.5-ea.1`) are detected by the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)