### PR TITLE
chore: update expiring task bundles and canary build (3.4)

### DIFF
--- a/.tekton/container-build-pull-request.yaml
+++ b/.tekton/container-build-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" 
-      && target_branch.matches("^rhoai-\\d+\\.\\d+$")
+      && target_branch.matches("^rhoai-\\d+\\.\\d+(-ea\\.\\d+)?$")
       && ( "pipelines/container-build.yaml".pathChanged() 
         || ".tekton/container-build-pull-request.yaml".pathChanged() )
   creationTimestamp:

--- a/.tekton/container-build-pull-request.yaml
+++ b/.tekton/container-build-pull-request.yaml
@@ -38,9 +38,9 @@ spec:
   - name: output-image
     value: quay.io/redhat-user-workloads/rhoai-tenant/pull-request-pipelines:konflux-central-{{revision}}
   - name: dockerfile
-    value: ./canary-build/Dockerfile.konflux
+    value: Dockerfile.konflux
   - name: path-context
-    value: .
+    value: ./canary-build
   # - name: prefetch-input
   #   value: |
   #   [{"type": "gomod"}, {"type": "rpm"}]

--- a/.tekton/multi-arch-container-build-pull-request.yaml
+++ b/.tekton/multi-arch-container-build-pull-request.yaml
@@ -38,9 +38,9 @@ spec:
   - name: output-image
     value: quay.io/redhat-user-workloads/rhoai-tenant/pull-request-pipelines:konflux-central-multi-arch-{{revision}}
   - name: dockerfile
-    value: ./canary-build/Dockerfile.konflux
+    value: Dockerfile.konflux
   - name: path-context
-    value: .
+    value: ./canary-build
   - name: build-platforms
     value:
       - linux/amd64

--- a/.tekton/multi-arch-container-build-pull-request.yaml
+++ b/.tekton/multi-arch-container-build-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" 
-      && target_branch.matches("^rhoai-\\d+\\.\\d+$")
+      && target_branch.matches("^rhoai-\\d+\\.\\d+(-ea\\.\\d+)?$")
       && ( "pipelines/multi-arch-container-build.yaml".pathChanged() 
         || ".tekton/multi-arch-container-build-pull-request.yaml".pathChanged() )
   creationTimestamp:

--- a/canary-build/Dockerfile.konflux
+++ b/canary-build/Dockerfile.konflux
@@ -1,1 +1,9 @@
-FROM registry.redhat.io/ubi8/python-312:1@sha256:3d9deabef276ff7a713f0d0f2387463eb96845170b86056fab42acf461baa827
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22 AS builder
+WORKDIR /opt/app-root/src
+COPY go.mod .
+COPY main.go .
+RUN go build -o canary main.go
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+COPY --from=builder /opt/app-root/src/canary /usr/local/bin/canary
+ENTRYPOINT ["canary"]

--- a/canary-build/go.mod
+++ b/canary-build/go.mod
@@ -1,0 +1,3 @@
+module canary
+
+go 1.22

--- a/canary-build/main.go
+++ b/canary-build/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("canary build ok")
+}

--- a/pipelines/container-build.yaml
+++ b/pipelines/container-build.yaml
@@ -499,7 +499,7 @@ spec:
       - name: name
         value: push-dockerfile-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:e2fe6ce7b32629632aec979bf3ecfb3ee1f7a67bda7b5fc7e34bbb23214bb4ff
+        value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:7855471abfe87de080b914f2f3ca27c59e64f6448a7c2435e51435b764494c71
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
## Summary
- Update `push-dockerfile-oci-ta` from 0.2 to 0.3 in `pipelines/container-build.yaml` (the other pipelines already had current versions)
- Replace the canary build Dockerfile with a multi-stage Go build using `ubi9/go-toolset:1.22` and `ubi9/ubi-minimal:9.5`, add `go.mod` and `main.go`
- Update `.tekton/container-build-pull-request.yaml` and `.tekton/multi-arch-container-build-pull-request.yaml` to set `path-context: ./canary-build` and `dockerfile: Dockerfile.konflux`

## Test plan
- [ ] Verify the PR pipelinerun triggers and the canary Go binary builds successfully
- [ ] Confirm no other pipelines need task bundle updates on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)