### PR TITLE
Add Renovate custom manager to auto-update rhoai-init task SHA

### DIFF
--- a/renovate/pipelines-renovate.json5
+++ b/renovate/pipelines-renovate.json5
@@ -3,8 +3,20 @@
   // Adding rhoai-3.2 because one customer has a support exception for it
   "baseBranches": ["main", "rhoai-2.16", "rhoai-2.25", "rhoai-3.3", "rhoai-3.4", "rhoai-3.5-ea.1"],
   "dependencyDashboard": true,
-  // Only manage Tekton task bundle references
-  "enabledManagers": ["tekton"],
+  // Manage Tekton task bundle references + custom git SHA tracking
+  "enabledManagers": ["tekton", "custom.regex"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["pipelines/.*\\.yaml$"],
+      "matchStrings": [
+        "- name: url\\s+value: https://github\\.com/(?<depName>[^.]+)\\.git\\s+- name: revision\\s+value: (?<currentDigest>[a-f0-9]+)"
+      ],
+      "datasource": "git-refs",
+      "packageName": "https://github.com/{{{depName}}}",
+      "currentValue": "main"
+    }
+  ],
   "tekton": {
     "schedule": ["at any time"],
     "fileMatch": ["\\.yaml$", "\\.yml$"],


### PR DESCRIPTION
## Summary
- Adds a `custom.regex` manager to `renovate/pipelines-renovate.json5` that tracks the `rhoai-konflux-tasks` main branch HEAD
- Renovate will now auto-update the git commit SHA used for the `rhoai-init` task resolver in all three pipeline definitions (`container-build.yaml`, `multi-arch-container-build.yaml`, `fbc-fragment-build.yaml`)
- Adds `custom.regex` to `enabledManagers` alongside the existing `tekton` manager

## Test plan
- [ ] Verify Renovate dependency dashboard picks up the new custom manager
- [ ] Confirm Renovate opens a PR when `rhoai-konflux-tasks` main branch advances past the current SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)