### PR TITLE
Rename llama-stack-k8s-operator repo refs to ogx-k8s-operator

### DIFF
--- a/.github/workflows/sync-pipelineruns.yml
+++ b/.github/workflows/sync-pipelineruns.yml
@@ -48,7 +48,7 @@ on:
           - kubeflow
           - kuberay
           - kueue
-          - llama-stack-k8s-operator
+          - ogx-k8s-operator
           - llama-stack-provider-trustyai-garak
           - llm-d-inference-scheduler
           - llm-d-kv-cache

--- a/pipelineruns/ogx-k8s-operator/.tekton/odh-llama-stack-k8s-operator-pull-request.yaml
+++ b/pipelineruns/ogx-k8s-operator/.tekton/odh-llama-stack-k8s-operator-pull-request.yaml
@@ -2,13 +2,13 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/llama-stack-k8s-operator?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/ogx-k8s-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
-    pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-llama-stack-k8s-operator]"
+    pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-ogx-k8s-operator]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/cancel-in-progress: "true"


### PR DESCRIPTION
## Summary
- The GitHub repo `llama-stack-k8s-operator` was renamed to `ogx-k8s-operator`
- Updated the pipelineruns directory name from `llama-stack-k8s-operator` to `ogx-k8s-operator`
- Updated the repo URL annotation and trigger label in the PipelineRun YAML to reference the new repo name
- Updated the sync-pipelineruns workflow dropdown to use `ogx-k8s-operator`
- Component names, image names, and Konflux resource names are intentionally unchanged

## Test plan
- [x] Verify the sync workflow can target `ogx-k8s-operator` via manual dispatch
- [x] Verify PR-triggered builds still work against the renamed repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)