### PR TITLE
Rename llama-stack-k8s-operator repo refs to ogx-k8s-operator

### DIFF
--- a/.github/workflows/sync-pipelineruns.yml
+++ b/.github/workflows/sync-pipelineruns.yml
@@ -38,7 +38,7 @@ on:
           - kubeflow
           - kuberay
           - llama-stack-distribution
-          - llama-stack-k8s-operator
+          - ogx-k8s-operator
           - llama-stack-provider-trustyai-garak
           - llm-d-inference-scheduler
           - lm-evaluation-harness

--- a/pipelineruns/ogx-k8s-operator/.tekton/odh-llama-stack-k8s-operator-v3-3-push.yaml
+++ b/pipelineruns/ogx-k8s-operator/.tekton/odh-llama-stack-k8s-operator-v3-3-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 # konflux build manual retrigger
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/llama-stack-k8s-operator?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/ogx-k8s-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"


### PR DESCRIPTION
## Summary
- The GitHub repo `llama-stack-k8s-operator` was renamed to `ogx-k8s-operator`
- Updated the `pipelineruns/` directory name from `llama-stack-k8s-operator` to `ogx-k8s-operator`
- Updated the `build.appstudio.openshift.io/repo` annotation URL to point to the new repo name
- Updated the sync-pipelineruns workflow dropdown to reference `ogx-k8s-operator`
- Component names, image names, service account names, and Konflux resource names are unchanged

## Test plan
- [ ] Verify the PipelineRun still references the correct component name (`odh-llama-stack-k8s-operator-v3-3`)
- [ ] Verify the repo URL annotation points to `ogx-k8s-operator`
- [ ] Verify the sync workflow lists `ogx-k8s-operator` in the dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)