### PR TITLE
Rename llama-stack-k8s-operator repo refs to ogx-k8s-operator

### DIFF
--- a/.github/workflows/sync-pipelineruns.yml
+++ b/.github/workflows/sync-pipelineruns.yml
@@ -42,7 +42,7 @@ on:
           - kubeflow
           - kuberay
           - llama-stack-distribution
-          - llama-stack-k8s-operator
+          - ogx-k8s-operator
           - llama-stack-provider-trustyai-garak
           - llm-d-inference-scheduler
           - llm-d-kv-cache

--- a/pipelineruns/ogx-k8s-operator/.tekton/odh-llama-stack-k8s-operator-v3-4-push.yaml
+++ b/pipelineruns/ogx-k8s-operator/.tekton/odh-llama-stack-k8s-operator-v3-4-push.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/llama-stack-k8s-operator?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/ogx-k8s-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"


### PR DESCRIPTION
## Summary
- The GitHub repo `llama-stack-k8s-operator` was renamed to `ogx-k8s-operator`
- Updated the `pipelineruns/` directory name from `llama-stack-k8s-operator` to `ogx-k8s-operator`
- Updated the `build.appstudio.openshift.io/repo` annotation URL to point to the new repo name
- Updated the sync workflow dropdown to reference `ogx-k8s-operator`
- Component names, image names, service account names, and resource names are intentionally unchanged

## Test plan
- [x] Verify the PipelineRun YAML still validates correctly
- [x] Confirm the sync workflow picks up the renamed directory for the ogx-k8s-operator repo
- [x] Verify no component name, image name, or service account references were changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)