### PR TITLE
Rename llama-stack-k8s-operator repo refs to ogx-k8s-operator

### DIFF
--- a/.github/workflows/sync-pipelineruns.yml
+++ b/.github/workflows/sync-pipelineruns.yml
@@ -38,7 +38,7 @@ on:
           - kubeflow
           - kuberay
           - llama-stack-distribution
-          - llama-stack-k8s-operator
+          - ogx-k8s-operator
           - llama-stack-provider-trustyai-garak
           - llm-d-inference-scheduler
           - lm-evaluation-harness

--- a/pipelineruns/ogx-k8s-operator/.tekton/odh-llama-stack-k8s-operator-v3-2-push.yaml
+++ b/pipelineruns/ogx-k8s-operator/.tekton/odh-llama-stack-k8s-operator-v3-2-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 # retrigger Konflux builds to fix https://issues.redhat.com/browse/RHOAIENG-31914
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/llama-stack-k8s-operator?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/ogx-k8s-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"


### PR DESCRIPTION
## Summary

- The GitHub repo `llama-stack-k8s-operator` was renamed to `ogx-k8s-operator`. This PR updates directory and URL references to match the new repo name.
- Renamed the `pipelineruns/llama-stack-k8s-operator` directory to `pipelineruns/ogx-k8s-operator`
- Updated the `build.appstudio.openshift.io/repo` annotation URL in the PipelineRun
- Updated the repository dropdown in `.github/workflows/sync-pipelineruns.yml`
- Component names, image names, service account names, and Konflux resource names are intentionally unchanged

## Test plan

- [ ] Verify the PR diff only changes the repo URL and directory name, not component/image/SA names
- [ ] Confirm the sync workflow lists `ogx-k8s-operator` instead of `llama-stack-k8s-operator`

🤖 Generated with [Claude Code](https://claude.com/claude-code)