### PR TITLE
Rename llama-stack-k8s-operator repo refs to ogx-k8s-operator

### DIFF
--- a/.github/workflows/sync-pipelineruns.yml
+++ b/.github/workflows/sync-pipelineruns.yml
@@ -43,7 +43,7 @@ on:
           - kubeflow
           - kuberay
           - llama-stack-distribution
-          - llama-stack-k8s-operator
+          - ogx-k8s-operator
           - llama-stack-provider-trustyai-garak
           - llm-d-inference-scheduler
           - llm-d-kv-cache

--- a/pipelineruns/ogx-k8s-operator/.tekton/odh-llama-stack-k8s-operator-v3-5-ea-1-push.yaml
+++ b/pipelineruns/ogx-k8s-operator/.tekton/odh-llama-stack-k8s-operator-v3-5-ea-1-push.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/llama-stack-k8s-operator?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/ogx-k8s-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"


### PR DESCRIPTION
## Summary

- The GitHub repo `llama-stack-k8s-operator` was renamed to `ogx-k8s-operator`
- Updated the `build.appstudio.openshift.io/repo` annotation URL to point to `ogx-k8s-operator`
- Renamed the `pipelineruns/` directory from `llama-stack-k8s-operator` to `ogx-k8s-operator`
- Updated the repository dropdown in `.github/workflows/sync-pipelineruns.yml`
- Component names, image names, service account names, and resource names are intentionally unchanged

## Test plan

- [ ] Verify the PipelineRun still references the correct repo URL
- [ ] Verify the sync workflow lists `ogx-k8s-operator` in its dropdown
- [ ] Confirm no component names, image names, or service accounts were altered

🤖 Generated with [Claude Code](https://claude.com/claude-code)