### PR TITLE
Rename llama-stack-k8s-operator repo refs to ogx-k8s-operator

### DIFF
--- a/.github/workflows/sync-pipelineruns.yml
+++ b/.github/workflows/sync-pipelineruns.yml
@@ -40,7 +40,7 @@ on:
           - kubeflow
           - kuberay
           - kueue
-          - llama-stack-k8s-operator
+          - ogx-k8s-operator
           - llm-d-inference-scheduler
           - llm-d-routing-sidecar
           - lm-evaluation-harness

--- a/pipelineruns/ogx-k8s-operator/.tekton/odh-llama-stack-k8s-operator-v2-25-push.yaml
+++ b/pipelineruns/ogx-k8s-operator/.tekton/odh-llama-stack-k8s-operator-v2-25-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 # konflux build manual retrigger - 2026-04-30 12:10:12
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/llama-stack-k8s-operator?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/ogx-k8s-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"


### PR DESCRIPTION
## Summary
- The `llama-stack-k8s-operator` GitHub repo was renamed to `ogx-k8s-operator`
- Updated the `pipelineruns/` directory name from `llama-stack-k8s-operator` to `ogx-k8s-operator`
- Updated the `build.appstudio.openshift.io/repo` annotation URL to point to the new repo name
- Updated the sync-pipelineruns workflow dropdown to use the new repo name
- Component names, image names, service account names, and Konflux resource names are intentionally unchanged

## Test plan
- [ ] Verify the PipelineRun triggers correctly from the renamed repo
- [ ] Verify sync-pipelineruns workflow shows `ogx-k8s-operator` in the dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)