### PR TITLE
Enable Renovate for ogx-k8s-operator

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -41,6 +41,7 @@
       targetFilePath: "renovate.json"
     - name: "red-hat-data-services/kube-auth-proxy"
       targetFilePath: ".github/renovate.json5"
+    - name: "red-hat-data-services/ogx-k8s-operator"
 
 - renovate-config: "renovate/custom-renovate-distribution.json"
   sync-repositories:


### PR DESCRIPTION
Adds 'red-hat-data-services/ogx-k8s-operator' to the default Renovate distribution in config.yaml.

## Details

| Field | Value |
|-------|-------|
| Component repo | `https://github.com/red-hat-data-services/ogx-k8s-operator` |
| Renovate entry | `red-hat-data-services/ogx-k8s-operator` |
| Distribution | `renovate/default-renovate-distribution.json` |

**Jira:** https://redhat.atlassian.net/browse/RHOAIENG-60933