### PR TITLE
chore: align helm chart PipelineRun memory limits with rhoai-3.4

### DIFF
--- a/pipelineruns/RHOAI-Build-Config/.tekton/rhai-on-openshift-chart-v3-5-ea-1-push.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/rhai-on-openshift-chart-v3-5-ea-1-push.yaml
@@ -53,7 +53,7 @@ spec:
         requests:
           memory: 0.3Gi
         limits:
-          memory: 0.5Gi
+          memory: 4Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-rhai-on-openshift-chart-v3-5-ea-1
   workspaces:

--- a/pipelineruns/RHOAI-Build-Config/.tekton/rhai-on-openshift-chart-v3-5-ea-1-scheduled.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/rhai-on-openshift-chart-v3-5-ea-1-scheduled.yaml
@@ -54,7 +54,7 @@ spec:
         requests:
           memory: 0.3Gi
         limits:
-          memory: 0.5Gi
+          memory: 4Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-rhai-on-openshift-chart-v3-5-ea-1
   workspaces:

--- a/pipelineruns/RHOAI-Build-Config/.tekton/rhai-on-xks-chart-v3-5-ea-1-push.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/rhai-on-xks-chart-v3-5-ea-1-push.yaml
@@ -53,7 +53,7 @@ spec:
         requests:
           memory: 0.3Gi
         limits:
-          memory: 0.5Gi
+          memory: 4Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-rhai-on-xks-chart-v3-5-ea-1
   workspaces:

--- a/pipelineruns/RHOAI-Build-Config/.tekton/rhai-on-xks-chart-v3-5-ea-1-scheduled.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/rhai-on-xks-chart-v3-5-ea-1-scheduled.yaml
@@ -54,7 +54,7 @@ spec:
         requests:
           memory: 0.3Gi
         limits:
-          memory: 0.5Gi
+          memory: 4Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-rhai-on-xks-chart-v3-5-ea-1
   workspaces:


### PR DESCRIPTION
Updates `build-helm-chart` / `package-and-push` `limits.memory` from 0.5Gi to 4Gi for RHOAI-Build-Config openshift and xks chart PipelineRuns (push and scheduled), consistent with `rhoai-3.4`.

Made with [Cursor](https://cursor.com)