### PR TITLE
Update prefetch-input to include kube-rbac-proxy [Do NOT Merge]

### DIFF
--- a/pipelineruns/kube-auth-proxy/.tekton/odh-kube-auth-proxy-v3-3-push.yaml
+++ b/pipelineruns/kube-auth-proxy/.tekton/odh-kube-auth-proxy-v3-3-push.yaml
@@ -39,7 +39,7 @@ spec:
     value: true
   - name: prefetch-input
     value: |
-      {"type": "gomod", "path": "."}
+      [{"type": "gomod", "path": "."}, {"type": "gomod", "path": "kube-rbac-proxy"}]
   - name: build-source-image
     value: true
   - name: build-image-index


### PR DESCRIPTION
The prefetch was missing the go.mod file. Check https://github.com/red-hat-data-services/kube-auth-proxy/pull/162 for details