### PR TITLE
Add odh-kserve-localmodelnode-agent pull-request PipelineRun for kserve

### DIFF
--- a/pipelineruns/kserve/.tekton/odh-kserve-localmodelnode-agent-pull-request.yaml
+++ b/pipelineruns/kserve/.tekton/odh-kserve-localmodelnode-agent-pull-request.yaml
@@ -1,0 +1,75 @@
+
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/kserve?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-odh-kserve-localmodelnode-agent]"
+    pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+  labels:
+    appstudio.openshift.io/application: automation
+    appstudio.openshift.io/component: pull-request-pipelines-odh-kserve-localmodelnode-agent
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-kserve-localmodelnode-agent-on-pull-request-{{pull_request_number}}
+  namespace: rhoai-tenant
+spec:
+  timeouts:
+    pipeline: 8h
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: additional-tags
+    value:
+    - 'pr-{{pull_request_number}}-into-{{target_branch}}'
+  - name: additional-labels
+    value:
+    - version=on-pr-{{revision}}
+    - io.openshift.tags=odh-kserve-localmodelnode-agent
+  - name: output-image
+    value: quay.io/rhoai/pull-request-pipelines:odh-kserve-localmodelnode-agent-{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux-m2xlarge/arm64
+    - linux/ppc64le
+    - linux/s390x
+  - name: image-expires-after
+    value: 5d
+  - name: dockerfile
+    value: Dockerfiles/localmodel-agent.Dockerfile.konflux
+  - name: path-context
+    value: .
+  - name: hermetic
+    value: true
+  - name: prefetch-input
+    value: |
+      [{"type": "gomod", "path": "."}]
+  - name: build-image-index
+    value: true
+  - name: enable-slack-failure-notification
+    value: "false"
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ target_branch }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-pull-request-pipelines
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Adds Tekton pull-request PipelineRun YAML for component 'odh-kserve-localmodelnode-agent'.

## Details

| Field | Value |
|-------|-------|
| Component | `odh-kserve-localmodelnode-agent` |
| Source repo | `https://github.com/red-hat-data-services/kserve` |
| File | `pipelineruns/kserve/.tekton/odh-kserve-localmodelnode-agent-pull-request.yaml` |
| Platforms | x86_64 arm64 ppc64le s390x |
| Output image | `quay.io/rhoai/pull-request-pipelines:odh-kserve-localmodelnode-agent-{{revision}}` |

**Jira:** https://redhat.atlassian.net/browse/RHOAIENG-56716