### PR TITLE
Rename llama-stack-distribution repo refs to ogx-distribution

### DIFF
--- a/.github/workflows/sync-pipelineruns.yml
+++ b/.github/workflows/sync-pipelineruns.yml
@@ -41,7 +41,7 @@ on:
           - kube-auth-proxy
           - kubeflow
           - kuberay
-          - llama-stack-distribution
+          - ogx-distribution
           - llama-stack-provider-trustyai-garak
           - llm-d-inference-scheduler
           - llm-d-kv-cache

--- a/pipelineruns/ogx-distribution/.tekton/odh-llama-stack-core-v3-4-push.yaml
+++ b/pipelineruns/ogx-distribution/.tekton/odh-llama-stack-core-v3-4-push.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/llama-stack-distribution?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/ogx-distribution?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"


### PR DESCRIPTION
RHOAIENG-60698

## Summary
- The GitHub repo `llama-stack-distribution` was renamed to `ogx-distribution`
- Updated the `pipelineruns/` directory name from `llama-stack-distribution` to `ogx-distribution`
- Updated the `build.appstudio.openshift.io/repo` annotation URL to point to the new repo name
- Updated the sync workflow dropdown to reference `ogx-distribution`
- Component names, image names, service account names, and resource names are intentionally unchanged

## Test plan
- [ ] Verify the PipelineRun YAML still validates correctly
- [ ] Confirm the sync workflow picks up the renamed directory for the ogx-distribution repo
- [ ] Verify no component name, image name, or service account references were changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)