### PR TITLE
fix: single-match Slack ts/channel for smoke dispatch (rhoai-3.5-ea.1)

### DIFF
--- a/pipelines/fbc-fragment-build.yaml
+++ b/pipelines/fbc-fragment-build.yaml
@@ -698,8 +698,8 @@ spec:
             -H "Content-Type: application/json; charset=utf-8" \
             -d '{"channel": "'"$SLACK_CHANNEL"'", "text": "'"${SLACK_MESSAGE//\"/\\\"}"'", "unfurl_links": false}')
 
-          THREAD_TS=$(echo "$RESPONSE" | grep -oP '"ts"\s*:\s*"\K[0-9]+\.[0-9]+')
-          CHANNEL_ID=$(echo "$RESPONSE" | grep -oP '"channel"\s*:\s*"\K[^"]+')
+          THREAD_TS=$(echo "$RESPONSE" | grep -oP '"ts"\s*:\s*"\K[0-9]+\.[0-9]+' | head -1)
+          CHANNEL_ID=$(echo "$RESPONSE" | grep -oP '"channel"\s*:\s*"\K[^"]+' | head -1)
           echo "Slack posted (thread_ts=$THREAD_TS)"
 
           [[ "$BUILD_TYPE" != "nightly" ]] && exit 0


### PR DESCRIPTION
Minimal follow-up on #2035: `grep -oP` can return multiple `ts` matches; use `| head -1` so GitHub workflow dispatch JSON stays valid (fixes HTTP 400 seen in e.g. `rhoai-fbc-fragment-v3-5-ea-1-on-schedule-r757w`).

Related: #2096 / RHOAIENG-50499