### PR TITLE
Add odh-ogx-core pull-request PipelineRun for ogx-distribution

### DIFF
--- a/pipelineruns/ogx-distribution/.tekton/odh-ogx-core-pull-request.yaml
+++ b/pipelineruns/ogx-distribution/.tekton/odh-ogx-core-pull-request.yaml
@@ -1,0 +1,74 @@
+
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/ogx-distribution?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-odh-ogx-core]"
+    pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+  labels:
+    appstudio.openshift.io/application: automation
+    appstudio.openshift.io/component: pull-request-pipelines-odh-ogx-core
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-ogx-core-on-pull-request-{{pull_request_number}}
+  namespace: rhoai-tenant
+spec:
+  timeouts:
+    pipeline: 8h
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: additional-tags
+    value:
+    - 'pr-{{pull_request_number}}-into-{{target_branch}}'
+  - name: additional-labels
+    value:
+    - version=on-pr-{{revision}}
+    - io.openshift.tags=odh-ogx-core
+  - name: output-image
+    value: quay.io/rhoai/pull-request-pipelines:odh-ogx-core-{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux-m2xlarge/arm64
+    - linux/ppc64le
+  - name: image-expires-after
+    value: 5d
+  - name: dockerfile
+    value: Dockerfile.konflux
+  - name: path-context
+    value: .
+  - name: hermetic
+    value: true
+  - name: prefetch-input
+    value: |
+      []
+  - name: build-image-index
+    value: true
+  - name: enable-slack-failure-notification
+    value: "false"
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ target_branch }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-pull-request-pipelines
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Adds Tekton pull-request PipelineRun YAML for component 'odh-ogx-core'.

## Details

| Field | Value |
|-------|-------|
| Component | `odh-ogx-core` |
| Source repo | `https://github.com/red-hat-data-services/ogx-distribution` |
| File | `pipelineruns/ogx-distribution/.tekton/odh-ogx-core-pull-request.yaml` |
| Platforms | linux/x86_64 linux-m2xlarge/arm64 linux/ppc64le |
| Output image | `quay.io/rhoai/pull-request-pipelines:odh-ogx-core-{{revision}}` |

**Jira:** https://redhat.atlassian.net/browse/RHOAIENG-61363