### PR TITLE
retrigger 18 rhoai-3.3 notebook builds

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-datascience-cpu-py312-v3-3-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-datascience-cpu-py312-v3-3-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-05-07 11:26:17
+# retrigger build 2026-05-07T15:49:47Z
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-minimal-cpu-py312-v3-3-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-minimal-cpu-py312-v3-3-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-05-07 11:26:17
+# retrigger build 2026-05-07T15:52:32Z
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-v3-3-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-v3-3-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-05-07 11:26:17
+# retrigger build 2026-05-07T15:49:47Z
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-3-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-3-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-05-07 11:26:17
+# retrigger build 2026-05-07T15:52:32Z
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v3-3-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v3-3-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-05-07 11:26:17
+# retrigger build 2026-05-07T15:49:47Z
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-v3-3-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-v3-3-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-05-07 11:26:17
+# retrigger build 2026-05-07T15:49:47Z
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v3-3-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v3-3-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-05-07 11:26:17
+# retrigger build 2026-05-07T15:49:47Z
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-3-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-3-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-05-07 11:26:17
+# retrigger build 2026-05-07T15:49:47Z
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v3-3-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v3-3-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-05-07 11:26:17
+# retrigger build 2026-05-07T15:49:47Z
 #
 metadata:
   annotations:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cpu-py312-v3-3-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cpu-py312-v3-3-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-05-07 11:26:17
+# retrigger build 2026-05-07T15:49:47Z
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cuda-py312-v3-3-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cuda-py312-v3-3-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-05-07 11:26:17
+# retrigger build 2026-05-07T15:49:47Z
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v3-3-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v3-3-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-05-07 11:26:17
+# retrigger build 2026-05-07T15:49:47Z
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-v3-3-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-v3-3-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-05-07 11:26:17
+# retrigger build 2026-05-07T15:49:47Z
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v3-3-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v3-3-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-05-07 11:26:17
+# retrigger build 2026-05-07T15:49:47Z
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v3-3-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v3-3-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-05-07 11:26:17
+# retrigger build 2026-05-07T15:49:47Z
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v3-3-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v3-3-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-05-07 11:26:17
+# retrigger build 2026-05-07T15:49:47Z
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v3-3-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v3-3-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-05-07 11:26:17
+# retrigger build 2026-05-07T15:49:47Z
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-v3-3-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-v3-3-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-05-07 11:26:17
+# retrigger build 2026-05-07T15:49:47Z
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}


### PR DESCRIPTION
## Summary
- Retrigger all 18 notebook/pipeline-runtime builds for rhoai-3.3 after fips-check-blocking YAML fix (PR #2120)

## Components (18)
**Pipeline Runtimes (7):**
- odh-pipeline-runtime-datascience-cpu-py312
- odh-pipeline-runtime-minimal-cpu-py312
- odh-pipeline-runtime-pytorch-cuda-py312
- odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312
- odh-pipeline-runtime-pytorch-rocm-py312
- odh-pipeline-runtime-tensorflow-cuda-py312
- odh-pipeline-runtime-tensorflow-rocm-py312

**Workbenches (11):**
- odh-workbench-codeserver-datascience-cpu-py312
- odh-workbench-jupyter-datascience-cpu-py312
- odh-workbench-jupyter-minimal-cpu-py312
- odh-workbench-jupyter-minimal-cuda-py312
- odh-workbench-jupyter-minimal-rocm-py312
- odh-workbench-jupyter-pytorch-cuda-py312
- odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312
- odh-workbench-jupyter-pytorch-rocm-py312
- odh-workbench-jupyter-tensorflow-cuda-py312
- odh-workbench-jupyter-tensorflow-rocm-py312
- odh-workbench-jupyter-trustyai-cpu-py312

## Context
Builds were blocked because PR #2106 placed `fips-check-blocking` param after `taskRunSpecs` instead of inside `spec.params`, breaking PipelineRun YAML parsing. PR #2120 fixed the placement. This PR retriggers all notebook builds.