### PR TITLE
Remove deprecated dev-package-managers param from prefetch-dependencies-oci-ta (rhoai-3.3)

### DIFF
--- a/pipelines/container-build.yaml
+++ b/pipelines/container-build.yaml
@@ -191,8 +191,6 @@ spec:
     params:
     - name: input
       value: $(params.prefetch-input)
-    - name: dev-package-managers
-      value: "true"
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     - name: ociStorage

--- a/pipelines/fbc-fragment-build.yaml
+++ b/pipelines/fbc-fragment-build.yaml
@@ -218,8 +218,6 @@ spec:
     params:
     - name: input
       value: $(params.prefetch-input)
-    - name: dev-package-managers
-      value: "true"
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     - name: ociStorage

--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -207,8 +207,6 @@ spec:
     params:
     - name: input
       value: $(params.prefetch-input)
-    - name: dev-package-managers
-      value: "true"
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     - name: ociStorage


### PR DESCRIPTION
## Summary

- Removes the deprecated `dev-package-managers` parameter from the `prefetch-dependencies` task step in all 3 pipeline spec files
- This is the 0.2 → 0.3 migration step for `prefetch-dependencies-oci-ta`: the parameter was removed in version 0.3
- The `enable-package-registry-proxy` parameter (0.3.1 → 0.3.2 migration step) was already present in these pipeline specs

## References

- Jira: RHOAIENG-62207
- Migration guide: https://github.com/konflux-ci/build-definitions/blob/main/task/prefetch-dependencies-oci-ta/0.3/MIGRATION.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)