### PR TITLE
Apply prefetch-dependencies-oci-ta migration steps (rhoai-3.4)

### DIFF
--- a/pipelines/container-build.yaml
+++ b/pipelines/container-build.yaml
@@ -113,6 +113,10 @@ spec:
     type: string
     default: .
     description: Target directories to scan with SAST tools. Multiple values should be separated with commas.
+  - name: enable-package-registry-proxy
+    default: 'true'
+    description: Use the package registry proxy when prefetching dependencies
+    type: string
   results:
   - description: ""
     name: IMAGE_URL
@@ -191,8 +195,6 @@ spec:
     params:
     - name: input
       value: $(params.prefetch-input)
-    - name: dev-package-managers
-      value: "true"
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     - name: ociStorage
@@ -205,6 +207,8 @@ spec:
       value: $(params.prefetch-config-file-content)
     - name: mode
       value: $(params.prefetch-mode)
+    - name: enable-package-registry-proxy
+      value: $(params.enable-package-registry-proxy)
     runAfter:
     - clone-repository
     taskRef:

--- a/pipelines/fbc-fragment-build.yaml
+++ b/pipelines/fbc-fragment-build.yaml
@@ -134,6 +134,10 @@ spec:
     type: string
     default: .
     description: Target directories to scan with SAST tools. Multiple values should be separated with commas.
+  - name: enable-package-registry-proxy
+    default: 'true'
+    description: Use the package registry proxy when prefetching dependencies
+    type: string
   results:
   - description: ""
     name: IMAGE_URL
@@ -214,8 +218,6 @@ spec:
     params:
     - name: input
       value: $(params.prefetch-input)
-    - name: dev-package-managers
-      value: "true"
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     - name: ociStorage
@@ -228,6 +230,8 @@ spec:
       value: $(params.prefetch-config-file-content)
     - name: mode
       value: $(params.prefetch-mode)
+    - name: enable-package-registry-proxy
+      value: $(params.enable-package-registry-proxy)
     runAfter:
     - clone-repository
     taskRef:

--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -129,6 +129,10 @@ spec:
     type: string
     default: .
     description: Target directories to scan with SAST tools. Multiple values should be separated with commas.
+  - name: enable-package-registry-proxy
+    default: 'true'
+    description: Use the package registry proxy when prefetching dependencies
+    type: string
   results:
   - description: ""
     name: IMAGE_URL
@@ -209,8 +213,6 @@ spec:
       value: $(params.prefetch-input)
     - name: ACTIVATION_KEY
       value: $(params.rhel-subscription-activation-key)
-    - name: dev-package-managers
-      value: "true"
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     - name: ociStorage
@@ -223,6 +225,8 @@ spec:
       value: $(params.prefetch-config-file-content)
     - name: mode
       value: $(params.prefetch-mode)
+    - name: enable-package-registry-proxy
+      value: $(params.enable-package-registry-proxy)
     runAfter:
     - clone-repository
     taskRef:


### PR DESCRIPTION
## Summary

- Removes the deprecated `dev-package-managers` parameter from the `prefetch-dependencies` task step in all 3 pipeline spec files (0.2 → 0.3 migration)
- Adds `enable-package-registry-proxy` as a Pipeline-level parameter with default `true`, and passes it to the `prefetch-dependencies` task step (0.3.1 → 0.3.2 migration)

Affected files:
- `pipelines/container-build.yaml`
- `pipelines/multi-arch-container-build.yaml`
- `pipelines/fbc-fragment-build.yaml`

## References

- Jira: RHOAIENG-62207
- Migration guide: https://github.com/konflux-ci/build-definitions/blob/main/task/prefetch-dependencies-oci-ta/0.3/MIGRATION.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)