### PR TITLE
migrate prefetch-dependencies-oci-ta: remove dev-package-managers, add enable-package-registry-proxy (rhoai-3.5-ea.1)

### DIFF
--- a/pipelines/container-build.yaml
+++ b/pipelines/container-build.yaml
@@ -113,6 +113,10 @@ spec:
     type: string
     default: .
     description: Target directories to scan with SAST tools. Multiple values should be separated with commas.
+  - name: enable-package-registry-proxy
+    default: 'true'
+    description: Use the package registry proxy when prefetching dependencies
+    type: string
   results:
   - description: ""
     name: IMAGE_URL
@@ -191,8 +195,6 @@ spec:
     params:
     - name: input
       value: $(params.prefetch-input)
-    - name: dev-package-managers
-      value: "true"
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     - name: ociStorage
@@ -205,6 +207,8 @@ spec:
       value: $(params.prefetch-config-file-content)
     - name: mode
       value: $(params.prefetch-mode)
+    - name: enable-package-registry-proxy
+      value: $(params.enable-package-registry-proxy)
     runAfter:
     - clone-repository
     taskRef:

--- a/pipelines/fbc-fragment-build.yaml
+++ b/pipelines/fbc-fragment-build.yaml
@@ -134,6 +134,10 @@ spec:
     type: string
     default: .
     description: Target directories to scan with SAST tools. Multiple values should be separated with commas.
+  - name: enable-package-registry-proxy
+    default: 'true'
+    description: Use the package registry proxy when prefetching dependencies
+    type: string
   results:
   - description: ""
     name: IMAGE_URL
@@ -214,8 +218,6 @@ spec:
     params:
     - name: input
       value: $(params.prefetch-input)
-    - name: dev-package-managers
-      value: "true"
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     - name: ociStorage
@@ -228,6 +230,8 @@ spec:
       value: $(params.prefetch-config-file-content)
     - name: mode
       value: $(params.prefetch-mode)
+    - name: enable-package-registry-proxy
+      value: $(params.enable-package-registry-proxy)
     runAfter:
     - clone-repository
     taskRef:

--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -129,6 +129,10 @@ spec:
     type: string
     default: .
     description: Target directories to scan with SAST tools. Multiple values should be separated with commas.
+  - name: enable-package-registry-proxy
+    default: 'true'
+    description: Use the package registry proxy when prefetching dependencies
+    type: string
   results:
   - description: ""
     name: IMAGE_URL
@@ -209,8 +213,6 @@ spec:
       value: $(params.prefetch-input)
     - name: ACTIVATION_KEY
       value: $(params.rhel-subscription-activation-key)
-    - name: dev-package-managers
-      value: "true"
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     - name: ociStorage
@@ -223,6 +225,8 @@ spec:
       value: $(params.prefetch-config-file-content)
     - name: mode
       value: $(params.prefetch-mode)
+    - name: enable-package-registry-proxy
+      value: $(params.enable-package-registry-proxy)
     runAfter:
     - clone-repository
     taskRef:


### PR DESCRIPTION
## Summary

Applies `prefetch-dependencies-oci-ta` migration steps for the `rhoai-3.5-ea.1` branch.

- **0.2→0.3 migration**: Remove deprecated `dev-package-managers` parameter from `prefetch-dependencies` task steps in all pipeline specs (`container-build.yaml`, `multi-arch-container-build.yaml`, `fbc-fragment-build.yaml`)
- **0.3.1→0.3.2 migration**: Add `enable-package-registry-proxy` parameter at Pipeline level (with `default: true`) and pass it to the `prefetch-dependencies` task step in all pipeline specs

> **Note**: The `prefetch-dependencies-oci-ta` bundle on `rhoai-3.5-ea.1` is still at version `0.2` — the 0.2→0.3 bundle version bump has an open PR that has not yet been merged. This PR can be merged after that bump lands.

Ref: RHOAIENG-62207