### PR TITLE
Enable FIPS check blocking for all components, with some exceptions (rhoai-3.5-ea.1)

### DIFF
--- a/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-argoexec-v3-5-ea-1-push.yaml
+++ b/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-argoexec-v3-5-ea-1-push.yaml
@@ -56,6 +56,8 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-launcher-v3-5-ea-1-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-launcher-v3-5-ea-1-push.yaml
@@ -52,6 +52,8 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-datascience-cpu-py312-v3-5-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-datascience-cpu-py312-v3-5-ea-1-push.yaml
@@ -66,6 +66,8 @@ spec:
       binary:
         arch: "x86_64,aarch64,ppc64le,s390x"
       requirements_files: [requirements.cpu.txt]
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-minimal-cpu-py312-v3-5-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-minimal-cpu-py312-v3-5-ea-1-push.yaml
@@ -66,6 +66,8 @@ spec:
       binary:
         arch: "x86_64,aarch64,ppc64le,s390x"
       requirements_files: [requirements.cpu.txt]
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-v3-5-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-v3-5-ea-1-push.yaml
@@ -63,6 +63,8 @@ spec:
       binary:
         arch: "x86_64"
       requirements_files: [requirements.cuda.txt]
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-5-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-5-ea-1-push.yaml
@@ -63,6 +63,8 @@ spec:
       binary:
         arch: "x86_64"
       requirements_files: [requirements.cuda.txt]
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v3-5-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v3-5-ea-1-push.yaml
@@ -63,6 +63,8 @@ spec:
       binary:
         arch: "x86_64"
       requirements_files: [requirements.rocm.txt]
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-v3-5-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-v3-5-ea-1-push.yaml
@@ -64,6 +64,8 @@ spec:
       binary:
         arch: "x86_64,aarch64"
       requirements_files: [requirements.cuda.txt]
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v3-5-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v3-5-ea-1-push.yaml
@@ -63,6 +63,8 @@ spec:
       binary:
         arch: "x86_64"
       requirements_files: [requirements.rocm.txt]
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-wb-jupyter-pytorch-llmcompressor-cuda-py312-v3-5-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-wb-jupyter-pytorch-llmcompressor-cuda-py312-v3-5-ea-1-push.yaml
@@ -67,6 +67,8 @@ spec:
       binary:
         arch: "x86_64,aarch64"
       requirements_files: ["requirements.cuda.txt"]
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-5-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-5-ea-1-push.yaml
@@ -181,6 +181,8 @@ spec:
     # Registry-only npm deps (ProdSec); @parcel/watcher, @emmetio/css-parser, @playwright/browser-chromium in custom-packages/package.json
     - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.106.3/custom-packages
       type: npm
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v3-5-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v3-5-ea-1-push.yaml
@@ -71,6 +71,8 @@ spec:
       binary:
         arch: "x86_64,aarch64,ppc64le,s390x"
       requirements_files: [requirements.cpu.txt]
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cpu-py312-v3-5-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cpu-py312-v3-5-ea-1-push.yaml
@@ -69,6 +69,8 @@ spec:
       binary:
         arch: "x86_64,aarch64,ppc64le,s390x"
       requirements_files: [requirements.cpu.txt]
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cuda-py312-v3-5-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cuda-py312-v3-5-ea-1-push.yaml
@@ -67,6 +67,8 @@ spec:
       binary:
         arch: "x86_64,aarch64"
       requirements_files: [requirements.cuda.txt]
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v3-5-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v3-5-ea-1-push.yaml
@@ -66,6 +66,8 @@ spec:
       binary:
         arch: "x86_64,aarch64"
       requirements_files: [requirements.rocm.txt]
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-v3-5-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-v3-5-ea-1-push.yaml
@@ -66,6 +66,8 @@ spec:
       binary:
         arch: "x86_64"
       requirements_files: [requirements.cuda.txt]
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v3-5-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v3-5-ea-1-push.yaml
@@ -66,6 +66,8 @@ spec:
       binary:
         arch: "x86_64"
       requirements_files: [requirements.rocm.txt]
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v3-5-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v3-5-ea-1-push.yaml
@@ -67,6 +67,8 @@ spec:
       binary:
         arch: "x86_64,aarch64"
       requirements_files: [requirements.cuda.txt]
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v3-5-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v3-5-ea-1-push.yaml
@@ -66,6 +66,8 @@ spec:
       binary:
         arch: "x86_64"
       requirements_files: [requirements.rocm.txt]
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-v3-5-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-v3-5-ea-1-push.yaml
@@ -71,6 +71,8 @@ spec:
       binary:
         arch: "x86_64,aarch64,ppc64le,s390x"
       requirements_files: [requirements.cpu.txt]
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -122,7 +122,7 @@ spec:
     name: disable-slack-notifications
     type: string
   - name: fips-check-blocking
-    default: "false"
+    default: "true"
     type: string
     description: When true, a FIPS check-payload failure will fail the pipeline
   - name: sast-target-dirs
@@ -736,7 +736,7 @@ spec:
     - rpms-signature-scan
     - sast-coverity-check
     - coverity-availability-check
-    # - fips-check
+    - fips-check
     taskSpec:
       steps:
       - name: noop


### PR DESCRIPTION
## Summary
- Set `fips-check-blocking: "false"` for all 18 notebook image on-push PipelineRuns
- Set `fips-check-blocking: "false"` for odh-ml-pipelines-launcher and odh-data-science-pipelines-argo-argoexec on-push PipelineRuns
- FIPS checks still run but failures log warnings instead of blocking the pipeline

## Components affected (20 total)
**Notebooks (18):** all jupyter workbench, pipeline-runtime, and codeserver images
**Other (2):** odh-ml-pipelines-launcher, odh-data-science-pipelines-argo-argoexec

## Test plan
- [ ] Verify on-push builds trigger successfully for affected components
- [ ] Confirm FIPS check task runs but does not block pipeline on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)