### PR TITLE
Disable FIPS check blocking for th06 images (rhoai-3.5-ea.1)

### DIFF
--- a/pipelineruns/distributed-workloads/.tekton/odh-th06-cpu-torch210-py312-v3-5-ea-1-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th06-cpu-torch210-py312-v3-5-ea-1-push.yaml
@@ -52,6 +52,8 @@ spec:
     value: '[{"type": "pip", "path": "images/universal/training/th06-cpu-torch210-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64,aarch64", "os": "linux"}}]'
   - name: build-args
     value: ["DOWNSTREAM=true"]
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/distributed-workloads/.tekton/odh-th06-cuda130-torch210-py312-v3-5-ea-1-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th06-cuda130-torch210-py312-v3-5-ea-1-push.yaml
@@ -52,6 +52,8 @@ spec:
     value: '[{"type": "pip", "path": "images/universal/training/th06-cuda130-torch210-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64,aarch64", "os": "linux"}}]'
   - name: build-args
     value: ["DOWNSTREAM=true"]
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/distributed-workloads/.tekton/odh-th06-rocm64-torch291-py312-v3-5-ea-1-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th06-rocm64-torch291-py312-v3-5-ea-1-push.yaml
@@ -51,6 +51,8 @@ spec:
     value: '[{"type": "pip", "path": "images/universal/training/th06-rocm64-torch291-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64,aarch64", "os": "linux"}}]'
   - name: build-args
     value: ["DOWNSTREAM=true"]
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Summary
- Set `fips-check-blocking: "false"` for all 3 th06 on-push PipelineRuns
- FIPS checks still run but failures log warnings instead of blocking the pipeline

## Components affected (3)
- odh-th06-cpu-torch210-py312
- odh-th06-cuda130-torch210-py312
- odh-th06-rocm64-torch291-py312

## Test plan
- [ ] Verify on-push builds trigger successfully for affected components
- [ ] Confirm FIPS check task runs but does not block pipeline on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)