### PR TITLE
retrigger notebooks builds on rhoai-3.3

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-minimal-cpu-py312-v3-3-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-minimal-cpu-py312-v3-3-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# retrigger build 2026-05-07T15:52:32Z
+# retrigger build 2026-05-14T02:30:00Z
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}

--- a/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-3-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-3-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# retrigger build 2026-05-07T15:49:47Z
+# retrigger build 2026-05-14T02:30:00Z
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}


### PR DESCRIPTION
## Summary
- Retrigger builds for `odh-pipeline-runtime-minimal-cpu-py312-v3-3` and `odh-workbench-codeserver-datascience-cpu-py312-v3-3` components

## Components
- `odh-pipeline-runtime-minimal-cpu-py312-v3-3`
- `odh-workbench-codeserver-datascience-cpu-py312-v3-3`