### PR TITLE
Rename llama-stack-distribution repo refs to ogx-distribution

### DIFF
--- a/.github/workflows/sync-pipelineruns.yml
+++ b/.github/workflows/sync-pipelineruns.yml
@@ -37,7 +37,7 @@ on:
           - kube-auth-proxy
           - kubeflow
           - kuberay
-          - llama-stack-distribution
+          - ogx-distribution
           - ogx-k8s-operator
           - llama-stack-provider-trustyai-garak
           - llm-d-inference-scheduler

--- a/pipelineruns/ogx-distribution/.tekton/odh-llama-stack-core-v3-3-push.yaml
+++ b/pipelineruns/ogx-distribution/.tekton/odh-llama-stack-core-v3-3-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 # konflux build manual retrigger - 2026-05-11 07:50:36
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/llama-stack-distribution?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/ogx-distribution?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"


### PR DESCRIPTION
## Summary
- The GitHub repo `llama-stack-distribution` was renamed to `ogx-distribution`
- Updated the `pipelineruns/` directory name from `llama-stack-distribution` to `ogx-distribution`
- Updated the `build.appstudio.openshift.io/repo` annotation URL to point to the new repo name
- Updated the sync-pipelineruns workflow dropdown to reference `ogx-distribution`
- Component names, image names, service account names, and Konflux resource names are unchanged

## Test plan
- [ ] Verify the PipelineRun still references the correct component name (`odh-llama-stack-core-v3-3`)
- [ ] Verify the repo URL annotation points to `ogx-distribution`
- [ ] Verify the sync workflow lists `ogx-distribution` in the dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)