### PR TITLE
Pin fips-check dependencies in multi-arch pipeline

### DIFF
--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -673,7 +673,7 @@ spec:
         default: "true"
       steps:
       - name: prepare-image-list
-        image: quay.io/konflux-ci/konflux-test:v1.4.53@sha256:724ecf16a1fc9b51a1b20c91c5125556c53d471d0d8db1648d2404e4715f204e
+        image: quay.io/konflux-ci/konflux-test:v1.5.0@sha256:fbd5ad045b902065990218922aa6f343e8eb5fd039ecd445bc54819b8e968c3e
         env:
         - name: IMAGE_PLATFORM
           value: $(params.image-platform)
@@ -702,7 +702,7 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/build-definitions.git
           - name: revision
-            value: main
+            value: 6660aed5c5388fade0f433c14d41c5d4e073d07a
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
       - name: evaluate-result


### PR DESCRIPTION
## Summary
- Update `konflux-test` image from v1.4.53 to v1.5.0 (with updated digest)
- Pin `fips-operator-check-step-action` git resolver to commit `6660aed` instead of `main`

## Test plan
- [x] Verify fips-check task runs successfully in a test PipelineRun
- [x] Confirm the pinned step action resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)