### PR TITLE
Fix automerge for custom regex manager packages

### DIFF
--- a/renovate/pipelines-renovate.json5
+++ b/renovate/pipelines-renovate.json5
@@ -9,7 +9,6 @@
   "customManagers": [
     {
       "schedule": ["at any time"],
-      "automerge": true,
       "customType": "regex",
       "fileMatch": ["pipelines/.*\\.yaml$"],
       "matchStrings": [
@@ -19,6 +18,12 @@
       "packageNameTemplate": "https://github.com/{{{depName}}}",
       "currentValueTemplate": "main",
       "versioningTemplate": "git"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["custom.regex"],
+      "automerge": true
     }
   ],
   "tekton": {

--- a/renovate/pipelines-renovate.json5
+++ b/renovate/pipelines-renovate.json5
@@ -24,6 +24,11 @@
     {
       "matchManagers": ["custom.regex"],
       "automerge": true
+    },
+    {
+      // Pin fips-operator-check step action (from build-definitions)
+      "matchPackageNames": ["https://github.com/konflux-ci/build-definitions"],
+      "enabled": false
     }
   ],
   "tekton": {


### PR DESCRIPTION
## Summary
- `automerge: true` inside `customManagers` entries is not applied by MintMaker/Renovate, causing rhoai-konflux-tasks and build-definitions digest PRs to show "Automerge: Disabled by config"
- Move automerge to a top-level `packageRules` entry matching `custom.regex` manager, which is how Renovate properly resolves it
- Disable Renovate updates for `konflux-ci/build-definitions` (fips-operator-check step action) to keep it pinned at its current digest across all branches

## Test plan
- [x] JSON5 config validated
- [x] Local Renovate dry-run confirms automerge enabled for custom.regex packages across all base branches
- [ ] After merge, tick rebase/retry on an existing rhoai-konflux-tasks PR and confirm it shows "Automerge: Enabled"
- [ ] Confirm build-definitions PRs are no longer created

🤖 Generated with [Claude Code](https://claude.ai/claude-code)