### PR TITLE
chore: Do not trigger pipelines push builds for pipeline.yaml edits

### DIFF
--- a/pipelineruns/ai-gateway-payload-processing/.tekton/odh-ai-gateway-payload-processing-e2e-v3-5-ea-2-on-push.yaml
+++ b/pipelineruns/ai-gateway-payload-processing/.tekton/odh-ai-gateway-payload-processing-e2e-v3-5-ea-2-on-push.yaml
@@ -10,7 +10,7 @@ metadata:
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "rhoai-3.5-ea.1"
+      && target_branch == "rhoai-3.5-ea.2"
       && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-ai-gateway-payload-processing-e2e-v3-5-ea-2-on-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5-ea-2

--- a/pipelineruns/ai-gateway-payload-processing/.tekton/odh-ai-gateway-payload-processing-e2e-v3-5-ea-2-on-push.yaml
+++ b/pipelineruns/ai-gateway-payload-processing/.tekton/odh-ai-gateway-payload-processing-e2e-v3-5-ea-2-on-push.yaml
@@ -11,12 +11,12 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5-ea.1"
-      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-ai-gateway-payload-processing-e2e-v3-5-ea-1-on-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-ai-gateway-payload-processing-e2e-v3-5-ea-2-on-push.yaml".pathChanged() )
   labels:
-    appstudio.openshift.io/application: rhoai-v3-5-ea-1
-    appstudio.openshift.io/component: odh-ai-gateway-payload-processing-e2e-v3-5-ea-1
+    appstudio.openshift.io/application: rhoai-v3-5-ea-2
+    appstudio.openshift.io/component: odh-ai-gateway-payload-processing-e2e-v3-5-ea-2
     pipelines.appstudio.openshift.io/type: build
-  name: odh-ai-gateway-payload-processing-e2e-v3-5-ea-1-on-push
+  name: odh-ai-gateway-payload-processing-e2e-v3-5-ea-2-on-push
   namespace: rhoai-tenant
 spec:
   params:
@@ -61,7 +61,7 @@ spec:
     - name: pathInRepo
       value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-ai-gateway-payload-processing-e2e-v3-5-ea-1
+    serviceAccountName: build-pipeline-odh-ai-gateway-payload-processing-e2e-v3-5-ea-2
   workspaces:
   - name: git-auth
     secret:

--- a/pipelineruns/pipelines-components/.tekton/odh-automl-v3-5-ea-2-push.yaml
+++ b/pipelineruns/pipelines-components/.tekton/odh-automl-v3-5-ea-2-push.yaml
@@ -10,6 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5-ea.2"
+      && !files.all.all(x, x.matches('pipeline\\.yaml$'))
       && ( files.all.exists(p, !p.matches('^\\.tekton/'))
         || ".tekton/odh-automl-v3-5-ea-2-push.yaml".pathChanged()
         || "Dockerfile.konflux.automl".pathChanged() )

--- a/pipelineruns/pipelines-components/.tekton/odh-autorag-v3-5-ea-2-push.yaml
+++ b/pipelineruns/pipelines-components/.tekton/odh-autorag-v3-5-ea-2-push.yaml
@@ -10,6 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5-ea.2"
+      && !files.all.all(x, x.matches('pipeline\\.yaml$'))
       && ( files.all.exists(p, !p.matches('^\\.tekton/'))
         || ".tekton/odh-autorag-v3-5-ea-2-push.yaml".pathChanged()
         || "Dockerfile.konflux.autorag".pathChanged() )


### PR DESCRIPTION
New PR due to different target branch `rhoai-3.5-ea.2` (instead of `rhoai-3.5-ea.1`)