### PR TITLE
Validate CEL pathChanged() paths exist in repo

### DIFF
--- a/.github/workflows/validate-release-branches.yml
+++ b/.github/workflows/validate-release-branches.yml
@@ -56,6 +56,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
           GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GITHUB_BLOB_URL_PREFIX: ${{ github.server_url }}/${{ github.repository }}/blob/${{ matrix.release-branch }}
+          GITHUB_COMMIT_SHA: ${{ matrix.release-branch }}
         run: |
           uv run --with pyyaml --with pytest pytest script/test_validate_pipelineruns.py \
             --pipelinerun-dir pipelineruns/ \

--- a/.github/workflows/validate-release-branches.yml
+++ b/.github/workflows/validate-release-branches.yml
@@ -36,6 +36,7 @@ jobs:
 
       - name: Overlay PR validator scripts
         run: |
+          mkdir -p script
           cp pr-scripts/script/test_validate_pipelineruns.py script/test_validate_pipelineruns.py
           cp pr-scripts/script/conftest.py script/conftest.py
 

--- a/script/conftest.py
+++ b/script/conftest.py
@@ -124,8 +124,13 @@ _CHECK_SEARCH_KEYS = {
     "test_prefetch_input": [r"prefetch-input"],
 }
 
+# Checks that need more context lines around the matched key in snippets.
+_CHECK_SNIPPET_CONTEXT = {
+    "test_cel_path_changed_exists": 8,
+}
 
-def _extract_snippet(filepath, check_name, context=1):
+
+def _extract_snippet(filepath, check_name, context=None):
     """Read a YAML file and return lines around the key relevant to check_name.
 
     Returns (snippet_str, matched_line_number) where snippet_str has line
@@ -133,6 +138,8 @@ def _extract_snippet(filepath, check_name, context=1):
         3 |   kind: Deployment
     Returns ("", None) if the file can't be read or no match is found.
     """
+    if context is None:
+        context = _CHECK_SNIPPET_CONTEXT.get(check_name, 1)
     patterns = _CHECK_SEARCH_KEYS.get(check_name, [])
     if not patterns:
         return "", None

--- a/script/conftest.py
+++ b/script/conftest.py
@@ -117,6 +117,7 @@ _CHECK_SEARCH_KEYS = {
         r"build\.appstudio\.openshift\.io/repo:",
     ],
     "test_cel_self_reference": [r"on-cel-expression:"],
+    "test_cel_path_changed_exists": [r"on-cel-expression:"],
     "test_quay_repo_existence": [r"output-image"],
     "test_quay_naming": [r"output-image"],
     "test_dockerfile_path": [r"name: dockerfile$", r"name: path-context$"],

--- a/script/conftest.py
+++ b/script/conftest.py
@@ -331,6 +331,62 @@ def _build_validation_summary(stats, exitstatus, pipelinerun_dir,
                     lines.append(f"  ```yaml\n{snippet}\n  ```\n\n")
                     lines.append("  </details>\n\n")
 
+    # Warnings summary
+    warning_reports = [w for w in stats.get("warnings", [])
+                       if getattr(w, "nodeid", None)]
+    if warning_reports:
+        warnings_by_check = {}
+        for report in warning_reports:
+            parts = report.nodeid.split("::")
+            test_part = parts[-1] if len(parts) > 1 else report.nodeid
+            bracket_idx = test_part.find("[")
+            if bracket_idx != -1:
+                check_name = test_part[:bracket_idx]
+                file_param = test_part[bracket_idx + 1:].rstrip("]")
+            else:
+                check_name = test_part
+                file_param = ""
+            msg = str(report.message)
+
+            snippet = ""
+            line_no = None
+            if file_param and pipelinerun_dir:
+                full_path = os.path.join(pipelinerun_dir, file_param)
+                snippet, line_no = _extract_snippet(full_path, check_name)
+
+            warnings_by_check.setdefault(check_name, []).append(
+                (file_param, msg, snippet, line_no)
+            )
+
+        lines.append("<details>\n")
+        lines.append(
+            f"<summary>:warning: Warnings ({len(warning_reports)})"
+            f"</summary>\n\n"
+        )
+        for check_name, file_warnings in warnings_by_check.items():
+            check_ref = _make_check_ref(
+                check_name, blob_url_prefix, test_file, test_line_map
+            )
+            lines.append(f"**{check_ref}**\n\n")
+            for file_param, msg, snippet, line_no in file_warnings:
+                file_ref = _make_file_ref(
+                    file_param, pipelinerun_dir, blob_url_prefix, line_no
+                )
+                lines.append(f"- {file_ref}\n\n")
+                if "\n" in msg:
+                    lines.append(f"  ```\n")
+                    for msg_line in msg.split("\n"):
+                        lines.append(f"  {msg_line}\n")
+                    lines.append(f"  ```\n\n")
+                else:
+                    lines.append(f"  {msg}\n\n")
+                if snippet:
+                    lines.append("  <details>\n")
+                    lines.append("  <summary>Details</summary>\n\n")
+                    lines.append(f"  ```yaml\n{snippet}\n  ```\n\n")
+                    lines.append("  </details>\n\n")
+        lines.append("</details>\n\n")
+
     # Skipped tests summary
     skipped_reports = stats.get("skipped", [])
     if skipped_reports:

--- a/script/test_validate_pipelineruns.py
+++ b/script/test_validate_pipelineruns.py
@@ -497,7 +497,7 @@ def test_cel_path_changed_exists(pipelinerun_file, github_token, branch,
             checked.append(branch)
         if len(checked) > 1:
             lines.append(f"  branches checked: {', '.join(checked)}")
-        pytest.fail("\n".join(lines))
+        warnings.warn("\n".join(lines))
 
 
 # ---------------------------------------------------------------------------

--- a/script/test_validate_pipelineruns.py
+++ b/script/test_validate_pipelineruns.py
@@ -419,6 +419,88 @@ def test_cel_self_reference(pipelinerun_file):
 
 
 # ---------------------------------------------------------------------------
+# Check 5b: CEL pathChanged() File Existence
+# ---------------------------------------------------------------------------
+
+def test_cel_path_changed_exists(pipelinerun_file, github_token, branch,
+                                 repo_access_cache):
+    """Validate non-glob .pathChanged() paths in CEL expressions exist in the repo."""
+    data = _load(pipelinerun_file)
+    pr_type = _detect_type(data)
+    if pr_type not in ("push", "scheduled"):
+        return
+
+    annotations = data.get("metadata", {}).get("annotations", {})
+    cel_expr = annotations.get(
+        "pipelinesascode.tekton.dev/on-cel-expression", ""
+    )
+    if not cel_expr:
+        return
+
+    # Skip globs (contain *) and .tekton/ paths (covered by test_cel_self_reference)
+    paths = re.findall(r'"([^"]+)"\.pathChanged\(\)', cel_expr)
+    paths = [p for p in paths if '*' not in p and not p.startswith(".tekton/")]
+    if not paths:
+        return
+
+    repo_url = annotations.get("build.appstudio.openshift.io/repo", "")
+    match = re.match(r"https://github\.com/([^/?]+/[^/?]+)", repo_url)
+    if not match:
+        warnings.warn(f"Cannot extract repo from annotation: '{repo_url}'")
+        return
+
+    repo_full = match.group(1)
+
+    if repo_full not in repo_access_cache:
+        repo_access_cache[repo_full] = _github_repo_accessible(
+            repo_full, github_token
+        )
+
+    accessible = repo_access_cache[repo_full]
+    if accessible is False:
+        pytest.skip(f"Repo '{repo_full}' is private or does not exist")
+    if isinstance(accessible, str):
+        pytest.skip(accessible)
+
+    cel_branch = _extract_target_branch(data)
+    refs_to_check = [None]
+    if cel_branch:
+        refs_to_check.insert(0, cel_branch)
+    if branch and branch != cel_branch:
+        refs_to_check.append(branch)
+
+    missing = []
+    for path in paths:
+        found = False
+        for ref in refs_to_check:
+            exists = _github_file_exists(repo_full, path, github_token, ref=ref)
+            if exists is True:
+                found = True
+                break
+            if exists is None:
+                found = True
+                break
+        if not found:
+            missing.append(path)
+
+    if missing:
+        lines = [
+            f"CEL .pathChanged() references file(s) not found in "
+            f"repo '{repo_full}':"
+        ]
+        for p in missing:
+            lines.append(f"  - {p}")
+        checked = ["default"]
+        if cel_branch:
+            checked.append(cel_branch)
+        if branch and branch != cel_branch:
+            checked.append(branch)
+        if len(checked) > 1:
+            lines.append(f"  branches checked: {', '.join(checked)}")
+        pytest.fail("\n".join(lines))
+
+
+# ---------------------------------------------------------------------------
 # Check 6: Quay Repo Existence
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds a new validator check (`test_cel_path_changed_exists`) that verifies non-glob `.pathChanged()` file paths in CEL expressions actually exist in the component's GitHub repository
- Glob paths (containing `*`) and `.tekton/` self-references are excluded (the latter is already covered by `test_cel_self_reference`)
- This would have caught the batch-gateway bug where CEL expressions referenced `Dockerfile.apiserver.konflux` in the root instead of `docker/Dockerfile.apiserver.konflux`

## Test plan
- [ ] Run validator against existing pipelineruns to verify no false positives
- [ ] Confirm it catches a CEL expression with a nonexistent literal path

🤖 Generated with [Claude Code](https://claude.com/claude-code)