### PR TITLE
Fix batch-gateway CEL expressions to ignore docker/ and .tekton/

### DIFF
--- a/pipelineruns/batch-gateway/.tekton/odh-llm-d-batch-gateway-apiserver-v3-4-push.yaml
+++ b/pipelineruns/batch-gateway/.tekton/odh-llm-d-batch-gateway-apiserver-v3-4-push.yaml
@@ -1,6 +1,5 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-#
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/batch-gateway?rev={{revision}}
@@ -9,10 +8,14 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "rhoai-3.4"
-      && ".tekton/odh-llm-d-batch-gateway-apiserver-v3-4-push.yaml".pathChanged()
-      || "Dockerfile.apiserver.konflux".pathChanged()
+    # Triggers on changes outside docker/ and .tekton/, or on this component's
+    # own Dockerfile and tekton file.
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push"
+      && target_branch == "rhoai-3.4"
+      && ( files.all.exists(p, !p.matches('^docker/') && !p.matches('^\\.tekton/'))
+        || ".tekton/odh-llm-d-batch-gateway-apiserver-v3-4-push.yaml".pathChanged()
+        || "docker/Dockerfile.apiserver.konflux".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: rhoai-v3-4

--- a/pipelineruns/batch-gateway/.tekton/odh-llm-d-batch-gateway-gc-v3-4-push.yaml
+++ b/pipelineruns/batch-gateway/.tekton/odh-llm-d-batch-gateway-gc-v3-4-push.yaml
@@ -1,6 +1,5 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-#
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/batch-gateway?rev={{revision}}
@@ -9,10 +8,14 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "rhoai-3.4"
-      && ".tekton/odh-llm-d-batch-gateway-gc-v3-4-push.yaml".pathChanged()
-      || "Dockerfile.gc.konflux".pathChanged()
+    # Triggers on changes outside docker/ and .tekton/, or on this component's
+    # own Dockerfile and tekton file.
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push"
+      && target_branch == "rhoai-3.4"
+      && ( files.all.exists(p, !p.matches('^docker/') && !p.matches('^\\.tekton/'))
+        || ".tekton/odh-llm-d-batch-gateway-gc-v3-4-push.yaml".pathChanged()
+        || "docker/Dockerfile.gc.konflux".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: rhoai-v3-4

--- a/pipelineruns/batch-gateway/.tekton/odh-llm-d-batch-gateway-processor-v3-4-push.yaml
+++ b/pipelineruns/batch-gateway/.tekton/odh-llm-d-batch-gateway-processor-v3-4-push.yaml
@@ -8,10 +8,14 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "rhoai-3.4"
-      && ".tekton/odh-llm-d-batch-gateway-processor-v3-4-push.yaml".pathChanged()
-      || "Dockerfile.processor.konflux".pathChanged()
+    # Triggers on changes outside docker/ and .tekton/, or on this component's
+    # own Dockerfile and tekton file.
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push"
+      && target_branch == "rhoai-3.4"
+      && ( files.all.exists(p, !p.matches('^docker/') && !p.matches('^\\.tekton/'))
+        || ".tekton/odh-llm-d-batch-gateway-processor-v3-4-push.yaml".pathChanged()
+        || "docker/Dockerfile.processor.konflux".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: rhoai-v3-4


### PR DESCRIPTION
## Summary
- Fixed operator precedence bug in CEL expressions where `||` for Dockerfile `.pathChanged()` was outside the `&&` grouping, causing builds to trigger regardless of branch or event type
- Fixed wrong Dockerfile paths in CEL — referenced root-level `Dockerfile.*.konflux` instead of `docker/Dockerfile.*.konflux`
- Added `files.all.exists()` filter to ignore changes to `docker/` and `.tekton/` directories, except each component's own Dockerfile and tekton file

## Test plan
- [ ] Verify builds trigger on source code changes (outside docker/ and .tekton/)
- [ ] Verify builds trigger on changes to the component's own Dockerfile (e.g. `docker/Dockerfile.apiserver.konflux`)
- [ ] Verify builds do NOT trigger on changes to other components' Dockerfiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)