### PR TITLE
updating tags for rhoai-2.25: apply-tags, buildah-remote-oci-ta and push-dockerfile-oci-ta

### DIFF
--- a/pipelines/container-build.yaml
+++ b/pipelines/container-build.yaml
@@ -546,7 +546,7 @@ spec:
       - name: name
         value: push-dockerfile-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:d4bfd429ec7e5d7b1da4e7132675ccaab98c7351e936bf3717739edd2df94891
+        value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:7855471abfe87de080b914f2f3ca27c59e64f6448a7c2435e51435b764494c71
       - name: kind
         value: task
       resolver: bundles

--- a/pipelines/fbc-fragment-build.yaml
+++ b/pipelines/fbc-fragment-build.yaml
@@ -312,7 +312,7 @@ spec:
       - name: name
         value: buildah-remote-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.8@sha256:a3924d1c04430b6488b5360fd851ce385eb81dd5f7ddf8f442e590877fc175b7
+        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.9@sha256:f667d1146533b1d49829c08097e31faf27db24563da576434a707353de62099f
       - name: kind
         value: task
       resolver: bundles

--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -301,7 +301,7 @@ spec:
       - name: name
         value: buildah-remote-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.8@sha256:a3924d1c04430b6488b5360fd851ce385eb81dd5f7ddf8f442e590877fc175b7
+        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.9@sha256:f667d1146533b1d49829c08097e31faf27db24563da576434a707353de62099f
       - name: kind
         value: task
       resolver: bundles
@@ -628,7 +628,7 @@ spec:
       - name: name
         value: apply-tags
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.2@sha256:60b873fd1dc151ce809daf6f590a2c7e3b53744b7e67c64e7f58d823f9bc80bb
+        value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:a291081de7fb27f832c6fc3c4b078acf7e6162ca4c085db38b118ca87e8b5b66
       - name: kind
         value: task
       resolver: bundles
@@ -651,7 +651,7 @@ spec:
       - name: name
         value: push-dockerfile-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:d4bfd429ec7e5d7b1da4e7132675ccaab98c7351e936bf3717739edd2df94891
+        value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:7855471abfe87de080b914f2f3ca27c59e64f6448a7c2435e51435b764494c71
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
## Summary
Updated Tekton task bundle versions in pipeline definitions for rhoai-2.25 branch.

## Changes
- **apply-tags**: 0.2 → 0.3
  - Updated in: `pipelines/multi-arch-container-build.yaml`
  
- **buildah-remote-oci-ta**: 0.8 → 0.9
  - Updated in: `pipelines/fbc-fragment-build.yaml`, `pipelines/multi-arch-container-build.yaml`
  
- **push-dockerfile-oci-ta**: 0.1 → 0.3
  - Updated in: `pipelines/container-build.yaml`, `pipelines/multi-arch-container-build.yaml`

## Verification
All image digests verified using `skopeo inspect` to ensure SHA256 hashes match the respective version tags.

Total: 5 task bundle updates across 3 pipeline files.