### PR TITLE
Rename -on-push tekton files to -push for consistency (rhoai-3.4)

### DIFF
--- a/pipelineruns/kserve-autogluon-server/.tekton/odh-kserve-autogluon-server-v3-4-push.yaml
+++ b/pipelineruns/kserve-autogluon-server/.tekton/odh-kserve-autogluon-server-v3-4-push.yaml
@@ -18,7 +18,7 @@ metadata:
     appstudio.openshift.io/application: rhoai-v3-4
     appstudio.openshift.io/component: odh-kserve-autogluon-server-v3-4
     pipelines.appstudio.openshift.io/type: build
-  name: odh-kserve-autogluon-server-v3-4-push
+  name: odh-kserve-autogluon-server-v3-4-on-push
   namespace: rhoai-tenant
 spec:
   params:

--- a/pipelineruns/kserve-autogluon-server/.tekton/odh-kserve-autogluon-server-v3-4-push.yaml
+++ b/pipelineruns/kserve-autogluon-server/.tekton/odh-kserve-autogluon-server-v3-4-push.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/rhaii-cluster-validation?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/kserve-autogluon-server?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
@@ -11,12 +11,14 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.4"
-      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-rhaii-validator-tools-v3-4-on-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/'))
+        || ".tekton/odh-kserve-autogluon-server-v3-4-push.yaml".pathChanged()
+        || "Dockerfile.konflux.autogluon".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-4
-    appstudio.openshift.io/component: odh-rhaii-validator-tools-v3-4
+    appstudio.openshift.io/component: odh-kserve-autogluon-server-v3-4
     pipelines.appstudio.openshift.io/type: build
-  name: odh-rhaii-validator-tools-v3-4-on-push
+  name: odh-kserve-autogluon-server-v3-4-push
   namespace: rhoai-tenant
 spec:
   params:
@@ -28,29 +30,37 @@ spec:
     value:
     - '{{target_branch}}-{{revision}}'
   - name: output-image
-    value: quay.io/rhoai/odh-rhaii-validator-tools-rhel9:{{target_branch}}
+    value: quay.io/rhoai/odh-kserve-autogluon-server-rhel9:{{target_branch}}
   - name: rhoai-version
     value: "3.4.0"
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux-m2xlarge/arm64
   - name: dockerfile
-    value: Dockerfile.konflux.validator.tools
+    value: ../Dockerfile.konflux.autogluon
   - name: path-context
-    value: .
+    value: python
   - name: hermetic
-    value: true
+    value: 'true'
   - name: prefetch-input
-    value: |
-      [
-        {"type": "rpm", "path": "tools"},
-        {"type": "rpm", "path": "tools/builder"}
-      ]
+    value:
+        [
+          {
+            "type": "pip",
+            "path": "python/autogluonserver",
+            "requirements_files": [
+              "autogluon-all-requirements.txt"
+            ],
+            "binary": {"arch": ":all:"}
+          }
+        ]
   - name: build-source-image
     value: true
   - name: build-image-index
     value: true
-  - name: build-platforms
-    value:
-    - linux/x86_64
-    - linux/arm64
   pipelineRef:
     resolver: git
     params:
@@ -61,10 +71,9 @@ spec:
     - name: pathInRepo
       value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-rhaii-validator-tools-v3-4
+    serviceAccountName: build-pipeline-odh-kserve-autogluon-server-v3-4
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
 status: {}
-

--- a/pipelineruns/kserve/.tekton/odh-kserve-llmisvc-controller-v3-4-push.yaml
+++ b/pipelineruns/kserve/.tekton/odh-kserve-llmisvc-controller-v3-4-push.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/kserve-autogluon-server?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/kserve?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
@@ -12,13 +12,12 @@ metadata:
       event == "push"
       && target_branch == "rhoai-3.4"
       && ( files.all.exists(p, !p.matches('^\\.tekton/'))
-        || ".tekton/odh-kserve-autogluon-server-v3-4-on-push.yaml".pathChanged()
-        || "Dockerfile.konflux.autogluon".pathChanged() )
+        || ".tekton/odh-kserve-llmisvc-controller-v3-4-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-4
-    appstudio.openshift.io/component: odh-kserve-autogluon-server-v3-4
+    appstudio.openshift.io/component: odh-kserve-llmisvc-controller-v3-4
     pipelines.appstudio.openshift.io/type: build
-  name: odh-kserve-autogluon-server-v3-4-on-push
+  name: odh-kserve-llmisvc-controller-v3-4-push
   namespace: rhoai-tenant
 spec:
   params:
@@ -30,37 +29,27 @@ spec:
     value:
     - '{{target_branch}}-{{revision}}'
   - name: output-image
-    value: quay.io/rhoai/odh-kserve-autogluon-server-rhel9:{{target_branch}}
+    value: quay.io/rhoai/odh-kserve-llmisvc-controller-rhel9:{{target_branch}}
   - name: rhoai-version
     value: "3.4.0"
+  - name: dockerfile
+    value: Dockerfiles/llmisvc-controller.Dockerfile.konflux
+  - name: path-context
+    value: .
+  - name: hermetic
+    value: true
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
+  - name: build-source-image
+    value: true
+  - name: build-image-index
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64
     - linux/ppc64le
     - linux/s390x
     - linux-m2xlarge/arm64
-  - name: dockerfile
-    value: ../Dockerfile.konflux.autogluon
-  - name: path-context
-    value: python
-  - name: hermetic
-    value: 'true'
-  - name: prefetch-input
-    value:
-        [
-          {
-            "type": "pip",
-            "path": "python/autogluonserver",
-            "requirements_files": [
-              "autogluon-all-requirements.txt"
-            ],
-            "binary": {"arch": ":all:"}
-          }
-        ]
-  - name: build-source-image
-    value: true
-  - name: build-image-index
-    value: true
   pipelineRef:
     resolver: git
     params:
@@ -71,7 +60,7 @@ spec:
     - name: pathInRepo
       value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-kserve-autogluon-server-v3-4
+    serviceAccountName: build-pipeline-odh-kserve-llmisvc-controller-v3-4
   workspaces:
   - name: git-auth
     secret:

--- a/pipelineruns/kserve/.tekton/odh-kserve-llmisvc-controller-v3-4-push.yaml
+++ b/pipelineruns/kserve/.tekton/odh-kserve-llmisvc-controller-v3-4-push.yaml
@@ -17,7 +17,7 @@ metadata:
     appstudio.openshift.io/application: rhoai-v3-4
     appstudio.openshift.io/component: odh-kserve-llmisvc-controller-v3-4
     pipelines.appstudio.openshift.io/type: build
-  name: odh-kserve-llmisvc-controller-v3-4-push
+  name: odh-kserve-llmisvc-controller-v3-4-on-push
   namespace: rhoai-tenant
 spec:
   params:

--- a/pipelineruns/rhaii-cluster-validation/.tekton/odh-rhaii-cluster-validator-v3-4-push.yaml
+++ b/pipelineruns/rhaii-cluster-validation/.tekton/odh-rhaii-cluster-validator-v3-4-push.yaml
@@ -16,7 +16,7 @@ metadata:
     appstudio.openshift.io/application: rhoai-v3-4
     appstudio.openshift.io/component: odh-rhaii-cluster-validator-v3-4
     pipelines.appstudio.openshift.io/type: build
-  name: odh-rhaii-cluster-validator-v3-4-push
+  name: odh-rhaii-cluster-validator-v3-4-on-push
   namespace: rhoai-tenant
 spec:
   params:

--- a/pipelineruns/rhaii-cluster-validation/.tekton/odh-rhaii-cluster-validator-v3-4-push.yaml
+++ b/pipelineruns/rhaii-cluster-validation/.tekton/odh-rhaii-cluster-validator-v3-4-push.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/kserve?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/rhaii-cluster-validation?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
@@ -11,13 +11,12 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.4"
-      && ( files.all.exists(p, !p.matches('^\\.tekton/'))
-        || ".tekton/odh-kserve-llmisvc-controller-v3-4-on-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-rhaii-cluster-validator-v3-4-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-4
-    appstudio.openshift.io/component: odh-kserve-llmisvc-controller-v3-4
+    appstudio.openshift.io/component: odh-rhaii-cluster-validator-v3-4
     pipelines.appstudio.openshift.io/type: build
-  name: odh-kserve-llmisvc-controller-v3-4-on-push
+  name: odh-rhaii-cluster-validator-v3-4-push
   namespace: rhoai-tenant
 spec:
   params:
@@ -29,17 +28,25 @@ spec:
     value:
     - '{{target_branch}}-{{revision}}'
   - name: output-image
-    value: quay.io/rhoai/odh-kserve-llmisvc-controller-rhel9:{{target_branch}}
+    value: quay.io/rhoai/odh-rhaii-cluster-validator-rhel9:{{target_branch}}
   - name: rhoai-version
     value: "3.4.0"
   - name: dockerfile
-    value: Dockerfiles/llmisvc-controller.Dockerfile.konflux
+    value: Dockerfile.konflux.cluster-validation
   - name: path-context
     value: .
   - name: hermetic
     value: true
   - name: prefetch-input
-    value: '{"type": "gomod", "path": "."}'
+    value: |
+      [{
+        "type": "gomod",
+        "path": "."
+      },
+      {
+        "type": "rpm",
+        "path": "."
+      }]
   - name: build-source-image
     value: true
   - name: build-image-index
@@ -47,9 +54,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/ppc64le
-    - linux/s390x
-    - linux-m2xlarge/arm64
+    - linux/arm64
   pipelineRef:
     resolver: git
     params:
@@ -60,9 +65,10 @@ spec:
     - name: pathInRepo
       value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-kserve-llmisvc-controller-v3-4
+    serviceAccountName: build-pipeline-odh-rhaii-cluster-validator-v3-4
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
 status: {}
+

--- a/pipelineruns/rhaii-cluster-validation/.tekton/odh-rhaii-validator-tools-v3-4-push.yaml
+++ b/pipelineruns/rhaii-cluster-validation/.tekton/odh-rhaii-validator-tools-v3-4-push.yaml
@@ -16,7 +16,7 @@ metadata:
     appstudio.openshift.io/application: rhoai-v3-4
     appstudio.openshift.io/component: odh-rhaii-validator-tools-v3-4
     pipelines.appstudio.openshift.io/type: build
-  name: odh-rhaii-validator-tools-v3-4-push
+  name: odh-rhaii-validator-tools-v3-4-on-push
   namespace: rhoai-tenant
 spec:
   params:

--- a/pipelineruns/rhaii-cluster-validation/.tekton/odh-rhaii-validator-tools-v3-4-push.yaml
+++ b/pipelineruns/rhaii-cluster-validation/.tekton/odh-rhaii-validator-tools-v3-4-push.yaml
@@ -11,12 +11,12 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.4"
-      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-rhaii-cluster-validator-v3-4-on-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-rhaii-validator-tools-v3-4-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-4
-    appstudio.openshift.io/component: odh-rhaii-cluster-validator-v3-4
+    appstudio.openshift.io/component: odh-rhaii-validator-tools-v3-4
     pipelines.appstudio.openshift.io/type: build
-  name: odh-rhaii-cluster-validator-v3-4-on-push
+  name: odh-rhaii-validator-tools-v3-4-push
   namespace: rhoai-tenant
 spec:
   params:
@@ -28,25 +28,21 @@ spec:
     value:
     - '{{target_branch}}-{{revision}}'
   - name: output-image
-    value: quay.io/rhoai/odh-rhaii-cluster-validator-rhel9:{{target_branch}}
+    value: quay.io/rhoai/odh-rhaii-validator-tools-rhel9:{{target_branch}}
   - name: rhoai-version
     value: "3.4.0"
   - name: dockerfile
-    value: Dockerfile.konflux.cluster-validation
+    value: Dockerfile.konflux.validator.tools
   - name: path-context
     value: .
   - name: hermetic
     value: true
   - name: prefetch-input
     value: |
-      [{
-        "type": "gomod",
-        "path": "."
-      },
-      {
-        "type": "rpm",
-        "path": "."
-      }]
+      [
+        {"type": "rpm", "path": "tools"},
+        {"type": "rpm", "path": "tools/builder"}
+      ]
   - name: build-source-image
     value: true
   - name: build-image-index
@@ -65,7 +61,7 @@ spec:
     - name: pathInRepo
       value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-rhaii-cluster-validator-v3-4
+    serviceAccountName: build-pipeline-odh-rhaii-validator-tools-v3-4
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
## Summary
Rename 4 pipelinerun files from `-on-push.yaml` to `-push.yaml` to match the naming convention used by all other components.

## Problem
The z-stream version bump script (`rhoai_pipelinerun_manager.sh`) searches for files matching `*v3-4-push*.yaml`, but these 4 files use `-on-push.yaml` naming which doesn't match the glob pattern. This caused the version bump to `3.4.1` to skip these components.

## What changed
- **Filenames**: renamed from `-on-push.yaml` to `-push.yaml` (so the z-stream glob matches)
- **cel expressions**: updated `.pathChanged()` references to match the new filenames
- **`metadata.name`**: kept as `-on-push` (required by PipelineRun validation rules)

## Files renamed
| Component | Old filename | New filename |
|-----------|-------------|-------------|
| kserve-autogluon-server | `odh-kserve-autogluon-server-v3-4-on-push.yaml` | `odh-kserve-autogluon-server-v3-4-push.yaml` |
| kserve | `odh-kserve-llmisvc-controller-v3-4-on-push.yaml` | `odh-kserve-llmisvc-controller-v3-4-push.yaml` |
| rhaii-cluster-validation | `odh-rhaii-cluster-validator-v3-4-on-push.yaml` | `odh-rhaii-cluster-validator-v3-4-push.yaml` |
| rhaii-cluster-validation | `odh-rhaii-validator-tools-v3-4-on-push.yaml` | `odh-rhaii-validator-tools-v3-4-push.yaml` |

## Follow-up (Step 2)
After this merges and syncs, the old `-on-push.yaml` files need to be deleted from the downstream repos:
- `red-hat-data-services/kserve-autogluon-server` — [PR #99](https://github.com/red-hat-data-services/kserve-autogluon-server/pull/99)
- `red-hat-data-services/kserve` — [PR #4361](https://github.com/red-hat-data-services/kserve/pull/4361)
- `red-hat-data-services/rhaii-cluster-validation` — [PR #81](https://github.com/red-hat-data-services/rhaii-cluster-validation/pull/81)

## Test plan
- [ ] Verify sync workflow pushes renamed files to downstream repos
- [ ] Verify z-stream version bump script picks up these files after rename
- [ ] Delete old `-on-push.yaml` files from downstream repos (step 2 PRs above)