### PR TITLE
Bump rhoai-version 3.4.0 → 3.4.1 for skipped components (rhoai-3.4)

### DIFF
--- a/pipelineruns/kserve-autogluon-server/.tekton/odh-kserve-autogluon-server-v3-4-push.yaml
+++ b/pipelineruns/kserve-autogluon-server/.tekton/odh-kserve-autogluon-server-v3-4-push.yaml
@@ -32,7 +32,7 @@ spec:
   - name: output-image
     value: quay.io/rhoai/odh-kserve-autogluon-server-rhel9:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.0"
+    value: "3.4.1"
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/kserve/.tekton/odh-kserve-llmisvc-controller-v3-4-push.yaml
+++ b/pipelineruns/kserve/.tekton/odh-kserve-llmisvc-controller-v3-4-push.yaml
@@ -31,7 +31,7 @@ spec:
   - name: output-image
     value: quay.io/rhoai/odh-kserve-llmisvc-controller-rhel9:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.0"
+    value: "3.4.1"
   - name: dockerfile
     value: Dockerfiles/llmisvc-controller.Dockerfile.konflux
   - name: path-context

--- a/pipelineruns/rhaii-cluster-validation/.tekton/odh-rhaii-cluster-validator-v3-4-push.yaml
+++ b/pipelineruns/rhaii-cluster-validation/.tekton/odh-rhaii-cluster-validator-v3-4-push.yaml
@@ -30,7 +30,7 @@ spec:
   - name: output-image
     value: quay.io/rhoai/odh-rhaii-cluster-validator-rhel9:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.0"
+    value: "3.4.1"
   - name: dockerfile
     value: Dockerfile.konflux.cluster-validation
   - name: path-context

--- a/pipelineruns/rhaii-cluster-validation/.tekton/odh-rhaii-validator-tools-v3-4-push.yaml
+++ b/pipelineruns/rhaii-cluster-validation/.tekton/odh-rhaii-validator-tools-v3-4-push.yaml
@@ -30,7 +30,7 @@ spec:
   - name: output-image
     value: quay.io/rhoai/odh-rhaii-validator-tools-rhel9:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.0"
+    value: "3.4.1"
   - name: dockerfile
     value: Dockerfile.konflux.validator.tools
   - name: path-context


### PR DESCRIPTION
## Summary
Bump `rhoai-version` from `3.4.0` to `3.4.1` for 4 components that were skipped by the z-stream version bump script due to the `-on-push` filename mismatch (fixed in PR #2259).

## Components
- `kserve-autogluon-server/odh-kserve-autogluon-server-v3-4-push.yaml`
- `kserve/odh-kserve-llmisvc-controller-v3-4-push.yaml`
- `rhaii-cluster-validation/odh-rhaii-cluster-validator-v3-4-push.yaml`
- `rhaii-cluster-validation/odh-rhaii-validator-tools-v3-4-push.yaml`

## Test plan
- [ ] Verify rhoai-version is 3.4.1 in all 4 files after merge