### PR TITLE
Cherry-pick FIPS fixes from rhoai-3.5-ea.1 into rhoai-3.3

### DIFF
--- a/.tekton/multi-arch-container-build-pull-request.yaml
+++ b/.tekton/multi-arch-container-build-pull-request.yaml
@@ -44,6 +44,9 @@ spec:
   - name: build-platforms
     value:
       - linux/amd64
+      - linux/arm64
+      - linux/s390x
+      - linux/ppc64le
   # - name: prefetch-input
   #   value: |
   #   [{"type": "gomod"}, {"type": "rpm"}]

--- a/canary-build/Dockerfile.konflux
+++ b/canary-build/Dockerfile.konflux
@@ -4,6 +4,6 @@ COPY go.mod .
 COPY main.go .
 RUN go build -o canary main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8
 COPY --from=builder /opt/app-root/src/canary /usr/local/bin/canary
 ENTRYPOINT ["canary"]

--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -696,7 +696,7 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/build-definitions.git
           - name: revision
-            value: 6660aed5c5388fade0f433c14d41c5d4e073d07a
+            value: 9eddeafc3de7e609e087f3e04010383ba3979c4f
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
       - name: evaluate-result


### PR DESCRIPTION
## Summary

Cherry-pick of #2264 from `rhoai-3.5-ea.1` into `rhoai-3.3`.

- **Update FIPS check StepAction revision** — pin to `9eddeafc` to match build-definitions
- **Update canary Dockerfile.konflux runtime image** — bumps `ubi9/ubi-minimal` from `9.5` to `9.8`
- **Fix multi-arch pipeline pull-request platforms** — adds `linux/arm64`, `linux/s390x`, and `linux/ppc64le`