### PR TITLE
Fix FIPS issues and update canary build for rhoai-2.25

### DIFF
--- a/.tekton/container-build-pull-request.yaml
+++ b/.tekton/container-build-pull-request.yaml
@@ -34,9 +34,9 @@ spec:
   - name: output-image
     value: quay.io/redhat-user-workloads/rhoai-tenant/pull-request-pipelines:konflux-central-{{revision}}
   - name: dockerfile
-    value: ./canary-build/Dockerfile.konflux
+    value: Dockerfile.konflux
   - name: path-context
-    value: .
+    value: ./canary-build
   - name: rhoai-version
     value: 2.25.2
   # - name: prefetch-input

--- a/.tekton/multi-arch-container-build-pull-request.yaml
+++ b/.tekton/multi-arch-container-build-pull-request.yaml
@@ -34,9 +34,9 @@ spec:
   - name: output-image
     value: quay.io/redhat-user-workloads/rhoai-tenant/pull-request-pipelines:konflux-central-multi-arch-{{revision}}
   - name: dockerfile
-    value: ./canary-build/Dockerfile.konflux
+    value: Dockerfile.konflux
   - name: path-context
-    value: .
+    value: ./canary-build
   - name: build-platforms
     value:
       - linux/amd64

--- a/.tekton/multi-arch-container-build-pull-request.yaml
+++ b/.tekton/multi-arch-container-build-pull-request.yaml
@@ -40,6 +40,9 @@ spec:
   - name: build-platforms
     value:
       - linux/amd64
+      - linux/arm64
+      - linux/s390x
+      - linux/ppc64le
   - name: rhoai-version
     value: 2.25.2
   # - name: prefetch-input

--- a/canary-build/Dockerfile.konflux
+++ b/canary-build/Dockerfile.konflux
@@ -1,1 +1,9 @@
-FROM registry.redhat.io/ubi8/python-312:1@sha256:3d9deabef276ff7a713f0d0f2387463eb96845170b86056fab42acf461baa827
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22 AS builder
+WORKDIR /opt/app-root/src
+COPY go.mod .
+COPY main.go .
+RUN go build -o canary main.go
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8
+COPY --from=builder /opt/app-root/src/canary /usr/local/bin/canary
+ENTRYPOINT ["canary"]

--- a/canary-build/go.mod
+++ b/canary-build/go.mod
@@ -1,0 +1,3 @@
+module canary
+
+go 1.22

--- a/canary-build/main.go
+++ b/canary-build/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("canary build ok")
+}

--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -739,7 +739,7 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/build-definitions.git
           - name: revision
-            value: 6660aed5c5388fade0f433c14d41c5d4e073d07a
+            value: 9eddeafc3de7e609e087f3e04010383ba3979c4f
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
       - name: evaluate-result


### PR DESCRIPTION
## Summary

Backport of FIPS and build fixes from `rhoai-3.5-ea.1` (#2264) into `rhoai-2.25`.

- **Update FIPS check StepAction revision** — pin to `9eddeafc` to match build-definitions
- **Fix multi-arch pipeline pull-request platforms** — adds `linux/arm64`, `linux/s390x`, and `linux/ppc64le`
- **Update canary Dockerfile.konflux** — switch from `ubi8/python-312` single-stage to `ubi9/go-toolset` + `ubi-minimal:9.8` multi-stage build, consistent with other branches
- **Add canary Go source files** — `go.mod` and `main.go` needed by the new multi-stage Dockerfile