### PR TITLE
Add sbom-syft-generate step memory overrides for ROCm components

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v2-25-push.yaml
@@ -78,14 +78,16 @@ spec:
         limits:
           cpu: '16'
           memory: 32Gi
-    - pipelineTaskName: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '2'
-          memory: 16Gi
-        limits:
-          cpu: '4'
-          memory: 32Gi
+    - pipelineTaskName: build-images
+      stepSpecs:
+        - name: sbom-syft-generate
+          computeResources:
+            requests:
+              cpu: '8'
+              memory: 16Gi
+            limits:
+              cpu: '16'
+              memory: 32Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-workbench-jupyter-minimal-rocm-py312-v2-25
   workspaces:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v2-25-push.yaml
@@ -82,14 +82,16 @@ spec:
         limits:
           cpu: '16'
           memory: 32Gi
-    - pipelineTaskName: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '2'
-          memory: 16Gi
-        limits:
-          cpu: '4'
-          memory: 32Gi
+    - pipelineTaskName: build-images
+      stepSpecs:
+        - name: sbom-syft-generate
+          computeResources:
+            requests:
+              cpu: '8'
+              memory: 16Gi
+            limits:
+              cpu: '16'
+              memory: 32Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-workbench-jupyter-pytorch-rocm-py312-v2-25
   workspaces:

--- a/pipelineruns/vllm-rocm/.tekton/odh-vllm-rocm-v2-25-push.yaml
+++ b/pipelineruns/vllm-rocm/.tekton/odh-vllm-rocm-v2-25-push.yaml
@@ -67,14 +67,16 @@ spec:
         limits:
           cpu: '16'
           memory: 32Gi
-    - pipelineTaskName: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '2'
-          memory: 16Gi
-        limits:
-          cpu: '4'
-          memory: 32Gi
+    - pipelineTaskName: build-images
+      stepSpecs:
+        - name: sbom-syft-generate
+          computeResources:
+            requests:
+              cpu: '8'
+              memory: 16Gi
+            limits:
+              cpu: '16'
+              memory: 32Gi
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Summary
- ROCm component builds (`odh-vllm-rocm`, `odh-workbench-jupyter-pytorch-rocm-py312`, `odh-workbench-jupyter-minimal-rocm-py312`) are failing on the `sbom-syft-generate` step (inside `build-images` task) due to OOM on large images (6-9 GB).
- Adds `stepSpecs` under `pipelineTaskName: build-images` with **requests: 16Gi** and **limits: 32Gi** memory for the `sbom-syft-generate` step.
- Replaces the incorrect `taskRunSpecs` approach from #2307 which used a top-level task name that doesn't exist in the multi-arch pipeline.

## Files changed
- `pipelineruns/vllm-rocm/.tekton/odh-vllm-rocm-v2-25-push.yaml`
- `pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v2-25-push.yaml`
- `pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v2-25-push.yaml`

## Test plan
- [ ] Retrigger builds for all three components after merge
- [ ] Verify `sbom-syft-generate` step completes without OOM