### PR TITLE
Increase sbom-syft-generate memory to 32Gi/64Gi for ROCm notebooks

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v2-25-push.yaml
@@ -84,10 +84,10 @@ spec:
           computeResources:
             requests:
               cpu: '8'
-              memory: 16Gi
+              memory: 32Gi
             limits:
               cpu: '16'
-              memory: 32Gi
+              memory: 64Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-workbench-jupyter-minimal-rocm-py312-v2-25
   workspaces:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v2-25-push.yaml
@@ -88,10 +88,10 @@ spec:
           computeResources:
             requests:
               cpu: '8'
-              memory: 16Gi
+              memory: 32Gi
             limits:
               cpu: '16'
-              memory: 32Gi
+              memory: 64Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-workbench-jupyter-pytorch-rocm-py312-v2-25
   workspaces:


### PR DESCRIPTION
## Summary
Increased memory resources for the sbom-syft-generate step in ROCm notebook builds.

## Changes
- **Memory requests**: 16Gi → 32Gi
- **Memory limits**: 32Gi → 64Gi

## Affected components
- odh-workbench-jupyter-minimal-rocm-py312-v2-25
- odh-workbench-jupyter-pytorch-rocm-py312-v2-25

## Related
Follow-up to PR #2308 which added increased compute resources for ROCm builds.