### PR TITLE
[rhoai-3.4] fix(notebooks): add llmcompressor PR PipelineRun with repo-root prefetch paths (rhoai-3.4)

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-pull-request.yaml
@@ -1,0 +1,111 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+# retrigger Konflux builds to fix https://issues.redhat.com/browse/RHOAIENG-31914
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|kfbuild-llmcompressor-cuda)"
+    pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-workbench, kfbuild-pytorch, kfbuild-cuda, kfbuild-jupyter, kfbuild-llmcompressor, kfbuild-workbench-jupyter-pytorch-llmcompressor-cuda]"
+    pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+  labels:
+    appstudio.openshift.io/application: automation
+    appstudio.openshift.io/component: pull-request-pipelines-notebooks
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-on-pull-request-66001
+  namespace: rhoai-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/rhoai/pull-request-pipelines:notebooks-{{revision}}
+  - name: additional-tags
+    value:
+    - '{{target_branch}}-{{revision}}'
+  - name: additional-labels
+    value:
+    - version=on-pr-{{revision}}
+    - io.openshift.tags=odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312
+  - name: dockerfile
+    value: jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
+  - name: build-args-file
+    value: jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
+  - name: path-context
+    value: .
+  - name: enable-cache-proxy
+    value: true
+  - name: hermetic
+    value: false
+  - name: build-image-index
+    value: true
+  - name: build-platforms
+    value:
+    - linux-d160-m8xlarge/amd64
+  - name: image-expires-after
+    value: 5d
+  - name: enable-slack-failure-notification
+    value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
+  - name: prefetch-input
+    value:
+    - path: prefetch-input/mongocli
+      type: gomod
+    - path: prefetch-input/rhds
+      type: rpm
+    - path: jupyter/pytorch+llmcompressor/ubi9-python-3.12
+      type: pip
+      binary:
+        arch: "x86_64,aarch64"
+      requirements_files: [requirements.cuda.txt]
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ target_branch }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+  timeouts:
+    pipeline: 8h
+    tasks: 4h
+  taskRunSpecs:
+    - pipelineTaskName: prefetch-dependencies
+      computeResources:
+        requests:
+          cpu: '3'
+          memory: 8Gi
+        limits:
+          cpu: '3'
+          memory: 8Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 16Gi
+        limits:
+          cpu: '16'
+          memory: 32Gi
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 16Gi
+        limits:
+          cpu: '16'
+          memory: 32Gi
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-pull-request-pipelines
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
## Summary

Add the missing **pull-request** PipelineRun for `odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312` to the `rhoai-3.4` release branch with **repo-root** Hermeto prefetch paths (`prefetch-input/mongocli`, `prefetch-input/rhds`).

This aligns `rhoai-3.4` with **`main`**, which has been correct since the RHAIENG-4234 / konflux-central sync work (e.g. commit `5d414ee` → notebooks `f2b8c8cb3` on `rhds/main`).

## Problem

On `notebooks` `rhoai-3.4`, Konflux Production Internal failed on PR builds for llmcompressor with:

```text
package path does not exist (or is not a directory):
jupyter/pytorch+llmcompressor/ubi9-python-3.12/prefetch-input/mongocli
```

The mongocli git submodule lives at **`prefetch-input/mongocli`** (repo root). The v3-4 **push** pipelineruns on this branch already use the correct paths; only the **PR** yaml was wrong — it was added in notebooks (`4599e1911`) and never existed here on `rhoai-3.4`.

## Verified: `main` is already fixed

On **`konflux-central` `main`** (`78ad1e248c04e67ad5e427a3a905000df4397b52`), the file already exists with correct paths:

`pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-pull-request.yaml`

```yaml
- path: prefetch-input/mongocli
  type: gomod
- path: prefetch-input/rhds
  type: rpm
```

This PR copies that definition onto **`rhoai-3.4`**, with `binary.arch: x86_64,aarch64` to match the existing v3-4 **push** pipelinerun on this branch.

## Why this branch

Component repos document that Tekton under `.tekton/` must be edited in **`konflux-central`** on the release branch (`rhoai-3.4`), then autosynced to `red-hat-data-services/notebooks`.

Today, `rhoai-3.4` here only contains **18 `*-v3-4-push.yaml`** files. Pull-request pipelineruns were maintained only in notebooks and drifted. Adding the PR yaml here establishes source-of-truth for the release line.

**Note:** Current rhods autosync to notebooks `rhoai-3.4` updates **push** yamls only. This PR still matters for documentation, future sync scope, and pairing with the notebooks cherry-pick PR.

## Companion PR

**notebooks → `rhoai-3.4`:** https://github.com/red-hat-data-services/notebooks/pull/2281 — cherry-picks `c4eb85dcf` (codeserver es5-ext; not Tekton) and `f2b8c8cb3` (llmcompressor PR yaml) on branch `fix/konflux-tier-c-cherry-picks`.

Merge order: either order is fine; both should land for a complete fix.

## Test plan

- [ ] Merge to `rhoai-3.4`
- [ ] Confirm notebooks PR #2281 merges (or future sync receives matching prefetch paths)
- [ ] Retrigger Konflux Internal **jupyter-pytorch-llmcompressor-cuda** on-push or via PR after notebooks PR merges
- [ ] KubeArchive: `prefetch-dependencies` / `step-prefetch-dependencies` completes without `InvalidInput`

## Related

- RHAIENG-4234 — centralize prefetch at repo root (`b76e061c4`)
- RHAIENG-5135 / notebooks PR #2280 investigation (Tier C)
- notebooks PR #2281


Made with [Cursor](https://cursor.com)