### PR TITLE
Add sbom-syft-generate step memory overrides for tensorflow-rocm and pytorch-rocm runtime

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v2-25-push.yaml
@@ -78,6 +78,16 @@ spec:
         limits:
           cpu: '16'
           memory: 32Gi
+    - pipelineTaskName: build-images
+      stepSpecs:
+        - name: sbom-syft-generate
+          computeResources:
+            requests:
+              cpu: '8'
+              memory: 32Gi
+            limits:
+              cpu: '16'
+              memory: 64Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-pipeline-runtime-pytorch-rocm-py312-v2-25
   workspaces:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v2-25-push.yaml
@@ -82,6 +82,16 @@ spec:
         limits:
           cpu: '16'
           memory: 32Gi
+    - pipelineTaskName: build-images
+      stepSpecs:
+        - name: sbom-syft-generate
+          computeResources:
+            requests:
+              cpu: '8'
+              memory: 32Gi
+            limits:
+              cpu: '16'
+              memory: 64Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-workbench-jupyter-tensorflow-rocm-py312-v2-25
   workspaces:


### PR DESCRIPTION
## Summary
- `odh-workbench-jupyter-tensorflow-rocm-py312-v2-25` and `odh-pipeline-runtime-pytorch-rocm-py312-v2-25` builds failing on the `sbom-syft-generate` step due to OOM on large ROCm images.
- Adds `stepSpecs` under `pipelineTaskName: build-images` with **requests: 8 CPU / 32Gi** and **limits: 16 CPU / 64Gi** for the `sbom-syft-generate` step.
- Same approach as #2308 and #2309.

## Files changed
- `pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v2-25-push.yaml`
- `pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v2-25-push.yaml`

## Test plan
- [ ] Retrigger builds for both components after merge
- [ ] Verify `sbom-syft-generate` step completes without OOM