### PR TITLE
Add pull-request pipelines for guardrails-detectors on rhoai-3.3 branch

### DIFF
--- a/pipelineruns/guardrails-detectors/.tekton/odh-built-in-detector-pull-request.yaml
+++ b/pipelineruns/guardrails-detectors/.tekton/odh-built-in-detector-pull-request.yaml
@@ -1,0 +1,71 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/guardrails-detectors?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux built-in-detector"
+    pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-built-in-detector]"
+    pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+  labels:
+    appstudio.openshift.io/application: automation
+    appstudio.openshift.io/component: pull-request-pipelines-odh-built-in-detector
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-built-in-detector-on-pull-request-93857
+  namespace: rhoai-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: additional-tags
+    value:
+    - 'pr-{{pull_request_number}}-into-{{target_branch}}'
+  - name: additional-labels
+    value:
+    - version=on-pr-{{revision}}
+    - io.openshift.tags=odh-built-in-detector
+  - name: output-image
+    value: quay.io/rhoai/pull-request-pipelines:odh-built-in-detector-{{revision}}
+  - name: rhoai-version
+    value: "3.3.3"
+  - name: dockerfile
+    value: Dockerfile.konflux.builtIn
+  - name: path-context
+    value: detectors
+  - name: hermetic
+    value: false
+  - name: build-image-index
+    value: true
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux-m2xlarge/arm64
+    - linux/s390x
+  - name: image-expires-after
+    value: 5d
+  - name: enable-slack-failure-notification
+    value: "false"
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ target_branch }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-pull-request-pipelines
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/guardrails-detectors/.tekton/odh-guardrails-detector-huggingface-runtime-pull-request.yaml
+++ b/pipelineruns/guardrails-detectors/.tekton/odh-guardrails-detector-huggingface-runtime-pull-request.yaml
@@ -1,0 +1,69 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/guardrails-detectors?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux guardrails-detector-hf-runtime"
+    pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-guardrails-detector-hf-runtime]"
+    pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+  labels:
+    appstudio.openshift.io/application: automation
+    appstudio.openshift.io/component: pull-request-pipelines-odh-guardrails-detector-hf-runtime
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-guardrails-detector-hf-runtime-on-pull-request-71493
+  namespace: rhoai-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: additional-tags
+    value:
+    - 'pr-{{pull_request_number}}-into-{{target_branch}}'
+  - name: additional-labels
+    value:
+    - version=on-pr-{{revision}}
+    - io.openshift.tags=odh-guardrails-detector-huggingface-runtime
+  - name: output-image
+    value: quay.io/rhoai/pull-request-pipelines:odh-guardrails-detector-huggingface-runtime-{{revision}}
+  - name: rhoai-version
+    value: "3.3.3"
+  - name: dockerfile
+    value: Dockerfile.konflux.hf
+  - name: path-context
+    value: detectors
+  - name: hermetic
+    value: false
+  - name: build-image-index
+    value: true
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux-m2xlarge/arm64
+    - linux/s390x
+  - name: image-expires-after
+    value: 5d
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ target_branch }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-pull-request-pipelines
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
## Introduction

I would like to trigger konflux image build pipeline on rhoai-3.3 branch to check this [PR](https://github.com/red-hat-data-services/guardrails-detectors/pull/356) for component `guardrails-detectors`

It seems like this is not currently possible; I suspect since inside `.tekton` directory there are no pull requests PipelineRun requests

Here is an attempt at adding these; I could be completely of the mark. If so please let me know

cc @alexxfan @wznoinsk @ckhordiasma 