### PR TITLE
Fix com.redhat.component label to match check-payload config.toml (rhoai-3.3)

### DIFF
--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -281,7 +281,7 @@ spec:
       - cpe=$(tasks.rhoai-init.results.cpe-id)
       - name=$(tasks.rhoai-init.results.image-namespace)/$(tasks.rhoai-init.results.image-name)
       - io.openshift.tags=$(tasks.rhoai-init.results.image-name-without-rhel-suffix)
-      - com.redhat.component=$(tasks.rhoai-init.results.konflux-component-name)
+      - com.redhat.component=$(tasks.rhoai-init.results.image-name)
       - summary=$(tasks.rhoai-init.results.display-name)
       - description=$(tasks.rhoai-init.results.display-name)
       - io.k8s.display-name=$(tasks.rhoai-init.results.display-name)


### PR DESCRIPTION
## Summary

- Use `image-name` (Brew-style, e.g. `odh-workbench-...-rhel9`) instead of `konflux-component-name` (e.g. `odh-workbench-...-v3-5-ea-1`) for the `com.redhat.component` image label in the multi-arch pipeline.

## Problem

The notebooks team submitted [check-payload PR #327](https://github.com/openshift/check-payload/pull/327) to add `ErrNotDynLinked` ignore rules for pandoc, py-spy, and ripgrep. These rules are keyed by `com.redhat.component` label value using Brew naming (e.g. `[[payload.odh-workbench-jupyter-minimal-cuda-py312-rhel9.ignore]]`).

However, the pipeline currently sets `com.redhat.component` to the Konflux component name (from `rhoai-init` result `konflux-component-name`), which has a version suffix instead of `-rhel9` (e.g. `odh-workbench-jupyter-minimal-cuda-py312-v3-5-ea-1`). The names don't match, so the ignore rules are never applied.

## Fix

Change the `LABELS` in `multi-arch-container-build.yaml` from:
```
com.redhat.component=$(tasks.rhoai-init.results.konflux-component-name)
```
to:
```
com.redhat.component=$(tasks.rhoai-init.results.image-name)
```

The `image-name` result (produced by `rhoai-init` v0.1) is the Brew-style image name (e.g. `odh-workbench-jupyter-pytorch-rocm-py312-rhel9`) which matches the config.toml keys.

## Test plan

- [ ] Verify `rhoai-init` produces the correct `image-name` result for a workbench component
- [ ] Rerun a workbench component build and confirm the `com.redhat.component` label on the built image now has the `-rhel9` suffix
- [ ] Confirm `check-payload scan local --components=<value>` now matches the config.toml ignore rules and pandoc/py-spy findings are suppressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)