### PR TITLE
hotfix: Filter push triggers for pipeline.yaml and Konflux Dockerfiles

### DIFF
--- a/pipelineruns/pipelines-components/.tekton/odh-automl-v3-4-push.yaml
+++ b/pipelineruns/pipelines-components/.tekton/odh-automl-v3-4-push.yaml
@@ -10,7 +10,12 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.4"
-      && ( files.all.exists(p, !p.matches('^\\.tekton/'))
+      && ( (files.all.exists(p, !p.matches('^\\.tekton/'))
+        && !files.all.exists(
+          p,
+          p.matches('(^|/)pipeline\\.yaml$')
+          || (p.matches('^Dockerfile\\.konflux\\.')
+          && !p.matches('^Dockerfile\\.konflux\\.automl$'))))
         || ".tekton/odh-automl-v3-4-push.yaml".pathChanged()
         || "Dockerfile.konflux.automl".pathChanged() )
   labels:

--- a/pipelineruns/pipelines-components/.tekton/odh-autorag-v3-4-push.yaml
+++ b/pipelineruns/pipelines-components/.tekton/odh-autorag-v3-4-push.yaml
@@ -10,7 +10,12 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.4"
-      && ( files.all.exists(p, !p.matches('^\\.tekton/'))
+      && ( (files.all.exists(p, !p.matches('^\\.tekton/'))
+        && !files.all.exists(
+          p,
+          p.matches('(^|/)pipeline\\.yaml$')
+          || (p.matches('^Dockerfile\\.konflux\\.')
+          && !p.matches('^Dockerfile\\.konflux\\.autorag$'))))
         || ".tekton/odh-autorag-v3-4-push.yaml".pathChanged()
         || "Dockerfile.konflux.autorag".pathChanged() )
   labels:

--- a/pipelineruns/pipelines-components/.tekton/odh-pipelines-components-v3-4-push.yaml
+++ b/pipelineruns/pipelines-components/.tekton/odh-pipelines-components-v3-4-push.yaml
@@ -10,7 +10,8 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.4"
-      && ( files.all.exists(p, !p.matches('^\\.tekton/'))
+      && ( (files.all.exists(p, !p.matches('^\\.tekton/'))
+        && !files.all.exists(p, p.matches('(^|/)pipeline\\.yaml$')))
         || ".tekton/odh-pipelines-components-v3-4-push.yaml".pathChanged()
         || "Dockerfile.konflux.pipelines-components".pathChanged() )
   labels:


### PR DESCRIPTION
Description:

Backport Tekton trigger fixes for rhoai-3.4 to reduce unnecessary push pipeline runs for:

- odh-pipelines-components-v3-4
- odh-automl-v3-4
- odh-autorag-v3-4


Updated only pipelinesascode.tekton.dev/on-cel-expression in the three *-on-push PipelineRuns:

- block runs when a commit changes only pipeline.yaml
- for automl and autorag, also block runs when a commit changes only non-target Dockerfile.konflux.* files
- keep runs enabled for each component’s own .tekton file and own target Dockerfile (Dockerfile.konflux.automl / Dockerfile.konflux.autorag / Dockerfile.konflux.pipelines-components)