### PR TITLE
Revert FIPS check blocking to enabled with new check-payload image (rhoai-2.25)

### DIFF
--- a/canary-build/Dockerfile.konflux
+++ b/canary-build/Dockerfile.konflux
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.22 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 WORKDIR /opt/app-root/src
 COPY go.mod .
 COPY main.go .

--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -118,7 +118,7 @@ spec:
     name: disable-slack-notifications
     type: string
   - name: fips-check-blocking
-    default: "false"
+    default: "true"
     type: string
     description: When true, a FIPS check-payload failure will fail the pipeline
   - name: sast-target-dirs

--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -739,7 +739,7 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/build-definitions.git
           - name: revision
-            value: 9eddeafc3de7e609e087f3e04010383ba3979c4f
+            value: c260a257876a80ae55a50927dbf03914559ecb55
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
       - name: evaluate-result

--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -710,7 +710,7 @@ spec:
         default: "true"
       steps:
       - name: prepare-image-list
-        image: quay.io/konflux-ci/konflux-test:v1.5.0@sha256:fbd5ad045b902065990218922aa6f343e8eb5fd039ecd445bc54819b8e968c3e
+        image: quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd
         env:
         - name: IMAGE_PLATFORM
           value: $(params.image-platform)


### PR DESCRIPTION
## Summary
This PR contains two related changes to fix the s390x FIPS check issues:

1. Revert `fips-check-blocking` default from `"false"` back to `"true"`
2. Update `konflux-test` image from v1.5.0 to v1.5.1 with check-payload 0.3.15

## Changes
**Global pipeline configuration (1 file):**
- `pipelines/multi-arch-container-build.yaml`:
  - Changed `fips-check-blocking` parameter default from `"false"` to `"true"` (line 121)
  - Updated `konflux-test` image from v1.5.0 to v1.5.1 (line 713)

**Image update details:**
- **Old:** `quay.io/konflux-ci/konflux-test:v1.5.0@sha256:fbd5ad045b902065990218922aa6f343e8eb5fd039ecd445bc54819b8e968c3e`
- **New:** `quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd`

## Reason
The new konflux-test v1.5.1 image includes check-payload 0.3.15, which fixes the golang s390x build failures. With this fix in place, we can re-enable blocking FIPS checks.

## Related
- Reverts: #2283
- Upstream fix: https://github.com/konflux-ci/konflux-test/pull/827 (check-payload 0.3.14 → 0.3.15)

## Test plan
- [ ] Verify multi-arch builds trigger successfully with blocking FIPS checks
- [ ] Confirm golang s390x builds pass with check-payload 0.3.15
- [ ] Validate FIPS check failures properly block the pipeline