### PR TITLE
Sync feast feature-server hermetic config (rhoai-3.5-ea.1)

### DIFF
--- a/pipelineruns/feast/.tekton/odh-feature-server-v3-5-ea-1-push.yaml
+++ b/pipelineruns/feast/.tekton/odh-feature-server-v3-5-ea-1-push.yaml
@@ -39,7 +39,34 @@ spec:
   - name: path-context
     value: sdk/python/feast/infra/feature_servers/multicloud
   - name: hermetic
-    value: false
+    value: true
+  - name: prefetch-input
+    value: |
+      [
+        {
+          "type": "pip",
+          "path": ".",
+          "requirements_files": [
+            "sdk/python/feast/infra/feature_servers/multicloud/requirements.txt",
+            "sdk/python/feast/infra/feature_servers/multicloud/requirements-ppc64le.txt",
+            "sdk/python/feast/infra/feature_servers/multicloud/requirements-ppc64le2.txt"
+          ],
+          "requirements_build_files": [
+            "sdk/python/requirements/py3.12-minimal-requirements.txt",
+            "sdk/python/requirements/py3.12-minimal-sdist-requirements.txt",
+            "sdk/python/requirements/py3.12-minimal-sdist-requirements-build.txt"
+          ],
+          "allow_binary": "true"
+        },
+        {
+          "type": "rpm",
+          "path": "sdk/python/feast/infra/feature_servers/multicloud/offline"
+        },
+        {
+          "type": "generic",
+          "path": "sdk/python/feast/infra/feature_servers/multicloud"
+        }
+      ]
   - name: build-source-image
     value: true
   - name: build-image-index


### PR DESCRIPTION
## Summary
- Set `hermetic: true` and add `prefetch-input` for feast feature-server
- The feast repo on rhoai-3.5-ea.1 already has this config, but konflux-central was not updated to match

## Test plan
- [ ] Verify the PipelineRun triggers correctly with the new parameters
- [ ] Confirm the build completes with hermetic prefetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)