### PR TITLE
Update build-definitions to e96f4c7 for check-payload 0.3.15 (rhoai-2.25)

### DIFF
--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -739,7 +739,7 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/build-definitions.git
           - name: revision
-            value: c260a257876a80ae55a50927dbf03914559ecb55
+            value: e96f4c79387f635a1a49cb3298541ab25b3ddada
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
       - name: evaluate-result


### PR DESCRIPTION
## Summary
Updates build-definitions revision from `c260a257` to `e96f4c7` to use check-payload 0.3.15 which fixes s390x golang build failures.

## Changes
- `pipelines/multi-arch-container-build.yaml`: Updated build-definitions git revision to `e96f4c79387f635a1a49cb3298541ab25b3ddada`

## Context
The previous revision `c260a257` referenced konflux-test v1.5.0 with check-payload 0.3.14, which was causing failures on s390x builds. The new revision `e96f4c7` uses konflux-test v1.5.1 with check-payload 0.3.15 that includes the fix from https://github.com/konflux-ci/konflux-test/pull/827.

## Verification
- Confirmed `c260a257` has v1.5.0: `quay.io/konflux-ci/konflux-test:v1.5.0@sha256:fbd5ad045b902065990218922aa6f343e8eb5fd039ecd445bc54819b8e968c3e`
- Confirmed `e96f4c7` has v1.5.1: `quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd`

## Links
- c260a257: https://github.com/konflux-ci/build-definitions/commit/c260a257876a80ae55a50927dbf03914559ecb55
- e96f4c7: https://github.com/konflux-ci/build-definitions/commit/e96f4c79387f635a1a49cb3298541ab25b3ddada