### PR TITLE
Increase task timeout to 6h for tensorflow-rocm pipeline

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v2-25-push.yaml
@@ -60,7 +60,7 @@ spec:
       value: pipelines/multi-arch-container-build.yaml
   timeouts:
     pipeline: 8h
-    tasks: 4h
+    tasks: 6h
   taskRunSpecs:
     - pipelineTaskName: ecosystem-cert-preflight-checks
       computeResources:


### PR DESCRIPTION
## Summary

- PipelineRun `odh-pipeline-runtime-tensorflow-rocm-py312-v2-25-on-push-4z68b` failed at `STEP-SBOM-SYFT-GENERATE` — the syft SBOM generation exceeded the 4h per-task timeout on this large ROCm image.
- Bumps `tasks` timeout from `4h` to `6h` (pipeline timeout remains `8h`).

## Test plan

- [ ] Retrigger build for `odh-pipeline-runtime-tensorflow-rocm-py312-v2-25` and confirm SBOM syft step completes within the new 6h limit