### PR TITLE
Enable refresh-rpm-lockfiles preset in default Renovate config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,7 +13,6 @@
     - name: "red-hat-data-services/training-operator"
     - name: "red-hat-data-services/trustyai-explainability"
     - name: "red-hat-data-services/data-science-pipelines-operator"
-    - name: "red-hat-data-services/model-registry"
     - name: "red-hat-data-services/model-registry-operator"
     - name: "red-hat-data-services/rest-proxy"
     - name: "red-hat-data-services/odh-model-controller"
@@ -49,6 +48,11 @@
 - renovate-config: "renovate/custom-renovate-distribution.json"
   sync-repositories:
     - name: "red-hat-data-services/RHOAI-Build-Config"
+
+- renovate-config: "renovate/rpm-refresh-renovate-distribution.json"
+  sync-repositories:
+    - name: "red-hat-data-services/model-registry"
+    - name: "red-hat-data-services/fms-guardrails-orchestrator"
 
 - renovate-config: "renovate/ogx-renovate-distribution.json"
   sync-repositories:

--- a/renovate/default-renovate.json5
+++ b/renovate/default-renovate.json5
@@ -1,8 +1,7 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-        "config:recommended",
-        "github>konflux-ci/mintmaker-presets:refresh-rpm-lockfiles"
+        "config:recommended"
     ],
     "branchPrefix": "renovate/",
     "baseBranches": ["main", "rhoai-2.16", "rhoai-2.25", "rhoai-3.3", "rhoai-3.4", "rhoai-3.5-ea.1"],

--- a/renovate/default-renovate.json5
+++ b/renovate/default-renovate.json5
@@ -1,6 +1,9 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["config:recommended"],
+    "extends": [
+        "config:recommended",
+        "github>konflux-ci/mintmaker-presets:refresh-rpm-lockfiles"
+    ],
     "branchPrefix": "renovate/",
     "baseBranches": ["main", "rhoai-2.16", "rhoai-2.25", "rhoai-3.3", "rhoai-3.4", "rhoai-3.5-ea.1"],
     "ignoreTests": true,

--- a/renovate/rpm-refresh-renovate-distribution.json
+++ b/renovate/rpm-refresh-renovate-distribution.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>red-hat-data-services/konflux-central//renovate/rpm-refresh-renovate.json5"
+  ]
+}

--- a/renovate/rpm-refresh-renovate.json5
+++ b/renovate/rpm-refresh-renovate.json5
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "github>red-hat-data-services/konflux-central//renovate/default-renovate.json5",
+        "github>konflux-ci/mintmaker-presets:refresh-rpm-lockfiles"
+    ]
+}


### PR DESCRIPTION
## Summary

- Adds `github>konflux-ci/mintmaker-presets:refresh-rpm-lockfiles` to the default Renovate config
- When MintMaker updates a Dockerfile base image digest, the RPM lockfile is now also refreshed in the same PR
- Prevents build failures caused by stale RPM lockfiles pinning old package versions that no longer exist in the updated base image (e.g., openssl-devel version mismatch)

## Context

Multiple components are currently failing because Dependabot/MintMaker updated the base image digest but the RPM lockfile still pins old versions. For example, `odh-model-registry-job-async-upload` fails with:
```
nothing provides openssl-libs(x86-64) = 1:3.5.5-2.el9_8 needed by openssl-devel-1:3.5.5-2.el9_8.x86_64
```

See [MintMaker docs](https://konflux-ci.dev/docs/mintmaker/rpm-lockfile/) and [refresh-rpm-lockfiles preset](https://github.com/konflux-ci/mintmaker-presets).

Ref: RHOAIENG-60456