### PR TITLE
Enable Renovate for llm-d-batch-gateway-operator

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -44,6 +44,7 @@
     - name: "red-hat-data-services/spark-operator"
     - name: "red-hat-data-services/llama-stack-provider-trustyai-garak"
     - name: "red-hat-data-services/agents-operator"
+    - name: "red-hat-data-services/llm-d-batch-gateway-operator"
 
 - renovate-config: "renovate/custom-renovate-distribution.json"
   sync-repositories:


### PR DESCRIPTION
Adds 'red-hat-data-services/llm-d-batch-gateway-operator' to the default Renovate distribution in config.yaml.

| Field | Value |
|-------|-------|
| Component repo | `https://github.com/red-hat-data-services/llm-d-batch-gateway-operator` |
| Renovate entry | `red-hat-data-services/llm-d-batch-gateway-operator` |
| Distribution | `renovate/default-renovate-distribution.json` |

**Jira:** https://redhat.atlassian.net/browse/RHOAIENG-66464