### PR TITLE
Enable Renovate for odh-ai-sixth-demo

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -44,6 +44,7 @@
     - name: "red-hat-data-services/spark-operator"
     - name: "red-hat-data-services/llama-stack-provider-trustyai-garak"
     - name: "red-hat-data-services/agents-operator"
+    - name: "red-hat-data-services/odh-ai-sixth-demo"
 
 - renovate-config: "renovate/custom-renovate-distribution.json"
   sync-repositories:


### PR DESCRIPTION
Adds 'red-hat-data-services/odh-ai-sixth-demo' to the default Renovate distribution in config.yaml.

## Details

| Field | Value |
|-------|-------|
| Component repo | `https://github.com/rhoai-rhtap/odh-ai-sixth-demo` |
| Renovate entry | `red-hat-data-services/odh-ai-sixth-demo` |
| Distribution | `renovate/default-renovate-distribution.json` |

**Jira:** https://redhat.atlassian.net/browse/RHOAIENG-66730