### PR TITLE
Enable Renovate for llm-d-async

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -46,6 +46,7 @@
     - name: "red-hat-data-services/agents-operator"
     - name: "red-hat-data-services/llm-d-batch-gateway-operator"
     - name: "red-hat-data-services/ai-gateway-operator"
+    - name: "red-hat-data-services/llm-d-async"
 
 - renovate-config: "renovate/custom-renovate-distribution.json"
   sync-repositories:


### PR DESCRIPTION
Adds 'red-hat-data-services/llm-d-async' to the default Renovate distribution in config.yaml.

## Details

| Field | Value |
|-------|-------|
| Component repo | `https://github.com/red-hat-data-services/llm-d-async` |
| Renovate entry | `red-hat-data-services/llm-d-async` |
| Distribution | `renovate/default-renovate-distribution.json` |

**Jira:** https://redhat.atlassian.net/browse/RHOAIENG-66511