### PR TITLE
Add odh-ai-gateway-operator pull-request PipelineRun for ai-gateway-operator

### DIFF
--- a/pipelineruns/ai-gateway-operator/.tekton/odh-ai-gateway-operator-pull-request.yaml
+++ b/pipelineruns/ai-gateway-operator/.tekton/odh-ai-gateway-operator-pull-request.yaml
@@ -1,0 +1,77 @@
+
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/ai-gateway-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-odh-ai-gateway-operator]"
+    pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+  labels:
+    appstudio.openshift.io/application: automation
+    appstudio.openshift.io/component: pull-request-pipelines-odh-ai-gateway-operator
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-ai-gateway-operator-on-pull-request-{{pull_request_number}}
+  namespace: rhoai-tenant
+spec:
+  timeouts:
+    pipeline: 8h
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: additional-tags
+    value:
+    - 'pr-{{pull_request_number}}-into-{{target_branch}}'
+  - name: additional-labels
+    value:
+    - version=on-pr-{{revision}}
+    - io.openshift.tags=odh-ai-gateway-operator
+  - name: output-image
+    value: quay.io/rhoai/pull-request-pipelines:odh-ai-gateway-operator-{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux-m2xlarge/arm64
+    - linux/ppc64le
+    - linux/s390x
+  - name: image-expires-after
+    value: 5d
+  - name: dockerfile
+    value: Containerfile.konflux
+  - name: path-context
+    value: .
+  - name: hermetic
+    value: true
+  - name: prefetch-input
+    value: |
+      [{"type": "gomod", "path": "."}]
+  - name: build-image-index
+    value: true
+  - name: enable-slack-failure-notification
+    value: "false"
+  - name: additional-build-secret
+    value: "rhel-ai-private-index-auth"
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ target_branch }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-pull-request-pipelines
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Adds Tekton pull-request PipelineRun YAML for component 'odh-ai-gateway-operator'.

## Details

| Field | Value |
|-------|-------|
| Component | `odh-ai-gateway-operator` |
| Source repo | `https://github.com/red-hat-data-services/ai-gateway-operator` |
| File | `pipelineruns/ai-gateway-operator/.tekton/odh-ai-gateway-operator-pull-request.yaml` |
| Platforms | linux/x86_64 linux-m2xlarge/arm64 linux/ppc64le linux/s390x |
| Output image | `quay.io/rhoai/pull-request-pipelines:odh-ai-gateway-operator-{{revision}}` |

**Jira:** https://redhat.atlassian.net/browse/RHOAIENG-66477