### PR TITLE
Add odh-authbridge-proxy-v3-5-ea-2 PipelineRun for agents-operator

### DIFF
--- a/pipelineruns/agents-operator/.tekton/odh-authbridge-proxy-v3-5-ea-2-push.yaml
+++ b/pipelineruns/agents-operator/.tekton/odh-authbridge-proxy-v3-5-ea-2-push.yaml
@@ -1,0 +1,69 @@
+
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/agents-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push"
+      && target_branch == "rhoai-3.5-ea.2"
+      && ( files.all.exists(p, !p.matches('^\.tekton/')) || ".tekton/odh-authbridge-proxy-v3-5-ea-2-push.yaml".pathChanged() )
+  labels:
+    appstudio.openshift.io/application: rhoai-v3-5-ea-2
+    appstudio.openshift.io/component: odh-authbridge-proxy-v3-5-ea-2
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-authbridge-proxy-v3-5-ea-2-on-push
+  namespace: rhoai-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: additional-tags
+    value:
+    - '{{target_branch}}-{{revision}}'
+  - name: output-image
+    value: quay.io/rhoai/odh-authbridge-proxy-rhel9:{{target_branch}}
+  - name: rhoai-version
+    value: "3.5.0-ea.2"
+  - name: dockerfile
+    value: cmd/authbridge-proxy/Dockerfile.konflux
+  - name: path-context
+    value: authbridge
+  - name: hermetic
+    value: true
+
+  - name: build-source-image
+    value: true
+  - name: build-image-index
+    value: true
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux-m2xlarge/arm64
+  - name: rhel-subscription-activation-key
+    value: "rhel-subscription-activation-key-nonexistent"
+  - name: additional-build-secret
+    value: "rhel-ai-private-index-auth"
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ target_branch }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-authbridge-proxy-v3-5-ea-2
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Adds Tekton PipelineRun YAML for component 'odh-authbridge-proxy'.

## Details

| Field | Value |
|-------|-------|
| Component | `odh-authbridge-proxy` |
| Version | `3.5-ea-2` |
| Branch | `rhoai-3.5-ea.2` |
| Source repo | `https://github.com/red-hat-data-services/agents-operator` |
| File | `pipelineruns/agents-operator/.tekton/odh-authbridge-proxy-v3-5-ea-2-push.yaml` |
| Platforms | linux/x86_64 linux-m2xlarge/arm64 |

**Jira:** https://redhat.atlassian.net/browse/RHOAIENG-66070