### PR TITLE
Enable Renovate for llm-d-router

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -48,6 +48,7 @@
     - name: "red-hat-data-services/ai-gateway-operator"
     - name: "red-hat-data-services/llm-d-latency-predictor"
     - name: "red-hat-data-services/llm-d-async"
+    - name: "red-hat-data-services/llm-d-router"
 
 - renovate-config: "renovate/custom-renovate-distribution.json"
   sync-repositories:


### PR DESCRIPTION
Adds 'red-hat-data-services/llm-d-router' to the default Renovate distribution in config.yaml.

| Field | Value |
|-------|-------|
| Component repo | `https://github.com/red-hat-data-services/llm-d-router` |
| Renovate entry | `red-hat-data-services/llm-d-router` |
| Distribution   | `renovate/default-renovate-distribution.json` |

**Jira:** https://redhat.atlassian.net/browse/RHOAIENG-69343