### PR TITLE
odh-autorag remove generic prefetch

### DIFF
--- a/pipelineruns/pipelines-components/.tekton/odh-autorag-on-pull-request.yaml
+++ b/pipelineruns/pipelines-components/.tekton/odh-autorag-on-pull-request.yaml
@@ -65,11 +65,6 @@ spec:
             "requirements_files": [
               "requirements-pypi.txt"
             ]
-          },
-          {
-            "type": "generic",
-            "path": "pipelines/training/autorag/documents_rag_optimization_pipeline",
-            "lockfile": "artifacts.lock.yaml"
           }
         ]
     - name: prefetch-log-level

--- a/pipelines/container-build.yaml
+++ b/pipelines/container-build.yaml
@@ -484,7 +484,7 @@ spec:
       - name: name
         value: sast-snyk-check-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:b432d2208ee01b285567e77c3db2ac9c9a9abd4756f5dd684812f50f0452ffa1
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:a70661a2d8a354367987f90c0196001e8a3f54d4f0b51dd7dd35ee063aea49ac
       - name: kind
         value: task
       resolver: bundles

--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -473,7 +473,7 @@ spec:
       - name: name
         value: sast-snyk-check-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:b432d2208ee01b285567e77c3db2ac9c9a9abd4756f5dd684812f50f0452ffa1
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:a70661a2d8a354367987f90c0196001e8a3f54d4f0b51dd7dd35ee063aea49ac
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
Removing generic prefetch in hermetic builds for odh-autorag image due to changes in image build.