### PR TITLE
odh-autorag remove generic prefetch in release branch

### DIFF
--- a/pipelineruns/pipelines-components/.tekton/odh-autorag-v3-5-ea-2-push.yaml
+++ b/pipelineruns/pipelines-components/.tekton/odh-autorag-v3-5-ea-2-push.yaml
@@ -63,11 +63,6 @@ spec:
             "requirements_files": [
               "requirements-pypi.txt"
             ]
-          },
-          {
-            "type": "generic",
-            "path": "pipelines/training/autorag/documents_rag_optimization_pipeline",
-            "lockfile": "artifacts.lock.yaml"
           }
         ]
   - name: build-source-image


### PR DESCRIPTION
Removing generic prefetch in hermetic builds for odh-autorag image due to changes in image build for release branch.