### PR TITLE
odh-autorag remove generic prefetch

### DIFF
--- a/pipelineruns/pipelines-components/.tekton/odh-autorag-on-pull-request.yaml
+++ b/pipelineruns/pipelines-components/.tekton/odh-autorag-on-pull-request.yaml
@@ -65,11 +65,6 @@ spec:
             "requirements_files": [
               "requirements-pypi.txt"
             ]
-          },
-          {
-            "type": "generic",
-            "path": "pipelines/training/autorag/documents_rag_optimization_pipeline",
-            "lockfile": "artifacts.lock.yaml"
           }
         ]
     - name: prefetch-log-level


### PR DESCRIPTION
Removing generic prefetch in hermetic builds for odh-autorag image due to changes in image build.