### PR TITLE
add hermetic changes for release 3.5-ea.2

### DIFF
--- a/pipelineruns/fms-guardrails-orchestrator/.tekton/odh-fms-guardrails-orchestrator-v3-5-ea-2-push.yaml
+++ b/pipelineruns/fms-guardrails-orchestrator/.tekton/odh-fms-guardrails-orchestrator-v3-5-ea-2-push.yaml
@@ -38,7 +38,7 @@ spec:
   - name: hermetic
     value: true
   - name: prefetch-input
-    value: '[{"type":"cargo","path":"."},{"type":"rpm","path":"."},{"type":"generic","path":"."}]'
+    value: '[{"type":"cargo","path":"."},{"type":"rpm","path":"."}]'
   - name: build-source-image
     value: true
   - name: build-image-index

--- a/pipelineruns/lm-evaluation-harness/.tekton/odh-ta-lmes-job-v3-5-ea-2-push.yaml
+++ b/pipelineruns/lm-evaluation-harness/.tekton/odh-ta-lmes-job-v3-5-ea-2-push.yaml
@@ -39,7 +39,10 @@ spec:
   - name: path-context
     value: .
   - name: hermetic
-    value: false
+    value: true
+  - name: prefetch-input
+    value: |
+      {"type": "gomod", "path": "."}
   - name: build-source-image
     value: true
   - name: build-image-index

--- a/pipelineruns/vllm-orchestrator-gateway/.tekton/odh-trustyai-vllm-orchestrator-gateway-v3-5-ea-2-push.yaml
+++ b/pipelineruns/vllm-orchestrator-gateway/.tekton/odh-trustyai-vllm-orchestrator-gateway-v3-5-ea-2-push.yaml
@@ -36,7 +36,9 @@ spec:
   - name: path-context
     value: .
   - name: hermetic
-    value: false
+    value: true
+  - name: prefetch-input
+    value: '[{"type":"cargo","path":"."},{"type":"rpm","path":"."}]'
   - name: build-source-image
     value: true
   - name: build-image-index


### PR DESCRIPTION
THis PR includes changes to make 3 pipelines hermetic for konflux central release branch, syncing work from the following 3 prs:

https://github.com/red-hat-data-services/trustyai-service-operator/pull/1840/changes
https://github.com/red-hat-data-services/fms-guardrails-orchestrator/pull/254/changes
https://github.com/red-hat-data-services/vllm-orchestrator-gateway/pull/123/changes