### PR TITLE
feat(eval-hub): add build arguments for GIT_HASH for eval-hub

### DIFF
--- a/pipelineruns/eval-hub/.tekton/odh-eval-hub-pull-request.yaml
+++ b/pipelineruns/eval-hub/.tekton/odh-eval-hub-pull-request.yaml
@@ -42,6 +42,9 @@ spec:
     - linux/ppc64le
     - linux/s390x
     - linux-m2xlarge/arm64
+  - name: build-args
+    value:
+    - GIT_HASH={{revision}}
   - name: dockerfile
     value: Dockerfile.konflux
   - name: path-context


### PR DESCRIPTION
In the eval-hub executables we want the git commit hash to be passed to the final executable. For this the [Docker.konflux[(https://github.com/red-hat-data-services/eval-hub/blob/main/Dockerfile.konflux) has a build argument [GIT_HASH](https://github.com/red-hat-data-services/eval-hub/blob/main/Dockerfile.konflux#L24).

This PR attempts to set the build_arg so that the executables have the commit set correctly.

- [ ] Note that I am assuming that `{{revision}}` is the revision of the `eval-hub` repository that is being used to build the image?