### PR TITLE
Revert "Change hermetic value to true and add prefetch-input"

### DIFF
--- a/pipelineruns/lm-evaluation-harness/.tekton/odh-ta-lmes-job-pull-request.yaml
+++ b/pipelineruns/lm-evaluation-harness/.tekton/odh-ta-lmes-job-pull-request.yaml
@@ -38,9 +38,7 @@ spec:
   - name: path-context
     value: .
   - name: hermetic
-    value: true
-  - name: prefetch-input
-    value: '{"type": "pip", "path": "."}'
+    value: false
   - name: build-image-index
     value: true
   - name: build-platforms


### PR DESCRIPTION
Reverts red-hat-data-services/konflux-central#2460

Was unaware component team had an open PR addressing this here https://github.com/red-hat-data-services/lm-evaluation-harness/pull/562