### PR TITLE
Disable rhoai-2.25 in custom-renovate.json5 for hotfix release

### DIFF
--- a/renovate/custom-renovate.json5
+++ b/renovate/custom-renovate.json5
@@ -4,8 +4,8 @@
   "branchPrefix": "renovate/",
   "baseBranches": [
     "rhoai-2.16",
-    "rhoai-2.25",
-    "rhoai-3.3",
+//    "rhoai-2.25",
+      "rhoai-3.3",
 //    "rhoai-3.4",
     "rhoai-3.5-ea.1",
     "rhoai-3.5-ea.2"

--- a/renovate/custom-renovate.json5
+++ b/renovate/custom-renovate.json5
@@ -5,7 +5,7 @@
   "baseBranches": [
     "rhoai-2.16",
 //    "rhoai-2.25",
-      "rhoai-3.3",
+    "rhoai-3.3",
 //    "rhoai-3.4",
     "rhoai-3.5-ea.1",
     "rhoai-3.5-ea.2"


### PR DESCRIPTION
Comment out rhoai-2.25 base branches in Renovate config to stop untill Hotfix release