### PR TITLE
Onboard rhoai-version to 2.25.8 across all tekton pipelines

### DIFF
--- a/pipelineruns/RHOAI-Build-Config/.tekton/odh-operator-bundle-v2-25-push.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/odh-operator-bundle-v2-25-push.yaml
@@ -43,7 +43,7 @@ spec:
   - name: build-image-index
     value: false
   - name: rhoai-version
-    value: "2.25.7"
+    value: "2.25.8"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/RHOAI-Build-Config/.tekton/odh-operator-bundle-v2-25-scheduled.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/odh-operator-bundle-v2-25-scheduled.yaml
@@ -41,7 +41,7 @@ spec:
   - name: build-image-index
     value: false
   - name: rhoai-version
-    value: "2.25.7"
+    value: "2.25.8"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v2-25-push.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v2-25-push.yaml
@@ -48,7 +48,7 @@ spec:
   - name: build-type
     value: "ci"
   - name: rhoai-version
-    value: "2.25.7"
+    value: "2.25.8"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v2-25-scheduled.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v2-25-scheduled.yaml
@@ -46,7 +46,7 @@ spec:
   - name: build-type
     value: "nightly"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "2.25.7"
+    value: "2.25.8"
   - name: workflow_url
     value: "https://github.com/red-hat-data-services/conforma-reporter/actions/workflows/conforma-reporter.yaml"
   - name: smoke_url

--- a/pipelineruns/rhods-operator/.tekton/odh-operator-v2-25-push.yaml
+++ b/pipelineruns/rhods-operator/.tekton/odh-operator-v2-25-push.yaml
@@ -31,7 +31,7 @@ spec:
     value:
     - '{{target_branch}}-{{revision}}'
   - name: rhoai-version
-    value: "2.25.7"
+    value: "2.25.8"
   - name: output-image
     value: quay.io/rhoai/odh-rhel9-operator:{{target_branch}}
   - name: build-platforms

--- a/pipelineruns/rhods-operator/.tekton/odh-operator-v2-25-scheduled.yaml
+++ b/pipelineruns/rhods-operator/.tekton/odh-operator-v2-25-scheduled.yaml
@@ -29,7 +29,7 @@ spec:
     - '{{target_branch}}-{{revision}}'
     - '{{target_branch}}-nightly'
   - name: rhoai-version
-    value: "2.25.7"
+    value: "2.25.8"
   - name: output-image
     value: quay.io/rhoai/odh-rhel9-operator:{{target_branch}}
   - name: build-platforms


### PR DESCRIPTION
## Summary
Bump `rhoai-version` from `2.25.7` to `2.25.8` across all tekton pipelines on `rhoai-2.25` branch.

## Files (6)

**RHOAI-Build-Config:**
- `odh-operator-bundle-v2-25-push.yaml`
- `odh-operator-bundle-v2-25-scheduled.yaml`
- `rhoai-fbc-fragment-v2-25-push.yaml`
- `rhoai-fbc-fragment-v2-25-scheduled.yaml`

**rhods-operator:**
- `odh-operator-v2-25-push.yaml`
- `odh-operator-v2-25-scheduled.yaml`

All changes are version bump only (`2.25.7` → `2.25.8`). No cel-expression or pipeline logic changes.

Ref: RHOAIENG-69260