### PR TITLE
Add odh-latency-predictor-training pull-request PipelineRun

### DIFF
--- a/pipelineruns/llm-d-latency-predictor/.tekton/odh-latency-predictor-training-pull-request.yaml
+++ b/pipelineruns/llm-d-latency-predictor/.tekton/odh-latency-predictor-training-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: '[{{target_branch}}]'
   labels:
     appstudio.openshift.io/application: automation
-    appstudio.openshift.io/component: odh-latency-predictor-training
+    appstudio.openshift.io/component: pull-request-pipelines-odh-latency-predictor-training
     pipelines.appstudio.openshift.io/type: build
   name: odh-latency-predictor-training-on-pull-request-{{pull_request_number}}
   namespace: rhoai-tenant
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/rhoai/odh-latency-predictor-training-rhel9:pr-{{pull_request_number}}-{{revision}}
+    value: quay.io/rhoai/pull-request-pipelines:odh-latency-predictor-training-rhel9-{{revision}}
   - name: dockerfile
     value: Dockerfile.konflux.training
   - name: path-context

--- a/pipelineruns/llm-d-latency-predictor/.tekton/odh-latency-predictor-training-pull-request.yaml
+++ b/pipelineruns/llm-d-latency-predictor/.tekton/odh-latency-predictor-training-pull-request.yaml
@@ -1,0 +1,61 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/llm-d-latency-predictor?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-event: '[pull_request]'
+    pipelinesascode.tekton.dev/on-comment: '^/build-konflux'
+    pipelinesascode.tekton.dev/on-target-branch: '[{{target_branch}}]'
+  labels:
+    appstudio.openshift.io/application: automation
+    appstudio.openshift.io/component: odh-latency-predictor-training
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-latency-predictor-training-on-pull-request-{{pull_request_number}}
+  namespace: rhoai-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/rhoai/odh-latency-predictor-training-rhel9:pr-{{pull_request_number}}-{{revision}}
+  - name: dockerfile
+    value: Dockerfile.konflux.training
+  - name: path-context
+    value: .
+  - name: image-expires-after
+    value: 5d
+  - name: enable-slack-failure-notification
+    value: "false"
+  - name: prefetch-input
+    value: |
+      [{"type": "pip", "path": "requirements.txt"}]
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux-m2xlarge/arm64
+  pipelineRef:
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ target_branch }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+    resolver: git
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-pull-request-pipelines
+    podTemplate:
+      imagePullSecrets:
+      - name: redhat-appstudio-staginguser-pull-secret
+  timeouts:
+    pipeline: 8h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'


### PR DESCRIPTION
Adds pull-request PipelineRun YAML for 'odh-latency-predictor-training'.

Component repo: https://github.com/red-hat-data-services/llm-d-latency-predictor
Jira: https://redhat.atlassian.net/browse/RHOAIENG-68940