### PR TITLE
Remove gateway-payload-processing-e2e EA2 references

### DIFF
--- a/pipelineruns/ai-gateway-payload-processing/.tekton/odh-ai-gateway-payload-processing-e2e-v3-5-on-push.yaml
+++ b/pipelineruns/ai-gateway-payload-processing/.tekton/odh-ai-gateway-payload-processing-e2e-v3-5-on-push.yaml
@@ -10,13 +10,13 @@ metadata:
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "rhoai-3.5-ea.2"
-      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-ai-gateway-payload-processing-e2e-v3-5-ea-2-on-push.yaml".pathChanged() )
+      && target_branch == "rhoai-3.5"
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-ai-gateway-payload-processing-e2e-v3-5-on-push.yaml".pathChanged() )
   labels:
-    appstudio.openshift.io/application: rhoai-v3-5-ea-2
-    appstudio.openshift.io/component: odh-ai-gateway-payload-processing-e2e-v3-5-ea-2
+    appstudio.openshift.io/application: rhoai-v3-5
+    appstudio.openshift.io/component: odh-ai-gateway-payload-processing-e2e-v3-5
     pipelines.appstudio.openshift.io/type: build
-  name: odh-ai-gateway-payload-processing-e2e-v3-5-ea-2-on-push
+  name: odh-ai-gateway-payload-processing-e2e-v3-5-on-push
   namespace: rhoai-tenant
 spec:
   params:
@@ -30,7 +30,7 @@ spec:
   - name: output-image
     value: quay.io/rhoai/odh-ai-gateway-payload-processing-e2e-rhel9:{{target_branch}}
   - name: rhoai-version
-    value: "3.5.0-ea.2"
+    value: "3.5.0"
   - name: dockerfile
     value: Dockerfile.konflux.e2e
   - name: path-context
@@ -61,7 +61,7 @@ spec:
     - name: pathInRepo
       value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-ai-gateway-payload-processing-e2e-v3-5-ea-2
+    serviceAccountName: build-pipeline-odh-ai-gateway-payload-processing-e2e-v3-5
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
This pipelineRun file in the 3.5 branch seems to have EA2 referenced in every entry a version is listed