### PR TITLE
Add odh-latency-predictor-test-v3-5 push PipelineRun

### DIFF
--- a/pipelineruns/llm-d-latency-predictor/.tekton/odh-latency-predictor-test-v3-5-push.yaml
+++ b/pipelineruns/llm-d-latency-predictor/.tekton/odh-latency-predictor-test-v3-5-push.yaml
@@ -1,0 +1,63 @@
+
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/llm-d-latency-predictor?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push"
+      && target_branch == "rhoai-3.5"
+      && ( files.all.exists(p, !p.matches('^\.tekton/')) || ".tekton/odh-latency-predictor-test-v3-5-push.yaml".pathChanged() )
+  labels:
+    appstudio.openshift.io/application: rhoai-v3-5
+    appstudio.openshift.io/component: odh-latency-predictor-test-v3-5
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-latency-predictor-test-v3-5-on-push
+  namespace: rhoai-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: additional-tags
+    value:
+    - '{{target_branch}}-{{revision}}'
+  - name: output-image
+    value: quay.io/rhoai/odh-latency-predictor-test-rhel9:{{target_branch}}
+  - name: rhoai-version
+    value: "3.5.0"
+  - name: dockerfile
+    value: Dockerfile.konflux.test
+  - name: path-context
+    value: .
+  - name: hermetic
+    value: true
+  - name: prefetch-input
+    value: |
+      [{"type": "pip", "path": "requirements.txt"}]
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux-m2xlarge/arm64
+  pipelineRef:
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ target_branch }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+    resolver: git
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-push-pipelines
+    podTemplate:
+      imagePullSecrets:
+      - name: redhat-appstudio-staginguser-pull-secret
+  timeouts:
+    pipeline: 2h

--- a/pipelineruns/llm-d-latency-predictor/.tekton/odh-latency-predictor-test-v3-5-push.yaml
+++ b/pipelineruns/llm-d-latency-predictor/.tekton/odh-latency-predictor-test-v3-5-push.yaml
@@ -40,7 +40,7 @@ spec:
     value: true
   - name: prefetch-input
     value: |
-      [{"type": "pip", "path": "requirements.txt"}]
+      [{"type": "pip", "path": "."}]
   - name: build-platforms
     value:
     - linux/x86_64
@@ -55,7 +55,7 @@ spec:
       value: pipelines/multi-arch-container-build.yaml
     resolver: git
   taskRunTemplate:
-    serviceAccountName: build-pipeline-push-pipelines
+    serviceAccountName: build-pipeline-odh-latency-predictor-test-v3-5
     podTemplate:
       imagePullSecrets:
       - name: redhat-appstudio-staginguser-pull-secret


### PR DESCRIPTION
Adds push PipelineRun YAML for 'odh-latency-predictor-test' targeting branch 'rhoai-3.5'.

Component repo: https://github.com/red-hat-data-services/llm-d-latency-predictor
Jira: https://redhat.atlassian.net/browse/RHOAIENG-68942