### PR TITLE
[RHOAIENG-61440] chore: removing python dependencies from odh-cli pipeline

### DIFF
--- a/pipelineruns/odh-cli/.tekton/odh-cli-pull-request.yaml
+++ b/pipelineruns/odh-cli/.tekton/odh-cli-pull-request.yaml
@@ -53,17 +53,6 @@ spec:
         {
           "type": "gomod",
           "path": "./yq"
-        },
-        {
-          "type": "pip",
-          "path": ".",
-          "requirements_files": [
-            "requirements.txt"
-          ],
-          "requirements_build_files": [
-            "requirements-build.txt"
-          ],
-          "binary": {}
         }
       ]
 


### PR DESCRIPTION
Removing python dependencies from the odh-cli build pipeline