### PR TITLE
Enable hermetic build for model-registry async-upload (rhoai-3.4)

### DIFF
--- a/pipelineruns/model-registry/.tekton/odh-model-registry-job-async-upload-v3-4-push.yaml
+++ b/pipelineruns/model-registry/.tekton/odh-model-registry-job-async-upload-v3-4-push.yaml
@@ -39,7 +39,7 @@ spec:
   - name: path-context
     value: ./jobs/async-upload
   - name: hermetic
-    value: false
+    value: true
   - name: prefetch-input
     value: |
       [
@@ -56,11 +56,7 @@ spec:
           "requirements_build_files": [
             "requirements-build.txt",
             "requirements-extra-build-deps.txt"
-          ],
-          "binary": {
-            "packages": ":all:",
-            "arch": "x86_64,aarch64,ppc64le,s390x"
-          }
+          ]
         }
       ]
   - name: build-source-image


### PR DESCRIPTION
## Summary

Enable hermetic build and remove binary prefetch config for `odh-model-registry-job-async-upload-v3-4` push pipeline.

## Changes

- `hermetic: false` → `hermetic: true`
- Removed `binary` block from `prefetch-input` (packages/arch no longer needed)

## Reference

Mirrors changes from: https://github.com/dkuc/model-registry/commit/880417cbfadf9af4ac5417beb3fa510f0fbf9205