### PR TITLE
RHAIENG-4981: Turn hermetic flag to true for all notebook images

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-datascience-cpu-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-datascience-cpu-py312-v3-5-push.yaml
@@ -42,7 +42,7 @@ spec:
   - name: enable-cache-proxy
     value: true
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-source-image
     value: true
   - name: build-image-index

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-minimal-cpu-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-minimal-cpu-py312-v3-5-push.yaml
@@ -42,7 +42,7 @@ spec:
   - name: enable-cache-proxy
     value: true
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-source-image
     value: true
   - name: build-image-index

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-v3-5-push.yaml
@@ -42,7 +42,7 @@ spec:
   - name: enable-cache-proxy
     value: true
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-source-image
     value: true
   - name: build-image-index

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-5-push.yaml
@@ -42,7 +42,7 @@ spec:
   - name: enable-cache-proxy
     value: true
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-source-image
     value: true
   - name: build-image-index

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v3-5-push.yaml
@@ -42,7 +42,7 @@ spec:
   - name: enable-cache-proxy
     value: true
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-source-image
     value: true
   - name: build-image-index

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-v3-5-push.yaml
@@ -42,7 +42,7 @@ spec:
   - name: enable-cache-proxy
     value: true
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-source-image
     value: true
   - name: build-image-index

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v3-5-push.yaml
@@ -42,7 +42,7 @@ spec:
   - name: enable-cache-proxy
     value: true
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-source-image
     value: true
   - name: build-image-index

--- a/pipelineruns/notebooks/.tekton/odh-wb-jupyter-pytorch-llmcompressor-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-wb-jupyter-pytorch-llmcompressor-cuda-py312-v3-5-push.yaml
@@ -29,7 +29,7 @@ spec:
   - name: enable-cache-proxy
     value: true
   - name: hermetic
-    value: false
+    value: 'true'
   - name: revision
     value: '{{revision}}'
   - name: additional-tags

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v3-5-push.yaml
@@ -43,7 +43,7 @@ spec:
     value: true
   # Hermetic: gomod (mongocli), RPM (datascience prefetch-input/rhds), pip (requirements.cpu.txt); same as odh-workbench-jupyter-datascience-cpu-py312-pull-request
   - name: hermetic
-    value: false # Set to false, pending AIPCC-7795
+    value: 'true'
   - name: build-source-image
     value: true
   - name: build-image-index

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cpu-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cpu-py312-v3-5-push.yaml
@@ -45,7 +45,7 @@ spec:
     value: true
   # Hermetic: RPMs from prefetch-input/rhds; pip from requirements.cpu.txt (see opendatahub-io/notebooks/.tekton minimal CPU PR pipeline)
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-source-image
     value: true
   - name: build-image-index

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cuda-py312-v3-5-push.yaml
@@ -45,7 +45,7 @@ spec:
     value: true
   # Hermetic: RPMs from prefetch-input/rhds; pip from requirements.cuda.txt (see opendatahub-io/notebooks/.tekton minimal CUDA PR pipeline)
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-source-image
     value: true
   - name: build-image-index

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v3-5-push.yaml
@@ -45,7 +45,7 @@ spec:
     value: true
   # Hermetic: RPMs from prefetch-input/rhds; pip from requirements.rocm.txt (see opendatahub-io/notebooks/.tekton minimal ROCm PR pipeline)
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-source-image
     value: true
   - name: build-image-index

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-v3-5-push.yaml
@@ -43,7 +43,7 @@ spec:
     value: true
   # Hermetic: gomod (mongocli), RPM (prefetch-input/rhds), pip (requirements.cuda.txt); Dockerfiles COPY prefetch-input/mongocli
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-source-image
     value: true
   - name: build-image-index

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v3-5-push.yaml
@@ -43,7 +43,7 @@ spec:
     value: true
   # Hermetic: gomod (mongocli), RPM (prefetch-input/rhds), pip (requirements.rocm.txt); Dockerfiles COPY prefetch-input/mongocli
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-source-image
     value: true
   - name: build-image-index

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v3-5-push.yaml
@@ -43,7 +43,7 @@ spec:
     value: true
   # Hermetic: gomod (mongocli), RPM (prefetch-input/rhds), pip (requirements.cuda.txt); Dockerfiles COPY prefetch-input/mongocli
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-source-image
     value: true
   - name: build-image-index

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v3-5-push.yaml
@@ -43,7 +43,7 @@ spec:
     value: true
   # Hermetic: gomod (mongocli), RPM (prefetch-input/rhds), pip (requirements.rocm.txt); Dockerfiles COPY prefetch-input/mongocli
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-source-image
     value: true
   - name: build-image-index

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-v3-5-push.yaml
@@ -43,7 +43,7 @@ spec:
     value: true
   # Hermetic: gomod (mongocli), RPM (prefetch-input/rhds), pip (requirements.cpu.txt); same pattern as odh-workbench-jupyter-datascience-cpu-py312-v3-5-push
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-source-image
     value: true
   - name: build-image-index


### PR DESCRIPTION
## Summary

- Backport of #2528 for the `rhoai-3.5` release branch
- Set `hermetic: 'true'` on all 17 notebook v3-5 push pipelines that were still `false`
- Codeserver pipeline was already hermetic and is unchanged

## Test plan

- [ ] Merge and verify sync-pipelineruns updates `red-hat-data-services/notebooks` on `rhoai-3.5`
- [ ] Trigger a notebook push build and confirm prefetch-dependencies runs with network isolation


Made with [Cursor](https://cursor.com)