### PR TITLE
Update renovate baseBranches: drop EOL branches, add rhoai-3.5

### DIFF
--- a/renovate/custom-renovate.json5
+++ b/renovate/custom-renovate.json5
@@ -3,12 +3,11 @@
   "extends": ["config:recommended"],
   "branchPrefix": "renovate/",
   "baseBranches": [
-    "rhoai-2.16",
     "rhoai-2.25",
 //    "rhoai-3.3",
     "rhoai-3.4",
-    "rhoai-3.5-ea.1",
-    "rhoai-3.5-ea.2"
+    "rhoai-3.5-ea.2",
+    "rhoai-3.5"
   ],
   "ignoreTests": true,
   "automergeType": "pr",

--- a/renovate/default-renovate.json5
+++ b/renovate/default-renovate.json5
@@ -4,7 +4,7 @@
         "config:recommended"
     ],
     "branchPrefix": "renovate/",
-    "baseBranches": ["main", "rhoai-2.16", "rhoai-2.25", "rhoai-3.3", "rhoai-3.4", "rhoai-3.5-ea.1"],
+    "baseBranches": ["main", "rhoai-2.25", "rhoai-3.3", "rhoai-3.4", "rhoai-3.5-ea.2", "rhoai-3.5"],
     "ignoreTests": true,
     "automergeType": "pr",
     "automerge": true,

--- a/renovate/pipelines-renovate.json5
+++ b/renovate/pipelines-renovate.json5
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  // Adding rhoai-3.2 because one customer has a support exception for it
-  "baseBranches": ["main", "rhoai-2.16", "rhoai-2.25", "rhoai-3.3", "rhoai-3.4", "rhoai-3.5-ea.1"],
+  "baseBranches": ["main", "rhoai-2.25", "rhoai-3.3", "rhoai-3.4", "rhoai-3.5-ea.2", "rhoai-3.5"],
   "dependencyDashboard": true,
   "prHourlyLimit": 0,
   // Manage Tekton task bundle references + custom git SHA tracking


### PR DESCRIPTION
## Summary
- Remove `rhoai-2.16`, `rhoai-3.2`, and `rhoai-3.5-ea.1` from `baseBranches` across renovate configs
- Add `rhoai-3.5-ea.2` and `rhoai-3.5` to all three configs
- Remove stale comment referencing `rhoai-3.2` in `pipelines-renovate.json5`

## Test plan
- [ ] Verify renovate runs successfully against the updated branch list

🤖 Generated with [Claude Code](https://claude.com/claude-code)