### PR TITLE
fix on-demand Renovate workflow: MintMaker config layering, grouping, and error handling

### DIFF
--- a/.github/workflows/post-renovate-dry-run-comment.yml
+++ b/.github/workflows/post-renovate-dry-run-comment.yml
@@ -1,8 +1,8 @@
-name: Post Renovate Dry Run Comment
+name: "Post PR Check: Renovate Dry Run Comment"
 
 on:
   workflow_run:
-    workflows: ["Renovate Dry Run"]
+    workflows: ["PR Check: Renovate Dry Run"]
     types:
       - completed
 

--- a/.github/workflows/renovate-dry-run.yml
+++ b/.github/workflows/renovate-dry-run.yml
@@ -110,7 +110,7 @@ jobs:
           script/run-renovate.sh \
             --repo "${{ matrix.config.repo }}" \
             --config-file "${{ matrix.config.config_file }}" \
-            --config-ref "${{ github.sha }}" \
+            --config-ref "$(git rev-parse HEAD)" \
             --image "${{ env.RENOVATE_IMAGE }}" \
             --branches '${{ toJSON(matrix.config.base_branches) }}' \
             --log-level debug \

--- a/.github/workflows/renovate-dry-run.yml
+++ b/.github/workflows/renovate-dry-run.yml
@@ -102,9 +102,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install dependencies
-        run: pip install json5
-
       - name: Run Renovate dry-run
         env:
           RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -113,6 +110,7 @@ jobs:
           script/run-renovate.sh \
             --repo "${{ matrix.config.repo }}" \
             --config-file "${{ matrix.config.config_file }}" \
+            --config-ref "${{ github.sha }}" \
             --image "${{ env.RENOVATE_IMAGE }}" \
             --branches '${{ toJSON(matrix.config.base_branches) }}' \
             --log-level debug \

--- a/.github/workflows/renovate-dry-run.yml
+++ b/.github/workflows/renovate-dry-run.yml
@@ -1,4 +1,4 @@
-name: Renovate Dry Run
+name: "PR Check: Renovate Dry Run"
 
 on:
   pull_request:
@@ -151,7 +151,7 @@ jobs:
         run: |
           {
             echo "<!-- renovate-dry-run-comment -->"
-            echo "## Renovate Dry Run Results"
+            echo "## PR Check: Renovate Dry Run Results"
             echo ""
             echo "| Repo | Config | Branches | Result |"
             echo "|------|--------|----------|--------|"

--- a/.github/workflows/renovate-dry-run.yml
+++ b/.github/workflows/renovate-dry-run.yml
@@ -102,6 +102,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install dependencies
+        run: pip install json5
+
       - name: Run Renovate dry-run
         env:
           RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/renovate-dry-run.yml
+++ b/.github/workflows/renovate-dry-run.yml
@@ -110,7 +110,7 @@ jobs:
           script/run-renovate.sh \
             --repo "${{ matrix.config.repo }}" \
             --config-file "${{ matrix.config.config_file }}" \
-            --config-ref "$(git rev-parse HEAD)" \
+            --config-ref "${{ github.sha }}" \
             --image "${{ env.RENOVATE_IMAGE }}" \
             --branches '${{ toJSON(matrix.config.base_branches) }}' \
             --log-level debug \

--- a/.github/workflows/renovate-dry-run.yml
+++ b/.github/workflows/renovate-dry-run.yml
@@ -109,6 +109,7 @@ jobs:
         env:
           RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          set -o pipefail
           script/run-renovate.sh \
             --repo "${{ matrix.config.repo }}" \
             --config-file "${{ matrix.config.config_file }}" \

--- a/.github/workflows/renovate-dry-run.yml
+++ b/.github/workflows/renovate-dry-run.yml
@@ -102,6 +102,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install dependencies
+        run: pip install json5
+
       - name: Run Renovate dry-run
         env:
           RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -110,7 +113,6 @@ jobs:
           script/run-renovate.sh \
             --repo "${{ matrix.config.repo }}" \
             --config-file "${{ matrix.config.config_file }}" \
-            --config-ref "${{ github.sha }}" \
             --image "${{ env.RENOVATE_IMAGE }}" \
             --branches '${{ toJSON(matrix.config.base_branches) }}' \
             --log-level debug \

--- a/.github/workflows/run-renovate.yml
+++ b/.github/workflows/run-renovate.yml
@@ -153,9 +153,6 @@ jobs:
         with:
           ref: ${{ github.ref_name }}
 
-      - name: Install dependencies
-        run: pip install json5
-
       - name: Run Renovate
         env:
           RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -164,6 +161,7 @@ jobs:
           script/run-renovate.sh \
             --repo "${{ matrix.config.repo }}" \
             --config-file "${{ matrix.config.config_file }}" \
+            --config-ref "${{ github.sha }}" \
             --image "${{ env.RENOVATE_IMAGE }}" \
             --branches '${{ toJSON(matrix.config.base_branches) }}' \
             --log-level "${{ inputs.log_level }}" \

--- a/.github/workflows/run-renovate.yml
+++ b/.github/workflows/run-renovate.yml
@@ -161,7 +161,7 @@ jobs:
           script/run-renovate.sh \
             --repo "${{ matrix.config.repo }}" \
             --config-file "${{ matrix.config.config_file }}" \
-            --config-ref "$(git rev-parse HEAD)" \
+            --config-ref "${{ github.sha }}" \
             --image "${{ env.RENOVATE_IMAGE }}" \
             --branches '${{ toJSON(matrix.config.base_branches) }}' \
             --log-level "${{ inputs.log_level }}" \

--- a/.github/workflows/run-renovate.yml
+++ b/.github/workflows/run-renovate.yml
@@ -161,7 +161,7 @@ jobs:
           script/run-renovate.sh \
             --repo "${{ matrix.config.repo }}" \
             --config-file "${{ matrix.config.config_file }}" \
-            --config-ref "${{ github.sha }}" \
+            --config-ref "$(git rev-parse HEAD)" \
             --image "${{ env.RENOVATE_IMAGE }}" \
             --branches '${{ toJSON(matrix.config.base_branches) }}' \
             --log-level "${{ inputs.log_level }}" \

--- a/.github/workflows/run-renovate.yml
+++ b/.github/workflows/run-renovate.yml
@@ -153,6 +153,9 @@ jobs:
         with:
           ref: ${{ github.ref_name }}
 
+      - name: Install dependencies
+        run: pip install json5
+
       - name: Run Renovate
         env:
           RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -161,7 +164,6 @@ jobs:
           script/run-renovate.sh \
             --repo "${{ matrix.config.repo }}" \
             --config-file "${{ matrix.config.config_file }}" \
-            --config-ref "${{ github.sha }}" \
             --image "${{ env.RENOVATE_IMAGE }}" \
             --branches '${{ toJSON(matrix.config.base_branches) }}' \
             --log-level "${{ inputs.log_level }}" \

--- a/.github/workflows/run-renovate.yml
+++ b/.github/workflows/run-renovate.yml
@@ -153,6 +153,9 @@ jobs:
         with:
           ref: ${{ github.ref_name }}
 
+      - name: Install dependencies
+        run: pip install json5
+
       - name: Run Renovate
         env:
           RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/run-renovate.yml
+++ b/.github/workflows/run-renovate.yml
@@ -160,6 +160,7 @@ jobs:
         env:
           RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          set -o pipefail
           script/run-renovate.sh \
             --repo "${{ matrix.config.repo }}" \
             --config-file "${{ matrix.config.config_file }}" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,9 +95,17 @@ Automates the synchronization of PipelineRun definitions to component repositori
 - Supports dry-run mode for testing without committing changes
 - Manages synchronization for all RHOAI components
 
+### Renovate Workflows
+
+On-demand and PR-triggered Renovate runs using the MintMaker image. See [docs/renovate-workflows.md](docs/renovate-workflows.md) for full documentation.
+
+- **Run Renovate** (`run-renovate.yml`) — `workflow_dispatch` for on-demand Renovate runs against any repo
+- **PR Check: Renovate Dry Run** (`renovate-dry-run.yml`) — automatic dry-run on PRs that modify renovate configs
+- **Post PR Check: Renovate Dry Run Comment** (`post-renovate-dry-run-comment.yml`) — posts dry-run results as a PR comment
+
 ### Update Repository List (`.github/workflows/update-repository-list.yml`)
 
-Maintains the list of repositories available in the sync workflow.
+Maintains the list of repositories available in the sync and Renovate workflows.
 
 ## Working with PipelineRuns
 

--- a/docs/renovate-config-layering-notes.md
+++ b/docs/renovate-config-layering-notes.md
@@ -1,0 +1,143 @@
+# Renovate Config Layering: What We Tried
+
+Notes on the various approaches attempted to replicate MintMaker's
+two-layer config stack (global admin config + repo config) in our
+on-demand Renovate workflow. Documented here for future reference
+in case Renovate's behavior changes or we need to revisit.
+
+## The Problem
+
+MintMaker (production Renovate) applies two config layers:
+1. **Global admin config** — sets `enabledManagers` (~60 managers),
+   `groupName`, `postUpgradeTasks`, `branchPrefix`, etc.
+2. **Repo config** — our source config (e.g., `pipelines-renovate.json5`)
+   overrides `enabledManagers` to just `["tekton", "custom.regex"]`
+
+Our on-demand workflow needs to replicate this. The challenge is that
+several Renovate config mechanisms behave unexpectedly when used outside
+the production MintMaker context.
+
+## What Worked
+
+**`RENOVATE_CONFIG_FILE` + `RENOVATE_EXTENDS` + `RENOVATE_FORCE`**
+
+- `RENOVATE_CONFIG_FILE` — our source config, mounted directly into the
+  container. Renovate auto-migrates deprecated fields (e.g., `fileMatch`
+  to `managerFilePatterns`).
+- `RENOVATE_EXTENDS` — MintMaker's global config as the base. Provides
+  `groupName`, `postUpgradeTasks`, `branchPrefix`, replacement rules.
+- `RENOVATE_FORCE` — overrides only `enabledManagers` and
+  `baseBranchPatterns`. Force has the highest priority in Renovate and
+  cannot be overridden by any other config layer.
+- `RENOVATE_REQUIRE_CONFIG=ignored` — prevents the repo's own
+  `.github/renovate.json` from loading (it would resolve `extends` from
+  the default branch, not the feature branch).
+
+## What Didn't Work
+
+### 1. Inline source config + extends to MintMaker in `RENOVATE_CONFIG_FILE`
+
+**Approach:** Read the source config locally, prepend MintMaker's
+`extends` reference, write as a wrapper config file.
+
+```json
+{
+  "extends": ["github>konflux-ci/mintmaker//config/renovate/renovate.json"],
+  "enabledManagers": ["tekton", "custom.regex"],
+  ...rest of source config...
+}
+```
+
+**Why it failed:** `extends` in `RENOVATE_CONFIG_FILE` are resolved at
+the repo level as an overlay that overrides the config file's own inline
+fields. MintMaker's `enabledManagers` (~60 managers) replaced our
+`["tekton", "custom.regex"]` even though inline fields should have
+higher priority than extends. This also affected `baseBranches`.
+
+### 2. Pure-extends wrapper with `github>` reference at a commit SHA
+
+**Approach:** A wrapper config with only extends — MintMaker first, our
+source config second (referenced via `github>...#sha`). No inline fields.
+
+```json
+{
+  "extends": [
+    "github>konflux-ci/mintmaker//config/renovate/renovate.json",
+    "github>red-hat-data-services/konflux-central//renovate/pipelines-renovate.json5#abc123"
+  ]
+}
+```
+
+**Why it failed:** `enabledManagers` is unmergeable, so our config (last
+in extends) correctly replaced MintMaker's. But `baseBranches` from our
+config also came through extends, overriding any inline or env var
+values. Adding `baseBranches` inline to the wrapper didn't help — extends
+override inline fields. Additionally, `github.sha` in `workflow_dispatch`
+events points to the default branch HEAD, not the feature branch.
+
+### 3. `RENOVATE_ENABLED_MANAGERS` env var
+
+**Approach:** Set `enabledManagers` via environment variable, which
+should have the highest priority.
+
+**Why it failed:** Env vars DO override config file inline fields, but
+they do NOT override values from `extends` presets that explicitly set
+the same field. Since MintMaker's extends sets `enabledManagers`, the
+env var was ignored. The same issue applied to `RENOVATE_BASE_BRANCHES`
+when `baseBranches` came through extends.
+
+Note: env vars DO work for fields that the extends don't set. For
+example, `RENOVATE_BASE_BRANCHES` worked when MintMaker was the only
+extends source (MintMaker doesn't set `baseBranches`).
+
+### 4. Full source config in `RENOVATE_FORCE`
+
+**Approach:** Put MintMaker in `RENOVATE_EXTENDS`, put our entire source
+config in `RENOVATE_FORCE`.
+
+**Why it partially failed:** Force overrides everything, so
+`enabledManagers` and `baseBranches` worked correctly. But force also
+overrides MintMaker's settings we WANT to inherit. For nested objects
+like `tekton`, our force config replaced MintMaker's entire `tekton`
+section — losing `groupName`, `postUpgradeTasks`, and other settings.
+This required duplicating all of MintMaker's tekton settings in our
+source config, which defeats the purpose of inheriting from MintMaker.
+
+### 5. `RENOVATE_REQUIRE_CONFIG=optional` (let repo config load)
+
+**Approach:** Let the repo's `.github/renovate.json` load naturally,
+providing our source config at the repo level (higher priority than
+the global admin config).
+
+**Why it partially failed:** Repo config correctly overrode MintMaker's
+global config for most fields. But the repo config resolves `extends`
+references via `github>` from the default branch (main), so feature
+branch config changes weren't picked up. Also, `baseBranches` from the
+repo config overrode the `RENOVATE_FORCE` value — force should have
+the highest priority, but `baseBranches` needed to use the migrated
+field name `baseBranchPatterns` (force bypasses config migration).
+
+## Key Takeaways
+
+- **`extends` in `RENOVATE_CONFIG_FILE` override inline fields.** This
+  is counterintuitive — normally extends are the base and inline fields
+  override them. But for config files loaded via `RENOVATE_CONFIG_FILE`,
+  resolved extends values take priority over the file's own fields.
+
+- **Env vars cannot override extends-resolved fields.** If an extends
+  preset explicitly sets a field, the env var for that field is ignored.
+  Env vars only work for fields not set by extends.
+
+- **`RENOVATE_FORCE` overrides everything but replaces entire objects.**
+  Force is the only reliable way to override extends-resolved fields.
+  But for nested objects (like `tekton`), it replaces the entire object
+  rather than merging, so you lose inherited settings.
+
+- **`RENOVATE_FORCE` bypasses config migration.** Deprecated field names
+  (e.g., `baseBranches` vs `baseBranchPatterns`, `fileMatch` vs
+  `managerFilePatterns`) must use the current names in force configs.
+  `RENOVATE_CONFIG_FILE` auto-migrates, but force does not.
+
+- **`github>` in extends always resolves from the default branch.** This
+  makes feature branch testing impossible via extends references. Mount
+  the local file via `RENOVATE_CONFIG_FILE` instead.

--- a/docs/renovate-workflows.md
+++ b/docs/renovate-workflows.md
@@ -116,32 +116,56 @@ In production, MintMaker applies two config layers:
 2. **Repo config** — the repo's own `renovate.json` (e.g., `.github/renovate.json`),
    which extends a source config from this repo (e.g., `renovate/pipelines-renovate.json5`)
 
-`run-renovate.sh` mimics this two-layer stack using two Renovate env vars:
+`run-renovate.sh` mimics this two-layer stack using three Renovate
+env vars:
 
-- **`RENOVATE_EXTENDS`** — loads MintMaker's global config as the base
-- **`RENOVATE_FORCE`** — applies our source config (read from the local
-  checkout) on top, overriding any conflicting settings
+- **`RENOVATE_CONFIG_FILE`** — our source config, mounted into the
+  container from the local checkout
+- **`RENOVATE_EXTENDS`** — loads
+  [MintMaker's global config](https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json)
+  as the base
+- **`RENOVATE_FORCE`** — overrides only the fields that conflict
+  between our config and MintMaker's
 
-`RENOVATE_FORCE` is necessary because of how Renovate's config
-hierarchy works. From lowest to highest priority:
+### Renovate Config Priority
+
+Renovate applies configuration in this order (lowest to highest priority):
 
 1. **Default config** — Renovate's built-in defaults
-2. **`extends` presets** — resolved from `RENOVATE_EXTENDS` (MintMaker's config)
-3. **Config file** (`RENOVATE_CONFIG_FILE`) — global admin config
-4. **Repo config** (`.github/renovate.json`) — disabled via `RENOVATE_REQUIRE_CONFIG=ignored`
+2. **`extends` presets** (`RENOVATE_EXTENDS`) — MintMaker's global config
+3. **Config file** (`RENOVATE_CONFIG_FILE`) — our source config
+4. **Repo config** (`.github/renovate.json`) — disabled via
+   `RENOVATE_REQUIRE_CONFIG=ignored`
 5. **`force`** (`RENOVATE_FORCE`) — overrides everything above
 
-In production MintMaker, our source config lives at the repo level (layer 4),
-which naturally overrides MintMaker's global config (layers 2-3). In our
-on-demand workflow, we skip the repo config and instead apply our source
-config via `force` (layer 5), which achieves the same override behavior.
+In production MintMaker, our source config lives at the repo level
+(layer 4), which naturally overrides MintMaker's global config
+(layers 2–3). In our on-demand workflow, our source config is at
+layer 3 (`RENOVATE_CONFIG_FILE`), which also overrides MintMaker's
+extends (layer 2) for most fields.
+
+However, `RENOVATE_CONFIG_FILE` has a quirk: when it contains
+`extends` presets, the resolved extends values override the config
+file's own inline fields. MintMaker's config sets `enabledManagers`
+to ~60 managers, and this would override our restricted list of
+`["tekton", "custom.regex"]` — even though our config file should
+have higher priority. To solve this, we use `RENOVATE_FORCE` (layer 5)
+to force only the fields that conflict:
+
+- **`enabledManagers`** — locks to our restricted manager list
+- **`baseBranchPatterns`** — limits to the branches specified via
+  `--branches` (otherwise all branches from the source config run)
+
+Everything else — `groupName`, `postUpgradeTasks`, `branchPrefix`,
+replacement rules — is inherited from MintMaker's extends without
+needing to be duplicated.
 
 ### Inherited MintMaker Settings
 
 The following settings are inherited from
 [MintMaker's global config](https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json)
-via `RENOVATE_EXTENDS`. These do not need to be duplicated in our source
-configs:
+via `RENOVATE_EXTENDS`. These do not need to be duplicated in our
+source configs:
 
 | Setting | Value | Effect |
 |---------|-------|--------|
@@ -152,6 +176,12 @@ configs:
 | `minimumReleaseAge` | `"3 days"` | Waits 3 days before proposing new releases |
 | `pruneStaleBranches` | `true` | Cleans up branches for closed/merged PRs |
 | Replacement rules | *(various)* | Migrates references from old tekton catalog locations to new ones |
+
+Note: `RENOVATE_CONFIG_FILE` goes through Renovate's normal config
+migration, so deprecated field names (e.g., `fileMatch`) are
+auto-migrated at runtime. Only `RENOVATE_FORCE` bypasses migration,
+which is why the force config uses only current field names
+(`enabledManagers`, `baseBranchPatterns`).
 
 ### Distribution Config Resolution
 
@@ -204,16 +234,38 @@ RENOVATE_TOKEN=<token> ./script/run-renovate.sh \
 | `--no-pull` | `false` | Skip pulling the image (use `--pull=never`) |
 
 The script:
-1. Reads the local source config (JSON or JSON5 via the `json5` Python
-   package) and strips `baseBranches` (controlled via `--branches`)
+1. Mounts the local source config (JSON or JSON5) into the container
+   as `RENOVATE_CONFIG_FILE`
 2. Sets `RENOVATE_EXTENDS` to load MintMaker's global config as the base
-3. Sets `RENOVATE_FORCE` to apply our source config as overrides
+3. Builds a minimal `RENOVATE_FORCE` with `enabledManagers` (from the
+   source config) and `baseBranchPatterns` (from `--branches`)
 4. Runs `podman run` with the appropriate env vars
 
-For local testing on ARM, use the upstream Renovate image:
+Requires `json5` Python package for parsing JSON5 configs.
+
+### Local Testing
+
+The MintMaker image (`quay.io/konflux-ci/mintmaker-renovate-image`)
+is x86_64 only and cannot be built on ARM (the UBI10 base image's
+`microdnf` segfaults under emulation). For local testing on ARM Macs,
+use the upstream Renovate image instead:
+
 ```bash
---image ghcr.io/renovatebot/renovate:latest --no-pull
+pip install json5  # or: uv venv .venv && source .venv/bin/activate && uv pip install json5
+
+RENOVATE_TOKEN=$(gh auth token) ./script/run-renovate.sh \
+  --repo red-hat-data-services/konflux-central \
+  --config-file renovate/pipelines-renovate.json5 \
+  --image ghcr.io/renovatebot/renovate:latest \
+  --branches '["rhoai-3.5"]' \
+  --dry-run \
+  --no-pull
 ```
+
+The upstream image has the same config resolution logic — it validates
+that `enabledManagers`, `baseBranches`, grouping, and branch naming
+all resolve correctly. It lacks the custom `rpm-lockfile` manager and
+`pipeline-migration-tool`, which only matter for live runs.
 
 ### `script/generate-renovate-matrix.py`
 

--- a/docs/renovate-workflows.md
+++ b/docs/renovate-workflows.md
@@ -121,6 +121,23 @@ runtime that `extends` MintMaker's global config, then layers the local
 source config on top. This ensures behavior matches production MintMaker
 (e.g., updates are grouped into a single PR per branch).
 
+### Inherited MintMaker Settings
+
+The following settings are inherited from
+[MintMaker's global config](https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json)
+via the `extends` mechanism. These do not need to be duplicated in our
+source configs:
+
+| Setting | Value | Effect |
+|---------|-------|--------|
+| `groupName` | `"Konflux references"` | Groups tekton task bundle updates into a single PR per branch |
+| `postUpgradeTasks` | `pipeline-migration-tool` | Runs the pipeline migration tool after task bundle updates |
+| `branchPrefix` | `"konflux/mintmaker/"` | PR branches follow `konflux/mintmaker/{baseBranch}/...` convention |
+| `additionalBranchPrefix` | `"{{baseBranch}}/"` | Adds the target branch name to the PR branch |
+| `minimumReleaseAge` | `"3 days"` | Waits 3 days before proposing new releases |
+| `pruneStaleBranches` | `true` | Cleans up branches for closed/merged PRs |
+| Replacement rules | *(various)* | Migrates references from old tekton catalog locations to new ones |
+
 **`enabledManagers` override:** `extends` in `RENOVATE_CONFIG_FILE` are
 resolved at the repo level as an overlay, which means MintMaker's
 `enabledManagers` (60+ managers) would replace our restricted list. To

--- a/docs/renovate-workflows.md
+++ b/docs/renovate-workflows.md
@@ -1,0 +1,247 @@
+# Renovate Workflows
+
+GitHub Actions workflows for running Renovate dependency updates against
+RHOAI component repositories. These complement MintMaker (the hosted
+Renovate instance in Konflux that runs on a 4-hour schedule) by providing
+on-demand runs and PR-level dry-run feedback.
+
+## Overview
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| Run Renovate | `workflow_dispatch` | On-demand Renovate runs (live or dry-run) against any repo |
+| PR Check: Renovate Dry Run | `pull_request` | Dry-run against repos affected by a config change |
+| Post PR Check: Renovate Dry Run Comment | `workflow_run` | Posts dry-run results as a PR comment |
+
+### Files
+
+| File | Purpose |
+|------|---------|
+| `.github/workflows/run-renovate.yml` | On-demand workflow |
+| `.github/workflows/renovate-dry-run.yml` | PR-triggered dry-run workflow |
+| `.github/workflows/post-renovate-dry-run-comment.yml` | Posts dry-run results as PR comment |
+| `script/run-renovate.sh` | Runs Renovate in a podman container with MintMaker config layering |
+| `script/generate-renovate-matrix.py` | Builds repo/branch matrix from `config.yaml` |
+| `script/detect-affected-renovate-repos.py` | Maps changed files to affected repos |
+| `script/extract-renovate-dry-run-results.py` | Parses Renovate JSON logs for dependency info |
+| `script/update-renovate-workflow-repository-list.py` | Maintains the repo dropdown in `run-renovate.yml` |
+
+## Run Renovate
+
+**Workflow:** `.github/workflows/run-renovate.yml`
+**Trigger:** Manual (`workflow_dispatch`) from the Actions tab
+
+### Inputs
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `repository` | choice | — | Target repo (from `config.yaml`) or `all` |
+| `branches` | string | *(empty)* | Comma-separated branch override; empty uses `baseBranches` from the renovate config |
+| `dry_run` | boolean | `true` | When true, Renovate simulates but creates no PRs |
+| `log_level` | choice | `debug` | Renovate log verbosity: debug, info, warn |
+
+### Jobs
+
+**`setup`** — Builds the matrix:
+1. Checks out the repo at the current ref (supports running from feature branches)
+2. Runs `generate-renovate-matrix.py` to map repos to configs and parse `baseBranches`
+3. Outputs a JSON matrix for the next job
+
+**`renovate`** (matrix) — Runs Renovate per repo:
+1. Creates a GitHub App token scoped to the target repo
+2. Installs `json5` (needed for config wrapper generation)
+3. Calls `run-renovate.sh` which generates a wrapper config, pulls the
+   mintmaker image, and runs Renovate
+4. Extracts PR numbers from the log, writes a step summary, and comments
+   on any created PRs with a link to the workflow run
+
+### Usage
+
+From the Actions tab:
+1. Select **Run Renovate**
+2. Pick a repository (or `all`)
+3. Optionally specify branches and change dry-run/log-level
+4. Click **Run workflow**
+
+The workflow can also be run from a feature branch — it checks out
+`github.ref_name`, so renovate configs from that branch are used.
+
+## PR Check: Renovate Dry Run
+
+**Workflow:** `.github/workflows/renovate-dry-run.yml`
+**Trigger:** Pull requests to `main` that modify:
+- `renovate/**`
+- `config.yaml`
+- `.github/renovate.json`
+
+Automatically detects which repos are affected by the config change and
+runs Renovate in dry-run mode against each one.
+
+### Jobs
+
+**`setup`** — Detects affected repos:
+1. Uses `detect-affected-renovate-repos.py` to map changed files to repos
+2. If `config.yaml` changed, all repos are affected
+3. If only specific configs changed, only repos using those configs are tested
+4. Builds the matrix via `generate-renovate-matrix.py`
+
+**`dry-run`** (matrix) — Runs Renovate dry-run per affected repo:
+1. Runs with `--dry-run --log-format json`
+2. Parses JSON logs with `extract-renovate-dry-run-results.py` to find
+   dependency updates
+3. Uploads per-repo markdown results as artifacts
+
+**`report`** — Consolidates results:
+1. Downloads all per-repo result artifacts
+2. Builds a markdown table: Repo | Config | Branches | Result
+3. Repos with updates get an expandable details section listing each
+   dependency and its affected branches
+4. Uploads the consolidated report as a `renovate-dry-run-comment` artifact
+
+### PR Comment
+
+A companion workflow (`post-renovate-dry-run-comment.yml`) posts the
+report as a PR comment. It uses the `workflow_run` trigger pattern
+(same as `post-validation-comment.yml`) so it works for fork PRs.
+
+The comment is identified by a `<!-- renovate-dry-run-comment -->` HTML
+marker and updated in place on subsequent runs.
+
+## Config Layering
+
+In production, MintMaker applies two config layers:
+1. **Global config** — [MintMaker's `renovate.json`](https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json),
+   which includes tekton task bundle grouping, branch prefix conventions,
+   post-upgrade migration tasks, and other defaults
+2. **Repo config** — the repo's own `renovate.json` (e.g., `.github/renovate.json`),
+   which extends a source config from this repo (e.g., `renovate/pipelines-renovate.json5`)
+
+`run-renovate.sh` mimics this stack by generating a wrapper config at
+runtime that `extends` MintMaker's global config, then layers the local
+source config on top. This ensures behavior matches production MintMaker
+(e.g., updates are grouped into a single PR per branch).
+
+### Distribution Config Resolution
+
+Distribution configs (e.g., `default-renovate-distribution.json`) are
+thin wrappers that `extends` a source config via a `github>` remote
+reference. The `github>` reference always resolves from the default
+branch (main), so feature branch changes wouldn't be tested.
+
+`generate-renovate-matrix.py` handles this by resolving distribution
+configs to their local source config path. This way, running the
+workflow from a feature branch uses the local version of the config.
+
+## Credentials
+
+Both workflows use a GitHub App (`APP_ID` and `PRIVATE_KEY` secrets)
+to create tokens scoped to individual target repos. Each matrix job
+creates its own token with `repositories: <short-name>`, following
+the principle of least privilege.
+
+The token is passed to Renovate via the `RENOVATE_TOKEN` environment
+variable (not a CLI argument, to avoid exposure in process listings).
+
+## Scripts
+
+### `script/run-renovate.sh`
+
+Runs Renovate in a podman container against a single repository.
+
+```bash
+RENOVATE_TOKEN=<token> ./script/run-renovate.sh \
+  --repo <org/repo> \
+  --config-file <path/to/config.json5> \
+  [--image <image>] \
+  [--branches '["main","rhoai-3.4"]'] \
+  [--dry-run] \
+  [--log-level debug] \
+  [--log-format json] \
+  [--no-pull]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--repo` | *(required)* | Target repository (e.g., `red-hat-data-services/odh-dashboard`) |
+| `--config-file` | *(required)* | Path to the Renovate config file |
+| `--image` | `quay.io/konflux-ci/mintmaker-renovate-image:latest` | Renovate container image |
+| `--branches` | `[]` | JSON array of base branches (empty = use config's `baseBranches`) |
+| `--dry-run` | `false` | Run in dry-run mode |
+| `--log-level` | `debug` | Renovate log level |
+| `--log-format` | *(unset)* | Set to `json` for structured log output |
+| `--no-pull` | `false` | Skip pulling the image (use `--pull=never`) |
+
+The script:
+1. Parses the source config (JSON or JSON5 via the `json5` Python package)
+2. Injects `extends: ["github>konflux-ci/mintmaker//config/renovate/renovate.json"]`
+   to inherit MintMaker's defaults
+3. Writes the merged config as JSON to a temp file
+4. Runs `podman run` with appropriate env vars and volume mounts
+
+### `script/generate-renovate-matrix.py`
+
+Builds the repo/branch matrix from `config.yaml`.
+
+```bash
+python3 script/generate-renovate-matrix.py \
+  --config-file config.yaml \
+  --org red-hat-data-services \
+  --repository all \
+  --branches ""
+```
+
+Outputs compact JSON to stdout, diagnostic info to stderr. Resolves
+distribution configs to source configs for feature branch testing.
+
+### `script/detect-affected-renovate-repos.py`
+
+Maps changed file paths to affected repos. Reads file paths from
+stdin or positional arguments.
+
+```bash
+echo "renovate/default-renovate.json5" | python3 script/detect-affected-renovate-repos.py
+```
+
+Outputs: `all` (if `config.yaml` changed), `none` (no renovate
+impact), or newline-separated repo short names.
+
+### `script/extract-renovate-dry-run-results.py`
+
+Parses Renovate JSON logs (from `--log-format json`) to extract
+dependency update information.
+
+```bash
+python3 script/extract-renovate-dry-run-results.py \
+  --repo odh-dashboard \
+  --config renovate/default-renovate.json5 \
+  --branches '["main","rhoai-3.5"]' \
+  --log /tmp/renovate.log \
+  --output /tmp/result.md
+```
+
+Looks for `"flattened updates found"` messages in the JSON log,
+extracts dependency names and base branches, and writes a markdown
+table row with optional expandable details.
+
+### `script/update-renovate-workflow-repository-list.py`
+
+Maintains the repository dropdown in `run-renovate.yml` from `config.yaml`.
+Called by `update-repository-list.yml` when `config.yaml` changes on `main`.
+
+```bash
+python3 script/update-renovate-workflow-repository-list.py \
+  --config-file config.yaml \
+  --workflow-file .github/workflows/run-renovate.yml
+```
+
+Uses `ruyaml` for round-trip YAML editing to preserve formatting.
+
+## Repo Dropdown Maintenance
+
+The `repository` choice list in `run-renovate.yml` is auto-maintained:
+- `update-repository-list.yml` triggers on pushes to `main` that change
+  `config.yaml` or `pipelineruns/**`
+- It runs `update-renovate-workflow-repository-list.py` to sync the
+  dropdown with repos in `config.yaml`
+- The list always includes `all` (first) and `konflux-central`, plus
+  all repos from `config.yaml`, sorted alphabetically

--- a/docs/renovate-workflows.md
+++ b/docs/renovate-workflows.md
@@ -116,17 +116,32 @@ In production, MintMaker applies two config layers:
 2. **Repo config** — the repo's own `renovate.json` (e.g., `.github/renovate.json`),
    which extends a source config from this repo (e.g., `renovate/pipelines-renovate.json5`)
 
-`run-renovate.sh` mimics this stack by generating a wrapper config at
-runtime that `extends` MintMaker's global config, then layers the local
-source config on top. This ensures behavior matches production MintMaker
-(e.g., updates are grouped into a single PR per branch).
+`run-renovate.sh` mimics this stack when `--config-ref` is provided.
+It generates a pure-extends wrapper config:
+
+```json
+{
+  "extends": [
+    "github>konflux-ci/mintmaker//config/renovate/renovate.json",
+    "github>red-hat-data-services/konflux-central//renovate/pipelines-renovate.json5#<sha>"
+  ]
+}
+```
+
+MintMaker's config is extended first, then our source config is extended
+second. Because `enabledManagers` is an unmergeable field in Renovate,
+our value replaces MintMaker's full list (~60 managers) rather than
+merging with it.
+
+Without `--config-ref`, the script uses the local config file directly
+with no MintMaker layering — useful for quick local testing.
 
 ### Inherited MintMaker Settings
 
 The following settings are inherited from
 [MintMaker's global config](https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json)
-via the `extends` mechanism. These do not need to be duplicated in our
-source configs:
+via the `extends` mechanism (when `--config-ref` is provided). These do
+not need to be duplicated in our source configs:
 
 | Setting | Value | Effect |
 |---------|-------|--------|
@@ -137,13 +152,6 @@ source configs:
 | `minimumReleaseAge` | `"3 days"` | Waits 3 days before proposing new releases |
 | `pruneStaleBranches` | `true` | Cleans up branches for closed/merged PRs |
 | Replacement rules | *(various)* | Migrates references from old tekton catalog locations to new ones |
-
-**`enabledManagers` override:** `extends` in `RENOVATE_CONFIG_FILE` are
-resolved at the repo level as an overlay, which means MintMaker's
-`enabledManagers` (60+ managers) would replace our restricted list. To
-prevent this, the script extracts `enabledManagers` from the source config
-and passes it as the `RENOVATE_ENABLED_MANAGERS` env var, which has the
-highest priority in Renovate and cannot be overridden by extends.
 
 ### Distribution Config Resolution
 
@@ -176,6 +184,7 @@ Runs Renovate in a podman container against a single repository.
 RENOVATE_TOKEN=<token> ./script/run-renovate.sh \
   --repo <org/repo> \
   --config-file <path/to/config.json5> \
+  [--config-ref <sha>] \
   [--image <image>] \
   [--branches '["main","rhoai-3.4"]'] \
   [--dry-run] \
@@ -188,6 +197,7 @@ RENOVATE_TOKEN=<token> ./script/run-renovate.sh \
 |------|---------|-------------|
 | `--repo` | *(required)* | Target repository (e.g., `red-hat-data-services/odh-dashboard`) |
 | `--config-file` | *(required)* | Path to the Renovate config file |
+| `--config-ref` | *(none)* | Git ref (SHA/branch) to fetch the config from GitHub. Enables MintMaker config layering. Omit for local-only testing |
 | `--image` | `quay.io/konflux-ci/mintmaker-renovate-image:latest` | Renovate container image |
 | `--branches` | `[]` | JSON array of base branches (empty = use config's `baseBranches`) |
 | `--dry-run` | `false` | Run in dry-run mode |
@@ -195,15 +205,13 @@ RENOVATE_TOKEN=<token> ./script/run-renovate.sh \
 | `--log-format` | *(unset)* | Set to `json` for structured log output |
 | `--no-pull` | `false` | Skip pulling the image (use `--pull=never`) |
 
-The script:
-1. Parses the source config (JSON or JSON5 via the `json5` Python package)
-2. Injects `extends: ["github>konflux-ci/mintmaker//config/renovate/renovate.json"]`
-   to inherit MintMaker's defaults
-3. Extracts `enabledManagers` from the source config and passes it as
-   `RENOVATE_ENABLED_MANAGERS` env var (prevents MintMaker's extends from
-   overriding our restricted manager list)
-4. Writes the merged config as JSON to a temp file
-5. Runs `podman run` with appropriate env vars and volume mounts
+With `--config-ref`, the script:
+1. Builds a pure-extends wrapper referencing MintMaker's global config
+   first, then the source config at the given ref second
+2. Runs `podman run` with the wrapper mounted as `RENOVATE_CONFIG_FILE`
+
+Without `--config-ref`, the script uses the local config file directly
+with no MintMaker layering.
 
 ### `script/generate-renovate-matrix.py`
 

--- a/docs/renovate-workflows.md
+++ b/docs/renovate-workflows.md
@@ -116,32 +116,32 @@ In production, MintMaker applies two config layers:
 2. **Repo config** — the repo's own `renovate.json` (e.g., `.github/renovate.json`),
    which extends a source config from this repo (e.g., `renovate/pipelines-renovate.json5`)
 
-`run-renovate.sh` mimics this stack when `--config-ref` is provided.
-It generates a pure-extends wrapper config:
+`run-renovate.sh` mimics this two-layer stack using two Renovate env vars:
 
-```json
-{
-  "extends": [
-    "github>konflux-ci/mintmaker//config/renovate/renovate.json",
-    "github>red-hat-data-services/konflux-central//renovate/pipelines-renovate.json5#<sha>"
-  ]
-}
-```
+- **`RENOVATE_EXTENDS`** — loads MintMaker's global config as the base
+- **`RENOVATE_FORCE`** — applies our source config (read from the local
+  checkout) on top, overriding any conflicting settings
 
-MintMaker's config is extended first, then our source config is extended
-second. Because `enabledManagers` is an unmergeable field in Renovate,
-our value replaces MintMaker's full list (~60 managers) rather than
-merging with it.
+`RENOVATE_FORCE` is necessary because of how Renovate's config
+hierarchy works. From lowest to highest priority:
 
-Without `--config-ref`, the script uses the local config file directly
-with no MintMaker layering — useful for quick local testing.
+1. **Default config** — Renovate's built-in defaults
+2. **`extends` presets** — resolved from `RENOVATE_EXTENDS` (MintMaker's config)
+3. **Config file** (`RENOVATE_CONFIG_FILE`) — global admin config
+4. **Repo config** (`.github/renovate.json`) — disabled via `RENOVATE_REQUIRE_CONFIG=ignored`
+5. **`force`** (`RENOVATE_FORCE`) — overrides everything above
+
+In production MintMaker, our source config lives at the repo level (layer 4),
+which naturally overrides MintMaker's global config (layers 2-3). In our
+on-demand workflow, we skip the repo config and instead apply our source
+config via `force` (layer 5), which achieves the same override behavior.
 
 ### Inherited MintMaker Settings
 
 The following settings are inherited from
 [MintMaker's global config](https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json)
-via the `extends` mechanism (when `--config-ref` is provided). These do
-not need to be duplicated in our source configs:
+via `RENOVATE_EXTENDS`. These do not need to be duplicated in our source
+configs:
 
 | Setting | Value | Effect |
 |---------|-------|--------|
@@ -184,7 +184,6 @@ Runs Renovate in a podman container against a single repository.
 RENOVATE_TOKEN=<token> ./script/run-renovate.sh \
   --repo <org/repo> \
   --config-file <path/to/config.json5> \
-  [--config-ref <sha>] \
   [--image <image>] \
   [--branches '["main","rhoai-3.4"]'] \
   [--dry-run] \
@@ -197,7 +196,6 @@ RENOVATE_TOKEN=<token> ./script/run-renovate.sh \
 |------|---------|-------------|
 | `--repo` | *(required)* | Target repository (e.g., `red-hat-data-services/odh-dashboard`) |
 | `--config-file` | *(required)* | Path to the Renovate config file |
-| `--config-ref` | *(none)* | Git ref (SHA/branch) to fetch the config from GitHub. Enables MintMaker config layering. Omit for local-only testing |
 | `--image` | `quay.io/konflux-ci/mintmaker-renovate-image:latest` | Renovate container image |
 | `--branches` | `[]` | JSON array of base branches (empty = use config's `baseBranches`) |
 | `--dry-run` | `false` | Run in dry-run mode |
@@ -205,13 +203,17 @@ RENOVATE_TOKEN=<token> ./script/run-renovate.sh \
 | `--log-format` | *(unset)* | Set to `json` for structured log output |
 | `--no-pull` | `false` | Skip pulling the image (use `--pull=never`) |
 
-With `--config-ref`, the script:
-1. Builds a pure-extends wrapper referencing MintMaker's global config
-   first, then the source config at the given ref second
-2. Runs `podman run` with the wrapper mounted as `RENOVATE_CONFIG_FILE`
+The script:
+1. Reads the local source config (JSON or JSON5 via the `json5` Python
+   package) and strips `baseBranches` (controlled via `--branches`)
+2. Sets `RENOVATE_EXTENDS` to load MintMaker's global config as the base
+3. Sets `RENOVATE_FORCE` to apply our source config as overrides
+4. Runs `podman run` with the appropriate env vars
 
-Without `--config-ref`, the script uses the local config file directly
-with no MintMaker layering.
+For local testing on ARM, use the upstream Renovate image:
+```bash
+--image ghcr.io/renovatebot/renovate:latest --no-pull
+```
 
 ### `script/generate-renovate-matrix.py`
 

--- a/docs/renovate-workflows.md
+++ b/docs/renovate-workflows.md
@@ -121,6 +121,13 @@ runtime that `extends` MintMaker's global config, then layers the local
 source config on top. This ensures behavior matches production MintMaker
 (e.g., updates are grouped into a single PR per branch).
 
+**`enabledManagers` override:** `extends` in `RENOVATE_CONFIG_FILE` are
+resolved at the repo level as an overlay, which means MintMaker's
+`enabledManagers` (60+ managers) would replace our restricted list. To
+prevent this, the script extracts `enabledManagers` from the source config
+and passes it as the `RENOVATE_ENABLED_MANAGERS` env var, which has the
+highest priority in Renovate and cannot be overridden by extends.
+
 ### Distribution Config Resolution
 
 Distribution configs (e.g., `default-renovate-distribution.json`) are
@@ -175,8 +182,11 @@ The script:
 1. Parses the source config (JSON or JSON5 via the `json5` Python package)
 2. Injects `extends: ["github>konflux-ci/mintmaker//config/renovate/renovate.json"]`
    to inherit MintMaker's defaults
-3. Writes the merged config as JSON to a temp file
-4. Runs `podman run` with appropriate env vars and volume mounts
+3. Extracts `enabledManagers` from the source config and passes it as
+   `RENOVATE_ENABLED_MANAGERS` env var (prevents MintMaker's extends from
+   overriding our restricted manager list)
+4. Writes the merged config as JSON to a temp file
+5. Runs `podman run` with appropriate env vars and volume mounts
 
 ### `script/generate-renovate-matrix.py`
 

--- a/renovate/pipelines-renovate.json5
+++ b/renovate/pipelines-renovate.json5
@@ -9,7 +9,7 @@
     {
       "schedule": ["at any time"],
       "customType": "regex",
-      "managerFilePatterns": ["pipelines/.*\\.yaml$"],
+      "managerFilePatterns": ["/pipelines/.*\\.yaml$/"],
       "matchStrings": [
         "- name: url\\s+value: https://github\\.com/(?<depName>[^.]+)\\.git\\s+- name: revision\\s+value: (?<currentDigest>[a-f0-9]+)"
       ],
@@ -34,7 +34,7 @@
   ],
   "tekton": {
     "schedule": ["at any time"],
-    "managerFilePatterns": ["\\.yaml$", "\\.yml$"],
+    "managerFilePatterns": ["/\\.yaml$/", "/\\.yml$/"],
     "includePaths": ["pipelineruns/**", "pipelines/**", "tasks/**"],
     "automerge": true,
     "packageRules": [

--- a/renovate/pipelines-renovate.json5
+++ b/renovate/pipelines-renovate.json5
@@ -21,7 +21,9 @@
   ],
   "packageRules": [
     {
+      // Group with tekton task bundle updates (MintMaker uses the same groupName)
       "matchManagers": ["custom.regex"],
+      "groupName": "Konflux references",
       "automerge": true
     },
     {

--- a/renovate/pipelines-renovate.json5
+++ b/renovate/pipelines-renovate.json5
@@ -37,6 +37,8 @@
     "managerFilePatterns": ["/\\.yaml$/", "/\\.yml$/"],
     "includePaths": ["pipelineruns/**", "pipelines/**", "tasks/**"],
     "automerge": true,
+    // Group all tekton updates into one PR per branch (matches MintMaker)
+    "groupName": "Konflux references",
     "packageRules": [
       {
         // Only allow digest (patch-level) updates — disable major/minor/pin changes

--- a/renovate/pipelines-renovate.json5
+++ b/renovate/pipelines-renovate.json5
@@ -9,7 +9,7 @@
     {
       "schedule": ["at any time"],
       "customType": "regex",
-      "managerFilePatterns": ["/pipelines/.*\\.yaml$/"],
+      "fileMatch": ["pipelines/.*\\.yaml$"],
       "matchStrings": [
         "- name: url\\s+value: https://github\\.com/(?<depName>[^.]+)\\.git\\s+- name: revision\\s+value: (?<currentDigest>[a-f0-9]+)"
       ],
@@ -34,7 +34,7 @@
   ],
   "tekton": {
     "schedule": ["at any time"],
-    "managerFilePatterns": ["/\\.yaml$/", "/\\.yml$/"],
+    "fileMatch": ["\\.yaml$", "\\.yml$"],
     "includePaths": ["pipelineruns/**", "pipelines/**", "tasks/**"],
     "automerge": true,
     // Group all tekton updates into one PR per branch (matches MintMaker)

--- a/renovate/pipelines-renovate.json5
+++ b/renovate/pipelines-renovate.json5
@@ -9,7 +9,7 @@
     {
       "schedule": ["at any time"],
       "customType": "regex",
-      "fileMatch": ["pipelines/.*\\.yaml$"],
+      "managerFilePatterns": ["pipelines/.*\\.yaml$"],
       "matchStrings": [
         "- name: url\\s+value: https://github\\.com/(?<depName>[^.]+)\\.git\\s+- name: revision\\s+value: (?<currentDigest>[a-f0-9]+)"
       ],
@@ -34,7 +34,7 @@
   ],
   "tekton": {
     "schedule": ["at any time"],
-    "fileMatch": ["\\.yaml$", "\\.yml$"],
+    "managerFilePatterns": ["\\.yaml$", "\\.yml$"],
     "includePaths": ["pipelineruns/**", "pipelines/**", "tasks/**"],
     "automerge": true,
     "packageRules": [

--- a/script/run-renovate.sh
+++ b/script/run-renovate.sh
@@ -70,27 +70,32 @@ fi
 
 CONFIG_FILE=$(realpath "$CONFIG_FILE")
 
-# MintMaker's global config is the base layer (RENOVATE_EXTENDS).
-# Our source config is applied via RENOVATE_FORCE, which overrides everything
-# including extends-resolved values. This mimics the production two-layer
-# stack: MintMaker global config (base) + repo config (override).
+# Our source config is RENOVATE_CONFIG_FILE (mounted into the container).
+# MintMaker's global config is the base via RENOVATE_EXTENDS.
+# RENOVATE_FORCE overrides only enabledManagers (MintMaker's extends sets
+# ~60 managers) and baseBranchPatterns (when --branches is provided).
 MINTMAKER_EXTENDS="github>konflux-ci/mintmaker//config/renovate/renovate.json"
 
-# Read the local source config, strip baseBranches (controlled via --branches),
-# and convert to JSON for RENOVATE_FORCE.
+# Build force config with only the fields that need overriding.
 FORCE_CONFIG=$(python3 -c "
 import json, json5, sys
 with open(sys.argv[1]) as f:
     config = json5.loads(f.read())
-config.pop('baseBranches', None)
-json.dump(config, sys.stdout)
-" "$CONFIG_FILE")
+force = {}
+if 'enabledManagers' in config:
+    force['enabledManagers'] = config['enabledManagers']
+branches = sys.argv[2]
+if branches != '[]':
+    force['baseBranchPatterns'] = json.loads(branches)
+json.dump(force, sys.stdout)
+" "$CONFIG_FILE" "$BRANCHES_JSON")
 
 # Build docker flags
 docker_flags=()
 docker_flags+=(-e "RENOVATE_TOKEN=$RENOVATE_TOKEN")
 docker_flags+=(-e "RENOVATE_REPOSITORIES=[\"$REPO\"]")
 docker_flags+=(-e "RENOVATE_REQUIRE_CONFIG=ignored")
+docker_flags+=(-e "RENOVATE_CONFIG_FILE=/tmp/renovate-config.json")
 docker_flags+=(-e "RENOVATE_EXTENDS=[\"$MINTMAKER_EXTENDS\"]")
 docker_flags+=(-e "RENOVATE_FORCE=$FORCE_CONFIG")
 docker_flags+=(-e "LOG_LEVEL=$LOG_LEVEL")
@@ -107,9 +112,7 @@ if [[ "$DRY_RUN" == "true" ]]; then
     docker_flags+=(-e "RENOVATE_DRY_RUN=full")
 fi
 
-if [[ "$BRANCHES_JSON" != "[]" && -n "$BRANCHES_JSON" ]]; then
-    docker_flags+=(-e "RENOVATE_BASE_BRANCHES=$BRANCHES_JSON")
-fi
+docker_flags+=(-v "$CONFIG_FILE:/tmp/renovate-config.json:ro")
 
 pull_policy="missing"
 if [[ "$NO_PULL" == "true" ]]; then

--- a/script/run-renovate.sh
+++ b/script/run-renovate.sh
@@ -70,19 +70,11 @@ fi
 
 CONFIG_FILE=$(realpath "$CONFIG_FILE")
 
-# MintMaker's global config is the base layer (RENOVATE_CONFIG_FILE).
+# MintMaker's global config is the base layer (RENOVATE_EXTENDS).
 # Our source config is applied via RENOVATE_FORCE, which overrides everything
 # including extends-resolved values. This mimics the production two-layer
 # stack: MintMaker global config (base) + repo config (override).
-MINTMAKER_CONFIG=$(mktemp "${TMPDIR:-/tmp}/renovate-mintmaker-XXXXXX")
-trap 'rm -f "$MINTMAKER_CONFIG"' EXIT
-
-python3 -c "
-import json, sys
-json.dump({'extends': [sys.argv[1]]}, sys.stdout, indent=2)
-" "github>konflux-ci/mintmaker//config/renovate/renovate.json" > "$MINTMAKER_CONFIG"
-
-chmod 644 "$MINTMAKER_CONFIG"
+MINTMAKER_EXTENDS="github>konflux-ci/mintmaker//config/renovate/renovate.json"
 
 # Read the local source config, strip baseBranches (controlled via --branches),
 # and convert to JSON for RENOVATE_FORCE.
@@ -99,7 +91,7 @@ docker_flags=()
 docker_flags+=(-e "RENOVATE_TOKEN=$RENOVATE_TOKEN")
 docker_flags+=(-e "RENOVATE_REPOSITORIES=[\"$REPO\"]")
 docker_flags+=(-e "RENOVATE_REQUIRE_CONFIG=ignored")
-docker_flags+=(-e "RENOVATE_CONFIG_FILE=/tmp/renovate-config.json")
+docker_flags+=(-e "RENOVATE_EXTENDS=[\"$MINTMAKER_EXTENDS\"]")
 docker_flags+=(-e "RENOVATE_FORCE=$FORCE_CONFIG")
 docker_flags+=(-e "LOG_LEVEL=$LOG_LEVEL")
 docker_flags+=(-e "RENOVATE_PR_HOURLY_LIMIT=20")
@@ -118,8 +110,6 @@ fi
 if [[ "$BRANCHES_JSON" != "[]" && -n "$BRANCHES_JSON" ]]; then
     docker_flags+=(-e "RENOVATE_BASE_BRANCHES=$BRANCHES_JSON")
 fi
-
-docker_flags+=(-v "$MINTMAKER_CONFIG:/tmp/renovate-config.json:ro")
 
 pull_policy="missing"
 if [[ "$NO_PULL" == "true" ]]; then

--- a/script/run-renovate.sh
+++ b/script/run-renovate.sh
@@ -91,6 +91,12 @@ config['extends'] = extends
 json.dump(config, sys.stdout, indent=2)
 " "$CONFIG_FILE" "$MINTMAKER_EXTENDS" > "$WRAPPER_CONFIG"
 
+if [[ ! -s "$WRAPPER_CONFIG" ]]; then
+    echo "error: failed to generate wrapper config" >&2
+    exit 1
+fi
+chmod 644 "$WRAPPER_CONFIG"
+
 # Build docker flags
 docker_flags=()
 docker_flags+=(-e "RENOVATE_TOKEN=$RENOVATE_TOKEN")
@@ -121,7 +127,4 @@ if [[ "$NO_PULL" == "true" ]]; then
     pull_policy="never"
 fi
 
-# Allow Renovate to exit non-zero without failing the script (it can exit
-# non-zero for non-fatal reasons like rate limiting or partial failures)
-set +e
 podman run --rm --pull="$pull_policy" --platform linux/amd64 "${docker_flags[@]}" "$IMAGE" renovate

--- a/script/run-renovate.sh
+++ b/script/run-renovate.sh
@@ -97,6 +97,20 @@ if [[ ! -s "$WRAPPER_CONFIG" ]]; then
 fi
 chmod 644 "$WRAPPER_CONFIG"
 
+# Extract enabledManagers from the source config and pass as an env var.
+# Env vars have the highest priority in Renovate and cannot be overridden by
+# extends presets. This is necessary because extends in RENOVATE_CONFIG_FILE
+# are resolved at the repo level as an overlay, which would otherwise replace
+# our enabledManagers with MintMaker's full list (~60 managers).
+ENABLED_MANAGERS=$(python3 -c "
+import json, json5, sys
+with open(sys.argv[1]) as f:
+    config = json5.loads(f.read())
+managers = config.get('enabledManagers', [])
+if managers:
+    print(json.dumps(managers))
+" "$CONFIG_FILE")
+
 # Build docker flags
 docker_flags=()
 docker_flags+=(-e "RENOVATE_TOKEN=$RENOVATE_TOKEN")
@@ -104,6 +118,10 @@ docker_flags+=(-e "RENOVATE_REPOSITORIES=[\"$REPO\"]")
 docker_flags+=(-e "RENOVATE_REQUIRE_CONFIG=ignored")
 docker_flags+=(-e "RENOVATE_CONFIG_FILE=/tmp/renovate-config.json")
 docker_flags+=(-e "LOG_LEVEL=$LOG_LEVEL")
+
+if [[ -n "$ENABLED_MANAGERS" ]]; then
+    docker_flags+=(-e "RENOVATE_ENABLED_MANAGERS=$ENABLED_MANAGERS")
+fi
 docker_flags+=(-e "RENOVATE_PR_HOURLY_LIMIT=20")
 docker_flags+=(-e "RENOVATE_BRANCH_CONCURRENT_LIMIT=20")
 docker_flags+=(-e "RENOVATE_RECREATE_WHEN=always")

--- a/script/run-renovate.sh
+++ b/script/run-renovate.sh
@@ -116,11 +116,12 @@ fi
 
 docker_flags+=(-v "$WRAPPER_CONFIG:/tmp/renovate-config.json:ro")
 
-# Run Renovate
-set +e
 pull_policy="missing"
 if [[ "$NO_PULL" == "true" ]]; then
     pull_policy="never"
 fi
 
+# Allow Renovate to exit non-zero without failing the script (it can exit
+# non-zero for non-fatal reasons like rate limiting or partial failures)
+set +e
 podman run --rm --pull="$pull_policy" --platform linux/amd64 "${docker_flags[@]}" "$IMAGE" renovate

--- a/script/run-renovate.sh
+++ b/script/run-renovate.sh
@@ -70,35 +70,29 @@ fi
 
 CONFIG_FILE=$(realpath "$CONFIG_FILE")
 
-WRAPPER_CONFIG=$(mktemp /tmp/renovate-wrapper-XXXXX.json)
-trap 'rm -f "$WRAPPER_CONFIG"' EXIT
+# MintMaker's global config is the base layer (RENOVATE_CONFIG_FILE).
+# Our source config is applied via RENOVATE_FORCE, which overrides everything
+# including extends-resolved values. This mimics the production two-layer
+# stack: MintMaker global config (base) + repo config (override).
+MINTMAKER_CONFIG=$(mktemp /tmp/renovate-mintmaker-XXXXX.json)
+trap 'rm -f "$MINTMAKER_CONFIG"' EXIT
 
-MINTMAKER_EXTENDS="github>konflux-ci/mintmaker//config/renovate/renovate.json"
-
-# Read the local source config, strip baseBranches (will be controlled via
-# env var or --branches), prepend MintMaker's extends, and write as JSON.
-# Extends in RENOVATE_CONFIG_FILE override inline fields, so baseBranches
-# must not come through the extends chain.
 python3 -c "
-import json, json5, sys
+import json, sys
+json.dump({'extends': [sys.argv[1]]}, sys.stdout, indent=2)
+" "github>konflux-ci/mintmaker//config/renovate/renovate.json" > "$MINTMAKER_CONFIG"
 
+chmod 644 "$MINTMAKER_CONFIG"
+
+# Read the local source config, strip baseBranches (controlled via --branches),
+# and convert to JSON for RENOVATE_FORCE.
+FORCE_CONFIG=$(python3 -c "
+import json, json5, sys
 with open(sys.argv[1]) as f:
     config = json5.loads(f.read())
-
 config.pop('baseBranches', None)
-
-extends = config.get('extends', [])
-extends.insert(0, sys.argv[2])
-config['extends'] = extends
-
-branches = sys.argv[3]
-if branches != '[]':
-    config['baseBranches'] = json.loads(branches)
-
-json.dump(config, sys.stdout, indent=2)
-" "$CONFIG_FILE" "$MINTMAKER_EXTENDS" "$BRANCHES_JSON" > "$WRAPPER_CONFIG"
-
-chmod 644 "$WRAPPER_CONFIG"
+json.dump(config, sys.stdout)
+" "$CONFIG_FILE")
 
 # Build docker flags
 docker_flags=()
@@ -106,6 +100,7 @@ docker_flags+=(-e "RENOVATE_TOKEN=$RENOVATE_TOKEN")
 docker_flags+=(-e "RENOVATE_REPOSITORIES=[\"$REPO\"]")
 docker_flags+=(-e "RENOVATE_REQUIRE_CONFIG=ignored")
 docker_flags+=(-e "RENOVATE_CONFIG_FILE=/tmp/renovate-config.json")
+docker_flags+=(-e "RENOVATE_FORCE=$FORCE_CONFIG")
 docker_flags+=(-e "LOG_LEVEL=$LOG_LEVEL")
 docker_flags+=(-e "RENOVATE_PR_HOURLY_LIMIT=20")
 docker_flags+=(-e "RENOVATE_BRANCH_CONCURRENT_LIMIT=20")
@@ -124,7 +119,7 @@ if [[ "$BRANCHES_JSON" != "[]" && -n "$BRANCHES_JSON" ]]; then
     docker_flags+=(-e "RENOVATE_BASE_BRANCHES=$BRANCHES_JSON")
 fi
 
-docker_flags+=(-v "$WRAPPER_CONFIG:/tmp/renovate-config.json:ro")
+docker_flags+=(-v "$MINTMAKER_CONFIG:/tmp/renovate-config.json:ro")
 
 pull_policy="missing"
 if [[ "$NO_PULL" == "true" ]]; then

--- a/script/run-renovate.sh
+++ b/script/run-renovate.sh
@@ -70,6 +70,34 @@ fi
 
 CONFIG_FILE=$(realpath "$CONFIG_FILE")
 
+# Create a wrapper config that extends MintMaker's global defaults, then layers
+# our source config on top. This mimics production MintMaker's config stack:
+# MintMaker global config -> repo-level config (our source config).
+MINTMAKER_EXTENDS="github>konflux-ci/mintmaker//config/renovate/renovate.json"
+WRAPPER_CONFIG=$(mktemp /tmp/renovate-wrapper-XXXXX.json)
+trap 'rm -f "$WRAPPER_CONFIG"' EXIT
+
+python3 -c "
+import json, re, sys
+
+with open(sys.argv[1]) as f:
+    raw = f.read()
+
+try:
+    import json5
+    config = json5.loads(raw)
+except ImportError:
+    cleaned = re.sub(r'//.*$', '', raw, flags=re.MULTILINE)
+    cleaned = re.sub(r',\s*([}\]])', r'\1', cleaned)
+    config = json.loads(cleaned)
+
+extends = config.get('extends', [])
+extends.insert(0, sys.argv[2])
+config['extends'] = extends
+
+json.dump(config, sys.stdout, indent=2)
+" "$CONFIG_FILE" "$MINTMAKER_EXTENDS" > "$WRAPPER_CONFIG"
+
 # Build docker flags
 docker_flags=()
 docker_flags+=(-e "RENOVATE_TOKEN=$RENOVATE_TOKEN")
@@ -93,7 +121,7 @@ if [[ "$BRANCHES_JSON" != "[]" && -n "$BRANCHES_JSON" ]]; then
     docker_flags+=(-e "RENOVATE_BASE_BRANCHES=$BRANCHES_JSON")
 fi
 
-docker_flags+=(-v "$CONFIG_FILE:/tmp/renovate-config.json:ro")
+docker_flags+=(-v "$WRAPPER_CONFIG:/tmp/renovate-config.json:ro")
 
 # Run Renovate
 set +e

--- a/script/run-renovate.sh
+++ b/script/run-renovate.sh
@@ -24,7 +24,6 @@ LOG_FORMAT=""
 BRANCHES_JSON="[]"
 IMAGE="quay.io/konflux-ci/mintmaker-renovate-image:latest"
 NO_PULL=false
-CONFIG_REF=""
 
 usage() {
     echo "Usage: RENOVATE_TOKEN=<token> $0 --repo ORG/REPO --config-file PATH [options]"
@@ -39,7 +38,6 @@ usage() {
     echo "Optional:"
     echo "  --image          Renovate container image (default: $IMAGE)"
     echo "  --branches       JSON array of base branches (default: use config's baseBranches)"
-    echo "  --config-ref     Git ref (SHA/branch) for the config file (default: HEAD)"
     echo "  --dry-run        Run in dry-run mode (no PRs created)"
     echo "  --log-level      Renovate log level: debug, info, warn (default: debug)"
     exit 1
@@ -53,7 +51,6 @@ while [[ $# -gt 0 ]]; do
         --branches)     BRANCHES_JSON="$2"; shift 2 ;;
         --dry-run)      DRY_RUN=true; shift ;;
         --log-level)    LOG_LEVEL="$2"; shift 2 ;;
-        --config-ref)   CONFIG_REF="$2"; shift 2 ;;
         --log-format)   LOG_FORMAT="$2"; shift 2 ;;
         --no-pull)      NO_PULL=true; shift ;;
         -h|--help)      usage ;;
@@ -76,28 +73,30 @@ CONFIG_FILE=$(realpath "$CONFIG_FILE")
 WRAPPER_CONFIG=$(mktemp /tmp/renovate-wrapper-XXXXX.json)
 trap 'rm -f "$WRAPPER_CONFIG"' EXIT
 
-if [[ -n "$CONFIG_REF" ]]; then
-    # Config is pushed to GitHub — build a pure-extends wrapper that layers
-    # MintMaker's global config first, then our source config second. Our
-    # config comes last so its unmergeable fields (like enabledManagers)
-    # replace MintMaker's values.
-    REPO_ROOT=$(git rev-parse --show-toplevel)
-    CONFIG_REL_PATH=$(realpath --relative-to="$REPO_ROOT" "$CONFIG_FILE")
-    CONFIG_REPO=$(git remote get-url origin | sed -E 's|.*github\.com[:/]||; s|\.git$||')
-    SOURCE_EXTENDS="github>${CONFIG_REPO}//${CONFIG_REL_PATH}#${CONFIG_REF}"
-    MINTMAKER_EXTENDS="github>konflux-ci/mintmaker//config/renovate/renovate.json"
+MINTMAKER_EXTENDS="github>konflux-ci/mintmaker//config/renovate/renovate.json"
 
-    python3 -c "
-import json, sys
-config = {'extends': [sys.argv[1], sys.argv[2]]}
-if sys.argv[3] != '[]':
-    config['baseBranches'] = json.loads(sys.argv[3])
+# Read the local source config, strip baseBranches (will be controlled via
+# env var or --branches), prepend MintMaker's extends, and write as JSON.
+# Extends in RENOVATE_CONFIG_FILE override inline fields, so baseBranches
+# must not come through the extends chain.
+python3 -c "
+import json, json5, sys
+
+with open(sys.argv[1]) as f:
+    config = json5.loads(f.read())
+
+config.pop('baseBranches', None)
+
+extends = config.get('extends', [])
+extends.insert(0, sys.argv[2])
+config['extends'] = extends
+
+branches = sys.argv[3]
+if branches != '[]':
+    config['baseBranches'] = json.loads(branches)
+
 json.dump(config, sys.stdout, indent=2)
-" "$MINTMAKER_EXTENDS" "$SOURCE_EXTENDS" "$BRANCHES_JSON" > "$WRAPPER_CONFIG"
-else
-    # No ref — use the local config file directly (no MintMaker layering).
-    cp "$CONFIG_FILE" "$WRAPPER_CONFIG"
-fi
+" "$CONFIG_FILE" "$MINTMAKER_EXTENDS" "$BRANCHES_JSON" > "$WRAPPER_CONFIG"
 
 chmod 644 "$WRAPPER_CONFIG"
 
@@ -121,7 +120,7 @@ if [[ "$DRY_RUN" == "true" ]]; then
     docker_flags+=(-e "RENOVATE_DRY_RUN=full")
 fi
 
-if [[ -z "$CONFIG_REF" && "$BRANCHES_JSON" != "[]" && -n "$BRANCHES_JSON" ]]; then
+if [[ "$BRANCHES_JSON" != "[]" && -n "$BRANCHES_JSON" ]]; then
     docker_flags+=(-e "RENOVATE_BASE_BRANCHES=$BRANCHES_JSON")
 fi
 

--- a/script/run-renovate.sh
+++ b/script/run-renovate.sh
@@ -125,6 +125,7 @@ fi
 docker_flags+=(-e "RENOVATE_PR_HOURLY_LIMIT=20")
 docker_flags+=(-e "RENOVATE_BRANCH_CONCURRENT_LIMIT=20")
 docker_flags+=(-e "RENOVATE_RECREATE_WHEN=always")
+docker_flags+=(-e "RENOVATE_DEPENDENCY_DASHBOARD=false")
 
 if [[ -n "$LOG_FORMAT" ]]; then
     docker_flags+=(-e "LOG_FORMAT=$LOG_FORMAT")

--- a/script/run-renovate.sh
+++ b/script/run-renovate.sh
@@ -78,18 +78,11 @@ WRAPPER_CONFIG=$(mktemp /tmp/renovate-wrapper-XXXXX.json)
 trap 'rm -f "$WRAPPER_CONFIG"' EXIT
 
 python3 -c "
-import json, re, sys
+import json, sys
+import json5
 
 with open(sys.argv[1]) as f:
-    raw = f.read()
-
-try:
-    import json5
-    config = json5.loads(raw)
-except ImportError:
-    cleaned = re.sub(r'//.*$', '', raw, flags=re.MULTILINE)
-    cleaned = re.sub(r',\s*([}\]])', r'\1', cleaned)
-    config = json.loads(cleaned)
+    config = json5.loads(f.read())
 
 extends = config.get('extends', [])
 extends.insert(0, sys.argv[2])

--- a/script/run-renovate.sh
+++ b/script/run-renovate.sh
@@ -89,8 +89,11 @@ if [[ -n "$CONFIG_REF" ]]; then
 
     python3 -c "
 import json, sys
-json.dump({'extends': [sys.argv[1], sys.argv[2]]}, sys.stdout, indent=2)
-" "$MINTMAKER_EXTENDS" "$SOURCE_EXTENDS" > "$WRAPPER_CONFIG"
+config = {'extends': [sys.argv[1], sys.argv[2]]}
+if sys.argv[3] != '[]':
+    config['baseBranches'] = json.loads(sys.argv[3])
+json.dump(config, sys.stdout, indent=2)
+" "$MINTMAKER_EXTENDS" "$SOURCE_EXTENDS" "$BRANCHES_JSON" > "$WRAPPER_CONFIG"
 else
     # No ref — use the local config file directly (no MintMaker layering).
     cp "$CONFIG_FILE" "$WRAPPER_CONFIG"
@@ -118,7 +121,7 @@ if [[ "$DRY_RUN" == "true" ]]; then
     docker_flags+=(-e "RENOVATE_DRY_RUN=full")
 fi
 
-if [[ "$BRANCHES_JSON" != "[]" && -n "$BRANCHES_JSON" ]]; then
+if [[ -z "$CONFIG_REF" && "$BRANCHES_JSON" != "[]" && -n "$BRANCHES_JSON" ]]; then
     docker_flags+=(-e "RENOVATE_BASE_BRANCHES=$BRANCHES_JSON")
 fi
 

--- a/script/run-renovate.sh
+++ b/script/run-renovate.sh
@@ -74,7 +74,7 @@ CONFIG_FILE=$(realpath "$CONFIG_FILE")
 # Our source config is applied via RENOVATE_FORCE, which overrides everything
 # including extends-resolved values. This mimics the production two-layer
 # stack: MintMaker global config (base) + repo config (override).
-MINTMAKER_CONFIG=$(mktemp /tmp/renovate-mintmaker-XXXXX.json)
+MINTMAKER_CONFIG=$(mktemp "${TMPDIR:-/tmp}/renovate-mintmaker-XXXXXX")
 trap 'rm -f "$MINTMAKER_CONFIG"' EXIT
 
 python3 -c "
@@ -126,4 +126,4 @@ if [[ "$NO_PULL" == "true" ]]; then
     pull_policy="never"
 fi
 
-podman run --rm --pull="$pull_policy" --platform linux/amd64 "${docker_flags[@]}" "$IMAGE" renovate
+podman run --rm --pull="$pull_policy" "${docker_flags[@]}" "$IMAGE" renovate

--- a/script/run-renovate.sh
+++ b/script/run-renovate.sh
@@ -24,6 +24,7 @@ LOG_FORMAT=""
 BRANCHES_JSON="[]"
 IMAGE="quay.io/konflux-ci/mintmaker-renovate-image:latest"
 NO_PULL=false
+CONFIG_REF=""
 
 usage() {
     echo "Usage: RENOVATE_TOKEN=<token> $0 --repo ORG/REPO --config-file PATH [options]"
@@ -38,6 +39,7 @@ usage() {
     echo "Optional:"
     echo "  --image          Renovate container image (default: $IMAGE)"
     echo "  --branches       JSON array of base branches (default: use config's baseBranches)"
+    echo "  --config-ref     Git ref (SHA/branch) for the config file (default: HEAD)"
     echo "  --dry-run        Run in dry-run mode (no PRs created)"
     echo "  --log-level      Renovate log level: debug, info, warn (default: debug)"
     exit 1
@@ -51,6 +53,7 @@ while [[ $# -gt 0 ]]; do
         --branches)     BRANCHES_JSON="$2"; shift 2 ;;
         --dry-run)      DRY_RUN=true; shift ;;
         --log-level)    LOG_LEVEL="$2"; shift 2 ;;
+        --config-ref)   CONFIG_REF="$2"; shift 2 ;;
         --log-format)   LOG_FORMAT="$2"; shift 2 ;;
         --no-pull)      NO_PULL=true; shift ;;
         -h|--help)      usage ;;
@@ -70,46 +73,30 @@ fi
 
 CONFIG_FILE=$(realpath "$CONFIG_FILE")
 
-# Create a wrapper config that extends MintMaker's global defaults, then layers
-# our source config on top. This mimics production MintMaker's config stack:
-# MintMaker global config -> repo-level config (our source config).
-MINTMAKER_EXTENDS="github>konflux-ci/mintmaker//config/renovate/renovate.json"
 WRAPPER_CONFIG=$(mktemp /tmp/renovate-wrapper-XXXXX.json)
 trap 'rm -f "$WRAPPER_CONFIG"' EXIT
 
-python3 -c "
+if [[ -n "$CONFIG_REF" ]]; then
+    # Config is pushed to GitHub — build a pure-extends wrapper that layers
+    # MintMaker's global config first, then our source config second. Our
+    # config comes last so its unmergeable fields (like enabledManagers)
+    # replace MintMaker's values.
+    REPO_ROOT=$(git rev-parse --show-toplevel)
+    CONFIG_REL_PATH=$(realpath --relative-to="$REPO_ROOT" "$CONFIG_FILE")
+    CONFIG_REPO=$(git remote get-url origin | sed -E 's|.*github\.com[:/]||; s|\.git$||')
+    SOURCE_EXTENDS="github>${CONFIG_REPO}//${CONFIG_REL_PATH}#${CONFIG_REF}"
+    MINTMAKER_EXTENDS="github>konflux-ci/mintmaker//config/renovate/renovate.json"
+
+    python3 -c "
 import json, sys
-import json5
-
-with open(sys.argv[1]) as f:
-    config = json5.loads(f.read())
-
-extends = config.get('extends', [])
-extends.insert(0, sys.argv[2])
-config['extends'] = extends
-
-json.dump(config, sys.stdout, indent=2)
-" "$CONFIG_FILE" "$MINTMAKER_EXTENDS" > "$WRAPPER_CONFIG"
-
-if [[ ! -s "$WRAPPER_CONFIG" ]]; then
-    echo "error: failed to generate wrapper config" >&2
-    exit 1
+json.dump({'extends': [sys.argv[1], sys.argv[2]]}, sys.stdout, indent=2)
+" "$MINTMAKER_EXTENDS" "$SOURCE_EXTENDS" > "$WRAPPER_CONFIG"
+else
+    # No ref — use the local config file directly (no MintMaker layering).
+    cp "$CONFIG_FILE" "$WRAPPER_CONFIG"
 fi
-chmod 644 "$WRAPPER_CONFIG"
 
-# Extract enabledManagers from the source config and pass as an env var.
-# Env vars have the highest priority in Renovate and cannot be overridden by
-# extends presets. This is necessary because extends in RENOVATE_CONFIG_FILE
-# are resolved at the repo level as an overlay, which would otherwise replace
-# our enabledManagers with MintMaker's full list (~60 managers).
-ENABLED_MANAGERS=$(python3 -c "
-import json, json5, sys
-with open(sys.argv[1]) as f:
-    config = json5.loads(f.read())
-managers = config.get('enabledManagers', [])
-if managers:
-    print(json.dumps(managers))
-" "$CONFIG_FILE")
+chmod 644 "$WRAPPER_CONFIG"
 
 # Build docker flags
 docker_flags=()
@@ -118,10 +105,6 @@ docker_flags+=(-e "RENOVATE_REPOSITORIES=[\"$REPO\"]")
 docker_flags+=(-e "RENOVATE_REQUIRE_CONFIG=ignored")
 docker_flags+=(-e "RENOVATE_CONFIG_FILE=/tmp/renovate-config.json")
 docker_flags+=(-e "LOG_LEVEL=$LOG_LEVEL")
-
-if [[ -n "$ENABLED_MANAGERS" ]]; then
-    docker_flags+=(-e "RENOVATE_ENABLED_MANAGERS=$ENABLED_MANAGERS")
-fi
 docker_flags+=(-e "RENOVATE_PR_HOURLY_LIMIT=20")
 docker_flags+=(-e "RENOVATE_BRANCH_CONCURRENT_LIMIT=20")
 docker_flags+=(-e "RENOVATE_RECREATE_WHEN=always")


### PR DESCRIPTION
## Summary

- Fix on-demand Renovate workflow to properly layer MintMaker's global config as a base, with our source config overriding via `RENOVATE_CONFIG_FILE` and `RENOVATE_FORCE` for conflicting fields (`enabledManagers`, `baseBranchPatterns`)
- Group all tekton task bundle and git SHA reference updates into a single PR per branch (matching production MintMaker behavior)
- Fix silent workflow failures: remove `set +e`, add `set -o pipefail` so errors propagate to workflow status
- Rename "Renovate Dry Run" workflow to "PR Check: Renovate Dry Run"
- Disable dependency dashboard for on-demand runs
- Add `groupName: "Konflux references"` to tekton and custom.regex configs
- Add comprehensive documentation covering config layering, local testing, and troubleshooting notes on approaches that didn't work

## Config Layering

Uses three Renovate env vars to mimic production MintMaker's two-layer stack:
- `RENOVATE_EXTENDS` — MintMaker's global config (base)
- `RENOVATE_CONFIG_FILE` — our source config mounted from the local checkout (overrides base)
- `RENOVATE_FORCE` — overrides only `enabledManagers` and `baseBranchPatterns` (force bypasses extends override quirks)

See `docs/renovate-workflows.md` and `docs/renovate-config-layering-notes.md` for details.

## Test plan

- [x] Local dry-run with upstream Renovate image: 1 branch, only tekton+regex managers, correct baseBranches
- [x] Workflow run creates grouped PR with `konflux/mintmaker/{baseBranch}/konflux-references` branch naming
- [ ] Verify postUpgradeTasks runs pipeline-migration-tool on task bundle updates
- [ ] Test PR Check dry-run workflow on a config change

🤖 Generated with [Claude Code](https://claude.com/claude-code)