### PR TITLE
Enable Renovate for mcp-lifecycle-operator

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -49,6 +49,7 @@
     - name: "red-hat-data-services/llm-d-latency-predictor"
     - name: "red-hat-data-services/llm-d-async"
     - name: "red-hat-data-services/llm-d-router"
+    - name: "red-hat-data-services/mcp-lifecycle-operator"
 
 - renovate-config: "renovate/custom-renovate-distribution.json"
   sync-repositories:


### PR DESCRIPTION
Adds 'red-hat-data-services/mcp-lifecycle-operator' to the default Renovate distribution in config.yaml.

| Field | Value |
|-------|-------|
| Component repo | `https://github.com/opendatahub-io/mcp-lifecycle-operator` |
| Renovate entry | `red-hat-data-services/mcp-lifecycle-operator` |
| Distribution   | `renovate/default-renovate-distribution.json` |

**Jira:** https://redhat.atlassian.net/browse/RHOAIENG-71452