### PR TITLE
chore: remove fips-check-blocking override for passing notebook components

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-datascience-cpu-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-datascience-cpu-py312-v3-5-push.yaml
@@ -66,8 +66,6 @@ spec:
       binary:
         arch: "x86_64,aarch64,ppc64le,s390x"
       requirements_files: [requirements.cpu.txt]
-  - name: fips-check-blocking
-    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-minimal-cpu-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-minimal-cpu-py312-v3-5-push.yaml
@@ -66,8 +66,6 @@ spec:
       binary:
         arch: "x86_64,aarch64,ppc64le,s390x"
       requirements_files: [requirements.cpu.txt]
-  - name: fips-check-blocking
-    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-v3-5-push.yaml
@@ -63,8 +63,6 @@ spec:
       binary:
         arch: "x86_64"
       requirements_files: [requirements.cuda.txt]
-  - name: fips-check-blocking
-    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-5-push.yaml
@@ -63,8 +63,6 @@ spec:
       binary:
         arch: "x86_64"
       requirements_files: [requirements.cuda.txt]
-  - name: fips-check-blocking
-    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v3-5-push.yaml
@@ -63,8 +63,6 @@ spec:
       binary:
         arch: "x86_64"
       requirements_files: [requirements.rocm.txt]
-  - name: fips-check-blocking
-    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-v3-5-push.yaml
@@ -64,8 +64,6 @@ spec:
       binary:
         arch: "x86_64,aarch64"
       requirements_files: [requirements.cuda.txt]
-  - name: fips-check-blocking
-    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v3-5-push.yaml
@@ -63,8 +63,6 @@ spec:
       binary:
         arch: "x86_64"
       requirements_files: [requirements.rocm.txt]
-  - name: fips-check-blocking
-    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-wb-jupyter-pytorch-llmcompressor-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-wb-jupyter-pytorch-llmcompressor-cuda-py312-v3-5-push.yaml
@@ -67,8 +67,6 @@ spec:
       binary:
         arch: "x86_64,aarch64"
       requirements_files: ["requirements.cuda.txt"]
-  - name: fips-check-blocking
-    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-5-push.yaml
@@ -181,8 +181,6 @@ spec:
     # Registry-only npm deps (ProdSec); @parcel/watcher, @emmetio/css-parser, @playwright/browser-chromium in custom-packages/package.json
     - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.106.3/custom-packages
       type: npm
-  - name: fips-check-blocking
-    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v3-5-push.yaml
@@ -71,8 +71,6 @@ spec:
       binary:
         arch: "x86_64,aarch64,ppc64le,s390x"
       requirements_files: [requirements.cpu.txt]
-  - name: fips-check-blocking
-    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cpu-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cpu-py312-v3-5-push.yaml
@@ -69,8 +69,6 @@ spec:
       binary:
         arch: "x86_64,aarch64,ppc64le,s390x"
       requirements_files: [requirements.cpu.txt]
-  - name: fips-check-blocking
-    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cuda-py312-v3-5-push.yaml
@@ -67,8 +67,6 @@ spec:
       binary:
         arch: "x86_64,aarch64"
       requirements_files: [requirements.cuda.txt]
-  - name: fips-check-blocking
-    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v3-5-push.yaml
@@ -66,8 +66,6 @@ spec:
       binary:
         arch: "x86_64,aarch64"
       requirements_files: [requirements.rocm.txt]
-  - name: fips-check-blocking
-    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-v3-5-push.yaml
@@ -66,8 +66,6 @@ spec:
       binary:
         arch: "x86_64"
       requirements_files: [requirements.cuda.txt]
-  - name: fips-check-blocking
-    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v3-5-push.yaml
@@ -66,8 +66,6 @@ spec:
       binary:
         arch: "x86_64"
       requirements_files: [requirements.rocm.txt]
-  - name: fips-check-blocking
-    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v3-5-push.yaml
@@ -67,8 +67,6 @@ spec:
       binary:
         arch: "x86_64,aarch64"
       requirements_files: [requirements.cuda.txt]
-  - name: fips-check-blocking
-    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v3-5-push.yaml
@@ -66,8 +66,6 @@ spec:
       binary:
         arch: "x86_64"
       requirements_files: [requirements.rocm.txt]
-  - name: fips-check-blocking
-    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-v3-5-push.yaml
@@ -71,8 +71,6 @@ spec:
       binary:
         arch: "x86_64,aarch64,ppc64le,s390x"
       requirements_files: [requirements.cpu.txt]
-  - name: fips-check-blocking
-    value: "false"
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Summary
- Remove the explicit `fips-check-blocking: "false"` parameter from 18 notebook push PipelineRun files that are passing FIPS checks, so they use the pipeline default (blocking enabled)

## Test plan
- [ ] Verify PipelineRuns trigger correctly without the explicit parameter
- [ ] Confirm FIPS check uses the pipeline-level default (blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)