### PR TITLE
AIPCC-19120: disable fips-check-blocking for DSPO/argo components using native Go FIPS

### DIFF
--- a/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-workflowcontroller-v3-5-push.yaml
+++ b/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-workflowcontroller-v3-5-push.yaml
@@ -56,6 +56,8 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/data-science-pipelines-operator/.tekton/odh-data-science-pipelines-operator-controller-v3-5-push.yaml
+++ b/pipelineruns/data-science-pipelines-operator/.tekton/odh-data-science-pipelines-operator-controller-v3-5-push.yaml
@@ -53,6 +53,8 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-api-server-v2-v3-5-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-api-server-v2-v3-5-push.yaml
@@ -56,6 +56,8 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-driver-v3-5-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-driver-v3-5-push.yaml
@@ -52,6 +52,8 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-scheduledworkflow-v2-v3-5-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-scheduledworkflow-v2-v3-5-push.yaml
@@ -53,6 +53,8 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Summary
- Disable `fips-check-blocking` for DSPO and argo components that use native Go FIPS (`GOFIPS140=v1.0.0`)
- `check-payload` v0.3.15 does not recognize Go 1.24+ native FIPS mode and incorrectly flags these binaries as "go binary is not CGO_ENABLED"
- Affected components: api-server-v2, workflowcontroller, driver, scheduledworkflow (operator-controller already had the override)

## Known Native Go FIPS Failures (GOFIPS140)

| Component | Failed Binary | Archs Failed | Blocking | Build Status | Dockerfile |
|---|---|---|---|---|---|
| [odh-data-science-pipelines-argo-argoexec-v3-5](https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhoai-tenant/applications/rhoai-v3-5/components/odh-data-science-pipelines-argo-argoexec-v3-5/activity/pipelineruns) | `/usr/bin/argoexec` | amd64, arm64, ppc64le | false | Completed | [argo-argoexec/Dockerfile.konflux](https://github.com/red-hat-data-services/argo-workflows/blob/rhoai-3.5/argo-argoexec/Dockerfile.konflux) |
| [odh-ml-pipelines-launcher-v3-5](https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhoai-tenant/applications/rhoai-v3-5/components/odh-ml-pipelines-launcher-v3-5/activity/pipelineruns) | `/usr/bin/launcher-v2` | amd64, arm64, ppc64le | false | Completed | [backend/Dockerfile.konflux.launcher](https://github.com/red-hat-data-services/data-science-pipelines/blob/rhoai-3.5/backend/Dockerfile.konflux.launcher) |
| [odh-ml-pipelines-api-server-v2-v3-5](https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhoai-tenant/applications/rhoai-v3-5/components/odh-ml-pipelines-api-server-v2-v3-5/activity/pipelineruns) | (not in scan detail) | amd64, arm64, ppc64le | true | **Failed** | [backend/Dockerfile.konflux.api](https://github.com/red-hat-data-services/data-science-pipelines/blob/rhoai-3.5/backend/Dockerfile.konflux.api) |
| [odh-data-science-pipelines-argo-workflowcontroller-v3-5](https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhoai-tenant/applications/rhoai-v3-5/components/odh-data-science-pipelines-argo-workflowcontroller-v3-5/activity/pipelineruns) | `/usr/bin/workflow-controller` | amd64, arm64, ppc64le | true | **Failed** | [argo-workflowcontroller/Dockerfile.konflux](https://github.com/red-hat-data-services/argo-workflows/blob/rhoai-3.5/argo-workflowcontroller/Dockerfile.konflux) |
| [odh-data-science-pipelines-operator-controller-v3-5](https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhoai-tenant/applications/rhoai-v3-5/components/odh-data-science-pipelines-operator-controller-v3-5/activity/pipelineruns) | `/manager` | amd64, arm64 | true | **Failed** | [Dockerfile.konflux](https://github.com/red-hat-data-services/data-science-pipelines-operator/blob/rhoai-3.5/Dockerfile.konflux) |
| [odh-ml-pipelines-driver-v3-5](https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhoai-tenant/applications/rhoai-v3-5/components/odh-ml-pipelines-driver-v3-5/activity/pipelineruns) | `/usr/bin/driver` | amd64, arm64, ppc64le | true | **Failed** | [backend/Dockerfile.konflux.driver](https://github.com/red-hat-data-services/data-science-pipelines/blob/rhoai-3.5/backend/Dockerfile.konflux.driver) |
| [odh-ml-pipelines-scheduledworkflow-v2-v3-5](https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhoai-tenant/applications/rhoai-v3-5/components/odh-ml-pipelines-scheduledworkflow-v2-v3-5/activity/pipelineruns) | `/usr/bin/controller` | amd64, arm64, ppc64le | true | **Failed** | [backend/Dockerfile.konflux.scheduledworkflow](https://github.com/red-hat-data-services/data-science-pipelines/blob/rhoai-3.5/backend/Dockerfile.konflux.scheduledworkflow) |

All Dockerfiles confirm native Go FIPS mode, e.g.:
```
RUN GOTOOLCHAIN=local CGO_ENABLED=0 GOFIPS140=v1.0.0 go build -tags no_openssl ...
```

Ref: [AIPCC-19120](https://redhat.atlassian.net/browse/AIPCC-19120)

## Test plan
- [ ] Verify builds complete successfully with blocking disabled
- [ ] Confirm FIPS check still runs (non-blocking) and reports results

🤖 Generated with [Claude Code](https://claude.com/claude-code)