### PR TITLE
AIPCC-19120: disable fips-check-blocking for persistenceagent and ai-gateway-e2e

### DIFF
--- a/pipelineruns/ai-gateway-payload-processing/.tekton/odh-ai-gateway-payload-processing-e2e-v3-5-on-push.yaml
+++ b/pipelineruns/ai-gateway-payload-processing/.tekton/odh-ai-gateway-payload-processing-e2e-v3-5-on-push.yaml
@@ -51,6 +51,8 @@ spec:
     - linux/x86_64
     - linux/arm64
     - linux/ppc64le
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-persistenceagent-v2-v3-5-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-persistenceagent-v2-v3-5-push.yaml
@@ -53,6 +53,8 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Summary
- Disable `fips-check-blocking` for two additional components failing FIPS checks with blocking enabled

| Component | Failure Reason | Archs |
|---|---|---|
| [odh-ml-pipelines-persistenceagent-v2-v3-5](https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhoai-tenant/applications/rhoai-v3-5/components/odh-ml-pipelines-persistenceagent-v2-v3-5/activity/pipelineruns) | `GOFIPS140=v1.0.0` not recognized by `check-payload` v0.3.15 | amd64, arm64, ppc64le |
| [odh-ai-gateway-payload-processing-e2e-v3-5](https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhoai-tenant/applications/rhoai-v3-5/components/odh-ai-gateway-payload-processing-e2e-v3-5/activity/pipelineruns) | bundled `kubectl` missing `libcrypto.so.1.1` | amd64, arm64, ppc64le |

Ref: [AIPCC-19120](https://redhat.atlassian.net/browse/AIPCC-19120)

## Test plan
- [ ] Verify builds complete successfully with blocking disabled
- [ ] Confirm FIPS check still runs (non-blocking) and reports results

🤖 Generated with [Claude Code](https://claude.com/claude-code)