### PR TITLE
Add odh-mcp-lifecycle-operator pull-request PipelineRun

### DIFF
--- a/pipelineruns/mcp-lifecycle-operator/.tekton/odh-mcp-lifecycle-operator-pull-request.yaml
+++ b/pipelineruns/mcp-lifecycle-operator/.tekton/odh-mcp-lifecycle-operator-pull-request.yaml
@@ -1,0 +1,61 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/mcp-lifecycle-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-event: '[pull_request]'
+    pipelinesascode.tekton.dev/on-comment: '^/build-konflux'
+    pipelinesascode.tekton.dev/on-target-branch: '[{{target_branch}}]'
+  labels:
+    appstudio.openshift.io/application: automation
+    appstudio.openshift.io/component: pull-request-pipelines-odh-mcp-lifecycle-operator
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-mcp-lifecycle-operator-on-pull-request-{{pull_request_number}}
+  namespace: rhoai-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/rhoai/pull-request-pipelines:odh-mcp-lifecycle-operator-{{revision}}
+  - name: dockerfile
+    value: Dockerfile.konflux
+  - name: path-context
+    value: .
+  - name: image-expires-after
+    value: 5d
+  - name: enable-slack-failure-notification
+    value: "false"
+  - name: prefetch-input
+    value: |
+      [{"type": "gomod", "path": "."}]
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux-m2xlarge/arm64
+  pipelineRef:
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ target_branch }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+    resolver: git
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-pull-request-pipelines
+    podTemplate:
+      imagePullSecrets:
+      - name: redhat-appstudio-staginguser-pull-secret
+  timeouts:
+    pipeline: 8h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'


### PR DESCRIPTION
Adds pull-request PipelineRun YAML for 'odh-mcp-lifecycle-operator'.

Component repo: https://github.com/red-hat-data-services/mcp-lifecycle-operator
Jira: https://redhat.atlassian.net/browse/RHOAIENG-71452