### PR TITLE
Allow renovate to bump buildah-remote-oci-ta to 0.10

### DIFF
--- a/renovate/pipelines-renovate.json5
+++ b/renovate/pipelines-renovate.json5
@@ -53,6 +53,15 @@
         "allowedVersions": "<=0.3",
         "enabled": true,
       },
+      {
+        // Allow minor version update for buildah-remote-oci-ta to pick up
+        // cross-platform image support (ALLOW_CROSS_PLATFORM_IMAGES param, STONEBLD-4817)
+        "matchPackageNames": ["quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta"],
+        "matchUpdateTypes": ["minor"],
+        "matchBaseBranches": ["main", "rhoai-3.5"],
+        "allowedVersions": "<=0.10",
+        "enabled": true,
+      },
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Adds a Renovate package rule to allow the `buildah-remote-oci-ta` minor version update (0.9 → 0.10) on `main` and `rhoai-3.5` branches
- This picks up cross-platform image support (`ALLOW_CROSS_PLATFORM_IMAGES` param) from [STONEBLD-4817](https://redhat.atlassian.net/browse/STONEBLD-4817)
- A follow-up PR will add the pipeline parameter to `multi-arch-container-build.yaml`

## Related
- [RHOAIENG-72057](https://redhat.atlassian.net/browse/RHOAIENG-72057)
- [STONEBLD-4817](https://redhat.atlassian.net/browse/STONEBLD-4817)

## Test plan
- [ ] Verify Renovate dry-run picks up the `buildah-remote-oci-ta` 0.10 update on `main` and `rhoai-3.5`
- [ ] Confirm no unintended version bumps on other branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)