### PR TITLE
fix(pipeline-components): unnecessary requirements files for autorag builds

### DIFF
--- a/pipelineruns/pipelines-components/.tekton/odh-autorag-v3-5-push.yaml
+++ b/pipelineruns/pipelines-components/.tekton/odh-autorag-v3-5-push.yaml
@@ -52,17 +52,9 @@ spec:
             "type": "pip",
             "path": "pipelines/training/autorag",
             "requirements_files": [
-              "documents_rag_optimization_pipeline/requirements.txt",
-              "documents_rag_optimization_pipeline/requirements-pypi-whl.txt"
+              "documents_rag_optimization_pipeline/requirements.txt"
             ],
             "binary": {"arch": ":all:"}
-          },
-          {
-            "type": "pip",
-            "path": "pipelines/training/autorag/documents_rag_optimization_pipeline",
-            "requirements_files": [
-              "requirements-pypi.txt"
-            ]
           }
         ]
   - name: build-source-image


### PR DESCRIPTION
Assisted by Cursor

Removed requirements after: github.com/opendatahub-io/pipelines-components/pull/135

Related slack thread: https://redhat-internal.slack.com/archives/C07ANR2U56C/p1782813298141609