### PR TITLE
Enable Renovate for workbenches-operator

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -51,6 +51,7 @@
     - name: "red-hat-data-services/llm-d-router"
     - name: "red-hat-data-services/mcp-lifecycle-operator"
     - name: "red-hat-data-services/mcp-lifecycle-module-operator"
+    - name: "red-hat-data-services/workbenches-operator"
 
 - renovate-config: "renovate/custom-renovate-distribution.json"
   sync-repositories:


### PR DESCRIPTION
Adds 'red-hat-data-services/workbenches-operator' to the default Renovate distribution in config.yaml.

| Field | Value |
|-------|-------|
| Component repo | `https://github.com/red-hat-data-services/workbenches-operator` |
| Renovate entry | `red-hat-data-services/workbenches-operator` |
| Distribution   | `renovate/default-renovate-distribution.json` |

**Jira:** https://redhat.atlassian.net/browse/RHOAIENG-72970