### PR TITLE
Enable push pipelinerun for mlserver on power for rhoai-3.5

### DIFF
--- a/pipelineruns/mlserver/.tekton/odh-mlserver-v3-5-push.yaml
+++ b/pipelineruns/mlserver/.tekton/odh-mlserver-v3-5-push.yaml
@@ -46,7 +46,7 @@ spec:
           "requirements/requirements-cpu.txt"
         ],
         "binary": {
-          "arch": "x86_64,aarch64",
+          "arch": "x86_64,aarch64,ppc64le",
           "os": "linux"
         }
       }
@@ -58,6 +58,7 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+    - linux/ppc64le
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
Enabling MLServer support on Power