### PR TITLE
Enable Renovate for trainer-operator

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -52,6 +52,7 @@
     - name: "red-hat-data-services/mcp-lifecycle-operator"
     - name: "red-hat-data-services/mcp-lifecycle-module-operator"
     - name: "red-hat-data-services/workbenches-operator"
+    - name: "red-hat-data-services/trainer-operator"
 
 - renovate-config: "renovate/custom-renovate-distribution.json"
   sync-repositories:


### PR DESCRIPTION
Adds 'red-hat-data-services/trainer-operator' to the default Renovate distribution in config.yaml.

| Field | Value |
|-------|-------|
| Component repo | `https://github.com/red-hat-data-services/trainer-operator` |
| Renovate entry | `red-hat-data-services/trainer-operator` |
| Distribution   | `renovate/default-renovate-distribution.json` |

**Jira:** https://redhat.atlassian.net/browse/RHOAIENG-73225