### PR TITLE
update latency predictor prefetch to use requirements-konflux.txt

### DIFF
--- a/pipelineruns/llm-d-latency-predictor/.tekton/odh-latency-predictor-prediction-pull-request.yaml
+++ b/pipelineruns/llm-d-latency-predictor/.tekton/odh-latency-predictor-prediction-pull-request.yaml
@@ -33,7 +33,7 @@ spec:
   - name: enable-slack-failure-notification
     value: "false"
   - name: prefetch-input
-    value: '[{"type": "pip", "path": ".", "binary": {"arch": ":all:"}}, {"type": "rpm"}]'
+    value: '[{"type": "pip", "path": ".", "requirements_files": ["requirements-konflux.txt"], "binary": {"arch": ":all:"}}, {"type": "rpm"}]'
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/llm-d-latency-predictor/.tekton/odh-latency-predictor-test-pull-request.yaml
+++ b/pipelineruns/llm-d-latency-predictor/.tekton/odh-latency-predictor-test-pull-request.yaml
@@ -33,7 +33,7 @@ spec:
   - name: enable-slack-failure-notification
     value: "false"
   - name: prefetch-input
-    value: '[{"type": "pip", "path": ".", "binary": {"arch": ":all:"}}, {"type": "rpm"}]'
+    value: '[{"type": "pip", "path": ".", "requirements_files": ["requirements-konflux.txt"], "binary": {"arch": ":all:"}}, {"type": "rpm"}]'
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/llm-d-latency-predictor/.tekton/odh-latency-predictor-training-pull-request.yaml
+++ b/pipelineruns/llm-d-latency-predictor/.tekton/odh-latency-predictor-training-pull-request.yaml
@@ -33,7 +33,7 @@ spec:
   - name: enable-slack-failure-notification
     value: "false"
   - name: prefetch-input
-    value: '[{"type": "pip", "path": ".", "binary": {"arch": ":all:"}}, {"type": "rpm"}]'
+    value: '[{"type": "pip", "path": ".", "requirements_files": ["requirements-konflux.txt"], "binary": {"arch": ":all:"}}, {"type": "rpm"}]'
   - name: build-platforms
     value:
     - linux/x86_64


### PR DESCRIPTION
## Summary
Update Hermeto prefetch config for llm-d-latency-predictor to use `requirements-konflux.txt` instead of `requirements.txt`.

The Konflux Dockerfiles use `requirements-konflux.txt` (RHAI index with hashes) while the upstream `requirements.txt` is unpinned for regular builds. This prevents prefetch from pulling the wrong file.

## Related
- opendatahub-io/llm-d-latency-predictor#5 (adds requirements-konflux.txt)