### PR TITLE
Add allow-cross-platform-images parameter to multi-arch pipeline

### DIFF
--- a/pipelineruns/llama-stack-provider-trustyai-garak/.tekton/odh-trustyai-garak-lls-provider-dsp-pull-request.yaml
+++ b/pipelineruns/llama-stack-provider-trustyai-garak/.tekton/odh-trustyai-garak-lls-provider-dsp-pull-request.yaml
@@ -70,6 +70,8 @@ spec:
     - linux/s390x
   - name: image-expires-after
     value: 5d
+  - name: allow-cross-platform-images
+    value: "true"
   - name: enable-slack-failure-notification
     value: "false"
   pipelineRef:

--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -139,6 +139,10 @@ spec:
     default: 'true'
     description: Use the package registry proxy when prefetching dependencies
     type: string
+  - name: allow-cross-platform-images
+    default: "false"
+    description: Allow cross-platform image usage in FROM instructions (e.g. using x86_64 base images in multi-arch builds). May create incompatible images.
+    type: string
   results:
   - description: ""
     name: IMAGE_URL
@@ -304,6 +308,8 @@ spec:
       value: $(params.buildah-format)
     - name: ACTIVATION_KEY
       value: $(params.rhel-subscription-activation-key)
+    - name: ALLOW_CROSS_PLATFORM_IMAGES
+      value: $(params.allow-cross-platform-images)
     runAfter:
     - prefetch-dependencies
     taskRef:


### PR DESCRIPTION
## Summary
- Adds `allow-cross-platform-images` pipeline parameter (default `"false"`) to `multi-arch-container-build.yaml`
- Wires it through to the `ALLOW_CROSS_PLATFORM_IMAGES` param on the `buildah-remote-oci-ta` task (available since 0.10)
- Allows components to opt in to using cross-platform base images in `FROM` instructions (e.g. x86_64 base in multi-arch builds)

## Related
- [RHOAIENG-72057](https://redhat.atlassian.net/browse/RHOAIENG-72057)
- [STONEBLD-4817](https://redhat.atlassian.net/browse/STONEBLD-4817)
- Renovate bump PR: #2660

## Test plan
- [ ] Verify pipeline validates with the new parameter
- [ ] Cherry-pick to `rhoai-3.5` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)