### PR TITLE
Add allow-cross-platform-images parameter to multi-arch pipeline

### DIFF
--- a/pipelineruns/llama-stack-provider-trustyai-garak/.tekton/odh-trustyai-garak-lls-provider-dsp-v3-5-push.yaml
+++ b/pipelineruns/llama-stack-provider-trustyai-garak/.tekton/odh-trustyai-garak-lls-provider-dsp-v3-5-push.yaml
@@ -64,6 +64,8 @@ spec:
     - linux-d160-m2xlarge/arm64
     - linux/ppc64le
     - linux/s390x
+  - name: allow-cross-platform-images
+    value: "true"
   pipelineRef:
     resolver: git
     params:

--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -133,6 +133,10 @@ spec:
     default: 'true'
     description: Use the package registry proxy when prefetching dependencies
     type: string
+  - name: allow-cross-platform-images
+    default: "false"
+    description: Allow cross-platform image usage in FROM instructions (e.g. using x86_64 base images in multi-arch builds). May create incompatible images.
+    type: string
   results:
   - description: ""
     name: IMAGE_URL
@@ -302,6 +306,8 @@ spec:
       value: "true"
     - name: BUILDAH_FORMAT
       value: $(params.buildah-format)
+    - name: ALLOW_CROSS_PLATFORM_IMAGES
+      value: $(params.allow-cross-platform-images)
     runAfter:
     - prefetch-dependencies
     taskRef:


### PR DESCRIPTION
## Summary
- Adds `allow-cross-platform-images` pipeline parameter (default `"false"`) to `multi-arch-container-build.yaml`
- Wires it through to the `ALLOW_CROSS_PLATFORM_IMAGES` param on the `buildah-remote-oci-ta` task (0.10)
- Enables it for the garak push pipelinerun

## Related
- [RHOAIENG-72057](https://redhat.atlassian.net/browse/RHOAIENG-72057)
- [STONEBLD-4817](https://redhat.atlassian.net/browse/STONEBLD-4817)
- Main branch PR: #2734

## Test plan
- [ ] Verify pipeline validates with the new parameter
- [ ] Verify garak push build succeeds with cross-platform images enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)