### PR TITLE
Revert cross-platform images for garak pipelinerun

### DIFF
--- a/pipelineruns/llama-stack-provider-trustyai-garak/.tekton/odh-trustyai-garak-lls-provider-dsp-pull-request.yaml
+++ b/pipelineruns/llama-stack-provider-trustyai-garak/.tekton/odh-trustyai-garak-lls-provider-dsp-pull-request.yaml
@@ -70,8 +70,6 @@ spec:
     - linux/s390x
   - name: image-expires-after
     value: 5d
-  - name: allow-cross-platform-images
-    value: "true"
   - name: enable-slack-failure-notification
     value: "false"
   pipelineRef:


### PR DESCRIPTION
## Summary
- Removes `allow-cross-platform-images: "true"` from garak pull-request pipelinerun — this was added in error

🤖 Generated with [Claude Code](https://claude.com/claude-code)