### PR TITLE
Revert cross-platform images for garak pipelinerun

### DIFF
--- a/pipelineruns/llama-stack-provider-trustyai-garak/.tekton/odh-trustyai-garak-lls-provider-dsp-v3-5-push.yaml
+++ b/pipelineruns/llama-stack-provider-trustyai-garak/.tekton/odh-trustyai-garak-lls-provider-dsp-v3-5-push.yaml
@@ -64,8 +64,6 @@ spec:
     - linux-d160-m2xlarge/arm64
     - linux/ppc64le
     - linux/s390x
-  - name: allow-cross-platform-images
-    value: "true"
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Summary
- Removes `allow-cross-platform-images: "true"` from garak push pipelinerun — this was added in error

🤖 Generated with [Claude Code](https://claude.com/claude-code)