### PR TITLE
Enable Renovate for feast-module-operator

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -53,6 +53,7 @@
     - name: "red-hat-data-services/mcp-lifecycle-module-operator"
     - name: "red-hat-data-services/workbenches-operator"
     - name: "red-hat-data-services/trainer-operator"
+    - name: "red-hat-data-services/feast-module-operator"
 
 - renovate-config: "renovate/custom-renovate-distribution.json"
   sync-repositories:


### PR DESCRIPTION
Adds 'red-hat-data-services/feast-module-operator' to the default Renovate distribution in config.yaml.

| Field | Value |
|-------|-------|
| Component repo | `https://github.com/red-hat-data-services/feast-module-operator` |
| Renovate entry | `red-hat-data-services/feast-module-operator` |
| Distribution   | `renovate/default-renovate-distribution.json` |

**Jira:** https://redhat.atlassian.net/browse/RHOAIENG-75017