### PR TITLE
RHOAIENG-75736: Update async-upload prefetch for AIPCC base image

### DIFF
--- a/pipelineruns/model-registry/.tekton/odh-model-registry-job-async-upload-pull-request.yaml
+++ b/pipelineruns/model-registry/.tekton/odh-model-registry-job-async-upload-pull-request.yaml
@@ -53,12 +53,9 @@ spec:
           "type": "pip",
           "path": "jobs/async-upload",
           "requirements_files": [
-            "requirements.txt"
+            "requirements-aipcc.txt"
           ],
-          "requirements_build_files": [
-            "requirements-build.txt",
-            "requirements-extra-build-deps.txt"
-          ]
+          "binary": { "arch": "x86_64,aarch64,ppc64le,s390x" }
         }
       ]
   - name: build-image-index


### PR DESCRIPTION
## Summary
- Updates the model-registry async-upload pull-request PipelineRun to use `requirements-aipcc.txt` with binary wheel arch specification instead of `requirements.txt` with build files
- Matches changes from upstream [model-registry PR #1431](https://github.com/red-hat-data-services/model-registry/pull/1431) which switched to the AIPCC base image and binary wheels

## Jira
https://redhat.atlassian.net/browse/RHOAIENG-75736

## Test plan
- [ ] Verify Konflux PR pipeline triggers and prefetch succeeds with the new config
- [ ] Confirm binary wheels are fetched for all specified architectures (x86_64, aarch64, ppc64le, s390x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)