### PR TITLE
Enable Hermeto generic pre-fetch for ogx-distribution PR pipeline

### DIFF
--- a/pipelineruns/ogx-distribution/.tekton/odh-ogx-core-pull-request.yaml
+++ b/pipelineruns/ogx-distribution/.tekton/odh-ogx-core-pull-request.yaml
@@ -47,11 +47,13 @@ spec:
     value: Dockerfile.konflux
   - name: path-context
     value: .
+  - name: build-args-file
+    value: konflux/cpu-ubi9.conf
   - name: hermetic
-    value: true
+    value: false
   - name: prefetch-input
     value: |
-      []
+      [{"type": "generic", "path": "./distribution"}]
   - name: build-image-index
     value: true
   - name: enable-slack-failure-notification


### PR DESCRIPTION
## Summary
- Adds `build-args-file: konflux/cpu-ubi9.conf` param so the pipeline can resolve `BASE_IMAGE` and `OGX_VERSION` build args from the Dockerfile's `FROM` instruction
- Sets `hermetic: false` (hermetic builds not yet possible for this component)
- Configures `prefetch-input` with generic fetcher (`{"type": "generic", "path": "./distribution"}`) to pre-fetch model/data files from `distribution/artifacts.lock.yaml` into `/cachi2/output/deps/generic/` before the container build

## Test plan
- [ ] Verify PR pipeline triggers correctly on a PR to `ogx-distribution`
- [ ] Confirm Hermeto generic pre-fetch reads `distribution/artifacts.lock.yaml` and deposits artifacts
- [ ] Confirm `copy-artifacts.sh` finds pre-fetched files in `/cachi2/output/deps/generic/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)