### PR TITLE
Enable Hermeto generic pre-fetch for ogx-distribution push pipeline

### DIFF
--- a/pipelineruns/ogx-distribution/.tekton/odh-ogx-core-v3-5-push.yaml
+++ b/pipelineruns/ogx-distribution/.tekton/odh-ogx-core-v3-5-push.yaml
@@ -38,6 +38,9 @@ spec:
     value: .
   - name: hermetic
     value: false
+  - name: prefetch-input
+    value: |
+      [{"type": "generic", "path": "./distribution"}]
   - name: build-source-image
     value: true
   - name: build-image-index


### PR DESCRIPTION
## Summary
- Adds `prefetch-input` with generic fetcher (`{"type": "generic", "path": "./distribution"}`) to pre-fetch model/data files from `distribution/artifacts.lock.yaml` into `/cachi2/output/deps/generic/` before the container build

## Test plan
- [ ] Verify push pipeline triggers correctly on push to `rhoai-3.5` in `ogx-distribution`
- [ ] Confirm Hermeto generic pre-fetch reads `distribution/artifacts.lock.yaml` and deposits artifacts
- [ ] Confirm `copy-artifacts.sh` finds pre-fetched files in `/cachi2/output/deps/generic/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)