### PR TITLE
Enable pip prefetch and hermetic builds for ogx-distribution PR pipeline

### DIFF
--- a/pipelineruns/ogx-distribution/.tekton/odh-ogx-core-pull-request.yaml
+++ b/pipelineruns/ogx-distribution/.tekton/odh-ogx-core-pull-request.yaml
@@ -50,10 +50,10 @@ spec:
   - name: build-args-file
     value: konflux/cpu-ubi9.conf
   - name: hermetic
-    value: false
+    value: true
   - name: prefetch-input
     value: |
-      [{"type": "generic", "path": "./distribution"}]
+      [{"type": "pip", "path": ".", "requirements_files": ["distribution/requirements-lock-konflux.txt"], "allow_binary": true}, {"type": "generic", "path": "./distribution"}]
   - name: build-image-index
     value: true
   - name: enable-slack-failure-notification


### PR DESCRIPTION
## Summary
- Add pip prefetch configuration for `distribution/requirements-lock-konflux.txt` alongside existing generic prefetch
- Enable hermetic builds (`hermetic: true`)

## Test plan
- [ ] Verify PR pipeline triggers correctly on pull requests
- [ ] Confirm pip dependencies are pre-fetched from requirements-lock-konflux.txt
- [ ] Confirm generic artifacts are still pre-fetched from `./distribution`
- [ ] Validate hermetic build completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)