### PR TITLE
Enable pip prefetch and hermetic builds for ogx-distribution push pipeline

### DIFF
--- a/pipelineruns/ogx-distribution/.tekton/odh-ogx-core-v3-5-push.yaml
+++ b/pipelineruns/ogx-distribution/.tekton/odh-ogx-core-v3-5-push.yaml
@@ -37,10 +37,10 @@ spec:
   - name: path-context
     value: .
   - name: hermetic
-    value: false
+    value: true
   - name: prefetch-input
     value: |
-      [{"type": "generic", "path": "./distribution"}]
+      [{"type": "pip", "path": ".", "requirements_files": ["distribution/requirements-lock-konflux.txt"], "allow_binary": true}, {"type": "generic", "path": "./distribution"}]
   - name: build-source-image
     value: true
   - name: build-image-index


### PR DESCRIPTION
## Summary
- Add pip prefetch configuration for `distribution/requirements-lock-konflux.txt` alongside existing generic prefetch
- Enable hermetic builds (`hermetic: true`)

## Test plan
- [ ] Verify push pipeline triggers correctly on push to `rhoai-3.5`
- [ ] Confirm pip dependencies are pre-fetched from requirements-lock-konflux.txt
- [ ] Confirm generic artifacts are still pre-fetched from `./distribution`
- [ ] Validate hermetic build completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)