### PR TITLE
RHAIENG-2860: Wire RHEL subscription activation key on rhoai-2.25 pipeline

### DIFF
--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -129,6 +129,10 @@ spec:
     default: 'true'
     description: Use the package registry proxy when prefetching dependencies
     type: string
+  - name: rhel-subscription-activation-key
+    default: 'custom-activation-key'
+    type: string
+    description: The name of the Kubernetes secret containing org and activationkey for RHEL subscription (used by prefetch-dependencies and buildah for hermetic RPM fetch and builds). See https://konflux-ci.dev/docs/building/activation-keys-subscription/
   results:
   - description: ""
     name: IMAGE_URL
@@ -207,6 +211,8 @@ spec:
     params:
     - name: input
       value: $(params.prefetch-input)
+    - name: ACTIVATION_KEY
+      value: $(params.rhel-subscription-activation-key)
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     - name: ociStorage
@@ -267,7 +273,7 @@ spec:
     - name: PRIVILEGED_NESTED
       value: $(params.privileged-nested)
     - name: ACTIVATION_KEY
-      value: custom-activation-key
+      value: $(params.rhel-subscription-activation-key)
     - name: LABELS
       value:
       - $(params.additional-labels[*])


### PR DESCRIPTION
## Summary

- Add `rhel-subscription-activation-key` pipeline param (default: `custom-activation-key`) to `multi-arch-container-build` on `rhoai-2.25`.
- Pass `ACTIVATION_KEY` to `prefetch-dependencies` so Cachi2 can fetch hermetic RPMs from RHEL subscription content.
- Use the same param for `build-images` / buildah instead of a hardcoded secret name.

This is a surgical backport of the subscription wiring already on `konflux-central/main` (RHAIENG-2860 / RHOAIENG-50460). It keeps all `rhoai-2.25`-specific behavior (`rhoai-version`, `rhoai-init`, cache proxy defaults, etc.) unchanged.

Needed for hermetic codeserver on `notebooks/rhoai-2.25` (PR red-hat-data-services/notebooks#2513), which passes `rhel-subscription-activation-key` in its PipelineRun but currently hits 403 on RPM prefetch because `rhoai-2.25` pipeline did not forward the secret to prefetch.

## Test plan

- [ ] Merge this PR to `konflux-central/rhoai-2.25`
- [ ] In notebooks PR #2513, revert codeserver Tekton `pipelineRef.revision` from `main` back to `{{ target_branch }}` (and restore `rhoai-version` on push yaml if removed)
- [ ] Re-run Konflux codeserver PR pipeline; confirm `prefetch-dependencies` succeeds on RHDS RPM lock fetch
- [ ] Confirm a non-hermetic notebook image still builds (default `custom-activation-key` unchanged)


Made with [Cursor](https://cursor.com)