### PR TITLE
Enable Renovate for MLServer

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -54,6 +54,7 @@
     - name: "red-hat-data-services/workbenches-operator"
     - name: "red-hat-data-services/trainer-operator"
     - name: "red-hat-data-services/feast-module-operator"
+    - name: "red-hat-data-services/MLServer"
 
 - renovate-config: "renovate/custom-renovate-distribution.json"
   sync-repositories:


### PR DESCRIPTION
Adds 'red-hat-data-services/MLServer' to the default Renovate distribution in config.yaml.

| Field | Value |
|-------|-------|
| Component repo | `https://github.com/red-hat-data-services/MLServer` |
| Renovate entry | `red-hat-data-services/MLServer` |
| Distribution   | `renovate/default-renovate-distribution.json` |

**Jira:** https://redhat.atlassian.net/browse/RHOAIENG-76474