### PR TITLE
chore(pipeline-components): Port AutoML and AutoRAG on pull requests tekton yamls.

### DIFF
--- a/pipelineruns/pipelines-components/.tekton/odh-automl-pull-request.yaml
+++ b/pipelineruns/pipelines-components/.tekton/odh-automl-pull-request.yaml
@@ -1,0 +1,83 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/pipelines-components?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux-automl"
+    pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-automl]"
+    pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+  labels:
+    appstudio.openshift.io/application: automation
+    appstudio.openshift.io/component: pull-request-pipelines-odh-automl
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-automl-on-pull-request
+  namespace: rhoai-tenant
+spec:
+  timeouts:
+    pipeline: 8h
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: additional-tags
+    value:
+    - 'pr-{{pull_request_number}}-into-{{target_branch}}'
+  - name: additional-labels
+    value:
+    - version=on-pr-{{revision}}
+    - io.openshift.tags=odh-automl
+  - name: output-image
+    value: quay.io/rhoai/pull-request-pipelines:odh-automl-{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux-m2xlarge/arm64
+  - name: image-expires-after
+    value: 5d
+  - name: dockerfile
+    value: Dockerfile.konflux.automl
+  - name: path-context
+    value: .
+  - name: hermetic
+    value: true
+  - name: prefetch-input
+    value:
+        [
+          {
+            "type": "pip",
+            "path": "pipelines/training/automl",
+            "requirements_files": [
+              "autogluon_tabular_training_pipeline/requirements.txt"
+            ],
+            "binary": {"arch": ":all:"}
+          }
+        ]
+  - name: build-image-index
+    value: true
+  - name: enable-slack-failure-notification
+    value: "false"
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ target_branch }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-pull-request-pipelines
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/pipelines-components/.tekton/odh-autorag-on-pull-request.yaml
+++ b/pipelineruns/pipelines-components/.tekton/odh-autorag-on-pull-request.yaml
@@ -1,0 +1,91 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/pipelines-components?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux-autorag"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+  labels:
+    appstudio.openshift.io/application: automation
+    appstudio.openshift.io/component: pull-request-pipelines-odh-autorag
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-autorag-on-pull-request
+  namespace: rhoai-tenant
+spec:
+  timeouts:
+    pipeline: 8h
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
+    - name: additional-tags
+      value:
+        - 'pr-{{pull_request_number}}-into-{{target_branch}}'
+    - name: additional-labels
+      value:
+        - version=on-pr-{{revision}}
+        - io.openshift.tags=odh-autorag
+    - name: output-image
+      value: quay.io/rhoai/pull-request-pipelines:odh-autorag-{{revision}}
+    - name: build-platforms
+      value:
+        - linux/x86_64
+        - linux/ppc64le
+        - linux/s390x
+        - linux-m2xlarge/arm64
+    - name: image-expires-after
+      value: 5d
+    - name: dockerfile
+      value: Dockerfile.konflux.autorag
+    - name: path-context
+      value: .
+    - name: hermetic
+      value: true
+    - name: prefetch-input
+      value:
+        [
+          {
+            "type": "pip",
+            "path": "pipelines/training/autorag",
+            "requirements_files": [
+              "documents_rag_optimization_pipeline/requirements.txt",
+              "documents_rag_optimization_pipeline/requirements-pypi-whl.txt"
+            ],
+            "binary": {"arch": ":all:"}
+          },
+          {
+            "type": "pip",
+            "path": "pipelines/training/autorag/documents_rag_optimization_pipeline",
+            "requirements_files": [
+              "requirements-pypi.txt"
+            ]
+          }
+        ]
+    - name: prefetch-log-level
+      value: "debug"
+    - name: build-image-index
+      value: true
+    - name: enable-slack-failure-notification
+      value: "false"
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: https://github.com/red-hat-data-services/konflux-central.git
+      - name: revision
+        value: '{{ target_branch }}'
+      - name: pathInRepo
+        value: pipelines/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-pull-request-pipelines
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Added missing konflux workflows to run AutoML and AutoRAG builds on pull requests to rhoai-3.4 branch (mostly to tests CVE fixes). 

Files ported from `main` branch (at time of rhoai-3.4 delivery). 