### PR TITLE
RHOAIENG-76599: Add Renovate package rule for vLLM build-suffixed tags

### DIFF
--- a/.github/workflows/renovate-dry-run.yml
+++ b/.github/workflows/renovate-dry-run.yml
@@ -108,6 +108,11 @@ jobs:
       - name: Run Renovate dry-run
         env:
           RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}
+          RENOVATE_HOST_RULES: >-
+            [
+              {"matchHost": "registry.redhat.io", "hostType": "docker", "username": "${{ secrets.REGISTRY_REDHAT_IO_USERNAME }}", "password": "${{ secrets.REGISTRY_REDHAT_IO_PASSWORD }}"},
+              {"matchHost": "registry.stage.redhat.io", "hostType": "docker", "username": "${{ secrets.REGISTRY_STAGE_REDHAT_IO_USERNAME }}", "password": "${{ secrets.REGISTRY_STAGE_REDHAT_IO_PASSWORD }}"}
+            ]
         run: |
           set -o pipefail
           script/run-renovate.sh \

--- a/.github/workflows/run-renovate.yml
+++ b/.github/workflows/run-renovate.yml
@@ -164,6 +164,11 @@ jobs:
       - name: Run Renovate
         env:
           RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}
+          RENOVATE_HOST_RULES: >-
+            [
+              {"matchHost": "registry.redhat.io", "hostType": "docker", "username": "${{ secrets.REGISTRY_REDHAT_IO_USERNAME }}", "password": "${{ secrets.REGISTRY_REDHAT_IO_PASSWORD }}"},
+              {"matchHost": "registry.stage.redhat.io", "hostType": "docker", "username": "${{ secrets.REGISTRY_STAGE_REDHAT_IO_USERNAME }}", "password": "${{ secrets.REGISTRY_STAGE_REDHAT_IO_PASSWORD }}"}
+            ]
         run: |
           set -o pipefail
           script/run-renovate.sh \

--- a/renovate/custom-renovate.json5
+++ b/renovate/custom-renovate.json5
@@ -63,7 +63,8 @@
         "registry\\.stage\\.redhat\\.io\\/rhaii.*\\/vllm-"
       ],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-ea\\.(?<prerelease>\\d+))?(-(?<build>\\d+))?$",
-      "enabled": true
+      "enabled": true,
+      "groupName": "vllm images"
     }
   ],
   "customManagers": [

--- a/renovate/custom-renovate.json5
+++ b/renovate/custom-renovate.json5
@@ -38,6 +38,32 @@
       "matchPackageNames": ["registry.redhat.io/cluster-observability-operator/perses-rhel9"],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)$",
       "enabled": true
+    },
+    {
+      // vLLM images across branches use several tag formats:
+      //
+      //   3.3.5                     — GA floating tag (rhoai-3.3)
+      //   3.4.0-1776326705          — GA non-floating build tag (rhoai-3.4, rhoai-3.5)
+      //   3.5.0-ea.1               — EA floating tag (rhoai-3.5-ea.1)
+      //   3.5.0-ea.2-1781643441    — EA non-floating build tag (rhoai-3.5-ea.2)
+      //
+      // Non-floating build tags never get new digests pushed to them, so
+      // Renovate must treat a build-number change as a version bump. But the
+      // global packageRule above disables major/minor/patch bumps for all
+      // images, so we re-enable them here and provide a regex versioning
+      // scheme that can parse all four formats.
+      //
+      // The images appear under multiple registry/org combinations:
+      //   registry.redhat.io/rhaii/...           — GA production
+      //   registry.redhat.io/rhaiis/...          — older GA production
+      //   registry.stage.redhat.io/rhaii/...           — GA staging
+      //   registry.stage.redhat.io/rhaii-early-access/... — EA staging
+      "matchPackagePatterns": [
+        "registry\\.redhat\\.io\\/rhaii.*\\/vllm-",
+        "registry\\.stage\\.redhat\\.io\\/rhaii.*\\/vllm-"
+      ],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-ea\\.(?<prerelease>\\d+))?(-(?<build>\\d+))?$",
+      "enabled": true
     }
   ],
   "customManagers": [

--- a/script/run-renovate.sh
+++ b/script/run-renovate.sh
@@ -40,6 +40,9 @@ usage() {
     echo "  --branches       JSON array of base branches (default: use config's baseBranches)"
     echo "  --dry-run        Run in dry-run mode (no PRs created)"
     echo "  --log-level      Renovate log level: debug, info, warn (default: debug)"
+    echo ""
+    echo "Environment (optional):"
+    echo "  RENOVATE_HOST_RULES  JSON array of hostRules for container registry auth"
     exit 1
 }
 
@@ -113,6 +116,10 @@ if [[ "$DRY_RUN" == "true" ]]; then
 fi
 
 docker_flags+=(-v "$CONFIG_FILE:/tmp/renovate-config.json:ro")
+
+if [[ -n "${RENOVATE_HOST_RULES:-}" ]]; then
+    docker_flags+=(-e "RENOVATE_HOST_RULES=$RENOVATE_HOST_RULES")
+fi
 
 pull_policy="missing"
 if [[ "$NO_PULL" == "true" ]]; then


### PR DESCRIPTION
## Summary

- vLLM images on `rhoai-3.5-ea.2` and `rhoai-3.5` switched to non-floating build-suffixed tags (e.g. `3.4.0-1776326705`, `3.5.0-ea.2-1781643441`), causing Renovate to silently stop updating them
- Adds a `packageRules` entry in `renovate/custom-renovate.json5` that re-enables version bumps for vLLM images with a regex versioning scheme that handles all tag formats: `3.3.5`, `3.4.0-1776326705`, `3.5.0-ea.1`, and `3.5.0-ea.2-1781643441`
- Covers all registry/org combinations: `registry.redhat.io` and `registry.stage.redhat.io` under `rhaii`, `rhaiis`, and `rhaii-early-access`
- Groups all vLLM variant updates (cuda, rocm, spyre, cpu, gaudi) into a single PR per branch
- Adds `RENOVATE_HOST_RULES` with registry credentials to both `run-renovate.yml` and `renovate-dry-run.yml` workflows so Renovate can authenticate to `registry.redhat.io` and `registry.stage.redhat.io` for image lookups

## Jira

[RHOAIENG-76599](https://redhat.atlassian.net/browse/RHOAIENG-76599)

## Test plan

- [x] Run Renovate dry-run against `RHOAI-Build-Config` and verify vLLM images are detected
- [x] Confirm registry auth works for both `registry.redhat.io` and `registry.stage.redhat.io`
- [x] Verify vLLM updates are grouped into a single PR per branch
- [x] Confirm existing non-vLLM image updates are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)