### PR TITLE
Add on-comment triggers for notebook push pipelines on rhoai-2.25

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-datascience-cpu-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-datascience-cpu-py312-v2-25-push.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-datascience)"
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-minimal-cpu-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-minimal-cpu-py312-v2-25-push.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-minimal-cpu)"
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-v2-25-push.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-pytorch-cuda)"
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v2-25-push.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-pytorch-llmcompressor)"
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v2-25-push.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-pytorch-rocm)"
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-v2-25-push.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-tensorflow-cuda)"
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v2-25-push.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-tensorflow-rocm)"
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"

--- a/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v2-25-push.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-codeserver)"
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v2-25-push.yaml
@@ -7,6 +7,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-datascience)"
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cpu-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cpu-py312-v2-25-push.yaml
@@ -7,6 +7,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-minimal-cpu)"
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cuda-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cuda-py312-v2-25-push.yaml
@@ -7,6 +7,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-minimal-cuda)"
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v2-25-push.yaml
@@ -7,6 +7,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-minimal-rocm)"
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-v2-25-push.yaml
@@ -7,6 +7,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-pytorch-cuda)"
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v2-25-push.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-pytorch-llmcompressor)"
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v2-25-push.yaml
@@ -7,6 +7,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-pytorch-rocm)"
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v2-25-push.yaml
@@ -7,6 +7,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-tensorflow-cuda)"
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v2-25-push.yaml
@@ -7,6 +7,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-tensorflow-rocm)"
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-v2-25-push.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-trustyai)"
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"


### PR DESCRIPTION
## Summary
- Add `pipelinesascode.tekton.dev/on-comment` annotations to all 18 notebook push PipelineRuns under `pipelineruns/notebooks/.tekton/` on `rhoai-2.25`
- Enables per-component rebuilds via PR comments (e.g. `/build-codeserver`) alongside existing push CEL expressions
- Comment triggers match the notebooks repo pull-request pipeline definitions

## Supported comment triggers

| Component | Comment |
|-----------|---------|
| codeserver | `/build-codeserver` |
| jupyter datascience | `/build-datascience` |
| jupyter minimal cpu | `/build-minimal-cpu` |
| jupyter minimal cuda | `/build-minimal-cuda` |
| jupyter minimal rocm | `/build-minimal-rocm` |
| jupyter pytorch cuda | `/build-pytorch-cuda` |
| jupyter pytorch llmcompressor | `/build-pytorch-llmcompressor` |
| jupyter pytorch rocm | `/build-pytorch-rocm` |
| jupyter tensorflow cuda | `/build-tensorflow-cuda` |
| jupyter tensorflow rocm | `/build-tensorflow-rocm` |
| jupyter trustyai | `/build-trustyai` |
| runtime datascience | `/build-runtime-datascience` |
| runtime minimal cpu | `/build-runtime-minimal-cpu` |
| runtime pytorch cuda | `/build-runtime-pytorch-cuda` |
| runtime pytorch llmcompressor | `/build-runtime-pytorch-llmcompressor` |
| runtime pytorch rocm | `/build-runtime-pytorch-rocm` |
| runtime tensorflow cuda | `/build-runtime-tensorflow-cuda` |
| runtime tensorflow rocm | `/build-runtime-tensorflow-rocm` |

All components also respond to `/build-konflux`.

## Test plan
- [ ] Open a PR against `notebooks` `rhoai-2.25` branch
- [ ] Comment `/build-codeserver` on the PR and verify only the codeserver push pipeline is triggered
- [ ] Comment `/build-datascience` and verify only the jupyter datascience push pipeline is triggered
- [ ] Confirm normal push-triggered builds still work via existing CEL expressions


Made with [Cursor](https://cursor.com)