### PR TITLE
fix(mlserver): disable package-registry-proxy for AIPCC index

### DIFF
--- a/pipelineruns/MLServer/.tekton/odh-mlserver-pull-request.yaml
+++ b/pipelineruns/MLServer/.tekton/odh-mlserver-pull-request.yaml
@@ -64,6 +64,8 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
+  - name: enable-package-registry-proxy
+    value: "false"
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Summary

- MLServer packages (mlserver-onnx, mlserver-lightgbm, etc. 1.7.1+rhaiv.8) only exist on the AIPCC index
- The pipeline default `enable-package-registry-proxy: "true"` causes hermeto to query the Nexus proxy instead of the `--index-url` in requirements.txt
- This results in FetchError (packages not found) during prefetch-dependencies
- Setting `enable-package-registry-proxy: "false"` allows hermeto to respect the AIPCC `--index-url` in requirements-cpu.txt

## Related

- MLServer build failure: odh-mlserver-v3-5 (never built successfully)
- Upstream fix PR: https://github.com/opendatahub-io/MLServer/pull/241 (stale hashes — problem 1)
- This PR fixes problem 2 (proxy overriding AIPCC index)

## Test plan

- [ ] Trigger build with `/build-konflux` and verify prefetch-dependencies passes
- [ ] Confirm mlserver packages resolve from AIPCC index