### PR TITLE
Wire RHEL subscription activation key for rhoai-3.3 hermetic prefetch

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-3-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-3-push.yaml
@@ -8,7 +8,6 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-codeserver)"
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"

--- a/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-3-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-3-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# retrigger build 2026-05-14T02:30:00Z
+# konflux build manual retrigger - 2026-05-29 15:32:03
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-codeserver)"
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
@@ -23,8 +24,8 @@ metadata:
   namespace: rhoai-tenant
 spec:
   timeouts:
-    pipeline: "8h0m0s"
-    tasks: "4h0m0s"
+    pipeline: 8h0m0s
+    tasks: 4h0m0s
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -32,19 +33,21 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9:{{target_branch}}
-  - name: rhoai-version
-    value: "3.3.5"
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
+  - name: rhoai-version
+    value: "3.3.5"
   - name: dockerfile
     value: codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
   - name: build-args-file
     value: codeserver/ubi9-python-3.12/build-args/konflux.cpu.conf
   - name: path-context
     value: .
+  - name: enable-cache-proxy
+    value: true
   - name: hermetic
-    value: false
+    value: true
   - name: build-image-index
     value: true
   - name: build-platforms
@@ -56,7 +59,144 @@ spec:
   - name: fips-check-blocking
     value: "false"
   - name: rhel-subscription-activation-key
-    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
+    value: "rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6"
+  - name: prefetch-input
+    value:
+    - path: codeserver/ubi9-python-3.12/prefetch-input/rhds
+      type: rpm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/rhds
+      type: generic
+    - path: codeserver/ubi9-python-3.12
+      type: pip
+      binary:
+        arch: "x86_64,aarch64,ppc64le,s390x"
+      requirements_files: ["requirements.cpu.txt"]
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/.vscode/extensions/vscode-selfhost-import-aid
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/.vscode/extensions/vscode-selfhost-test-provider
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/build
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/build/npm/gyp
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/build/vite
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/.vscode/extensions/vscode-extras
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/configuration-editing
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/css-language-features
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/css-language-features/server
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/debug-auto-launch
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/debug-server-ready
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/extension-editing
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/git
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/git-base
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/github
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/github-authentication
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/grunt
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/gulp
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/html-language-features
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/html-language-features/server
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/ipynb
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/jake
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/json-language-features
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/json-language-features/server
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/markdown-language-features
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/markdown-math
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/media-preview
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/merge-conflict
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/mermaid-chat-features
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/notebook-renderers
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/npm
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/php-language-features
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/references-view
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/search-result
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/simple-browser
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/terminal-suggest
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/tunnel-forwarding
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/typescript-language-features
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/vscode-api-tests
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/vscode-colorize-perf-tests
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/vscode-colorize-tests
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/vscode-test-resolver
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/remote
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/remote/web
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/test/automation
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/test/integration/browser
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/test/mcp
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/test/monaco
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/test/smoke
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/test/sanity
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/src/vs/sessions/test/e2e
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/test/e2e/extensions/test-extension
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server
+      type: npm
+    # patches/ overlay (codeserver/ubi9-python-3.12/prefetch-input/patches/) — Cachi2 prefetches registry-only lockfiles; keep in sync with patches that have package.json
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/remote
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/extensions
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/extensions/emmet
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/build/vite
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/test
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/extensions/microsoft-authentication
+      type: npm
+    # Registry-only npm deps (ProdSec); @parcel/watcher, @emmetio/css-parser, @playwright/browser-chromium in custom-packages/package.json
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/custom-packages
+      type: npm
   pipelineRef:
     resolver: git
     params:
@@ -73,4 +213,3 @@ spec:
     secret:
       secretName: '{{ git_auth_secret }}'
 status: {}
-#restart

--- a/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-3-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-3-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-05-29 15:32:03
+# retrigger build 2026-05-14T02:30:00Z
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}
@@ -23,8 +23,8 @@ metadata:
   namespace: rhoai-tenant
 spec:
   timeouts:
-    pipeline: 8h0m0s
-    tasks: 4h0m0s
+    pipeline: "8h0m0s"
+    tasks: "4h0m0s"
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -32,21 +32,19 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9:{{target_branch}}
+  - name: rhoai-version
+    value: "3.3.5"
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-  - name: rhoai-version
-    value: "3.3.5"
   - name: dockerfile
     value: codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
   - name: build-args-file
     value: codeserver/ubi9-python-3.12/build-args/konflux.cpu.conf
   - name: path-context
     value: .
-  - name: enable-cache-proxy
-    value: true
   - name: hermetic
-    value: true
+    value: false
   - name: build-image-index
     value: true
   - name: build-platforms
@@ -58,144 +56,7 @@ spec:
   - name: fips-check-blocking
     value: "false"
   - name: rhel-subscription-activation-key
-    value: "rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6"
-  - name: prefetch-input
-    value:
-    - path: codeserver/ubi9-python-3.12/prefetch-input/rhds
-      type: rpm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/rhds
-      type: generic
-    - path: codeserver/ubi9-python-3.12
-      type: pip
-      binary:
-        arch: "x86_64,aarch64,ppc64le,s390x"
-      requirements_files: ["requirements.cpu.txt"]
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/.vscode/extensions/vscode-selfhost-import-aid
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/.vscode/extensions/vscode-selfhost-test-provider
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/build
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/build/npm/gyp
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/build/vite
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/.vscode/extensions/vscode-extras
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/configuration-editing
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/css-language-features
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/css-language-features/server
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/debug-auto-launch
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/debug-server-ready
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/extension-editing
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/git
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/git-base
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/github
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/github-authentication
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/grunt
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/gulp
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/html-language-features
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/html-language-features/server
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/ipynb
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/jake
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/json-language-features
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/json-language-features/server
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/markdown-language-features
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/markdown-math
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/media-preview
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/merge-conflict
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/mermaid-chat-features
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/notebook-renderers
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/npm
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/php-language-features
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/references-view
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/search-result
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/simple-browser
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/terminal-suggest
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/tunnel-forwarding
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/typescript-language-features
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/vscode-api-tests
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/vscode-colorize-perf-tests
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/vscode-colorize-tests
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/vscode-test-resolver
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/remote
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/remote/web
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/test/automation
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/test/integration/browser
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/test/mcp
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/test/monaco
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/test/smoke
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/test/sanity
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/src/vs/sessions/test/e2e
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/test/e2e/extensions/test-extension
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server
-      type: npm
-    # patches/ overlay (codeserver/ubi9-python-3.12/prefetch-input/patches/) — Cachi2 prefetches registry-only lockfiles; keep in sync with patches that have package.json
-    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/remote
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/extensions
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/extensions/emmet
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/build/vite
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/test
-      type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/extensions/microsoft-authentication
-      type: npm
-    # Registry-only npm deps (ProdSec); @parcel/watcher, @emmetio/css-parser, @playwright/browser-chromium in custom-packages/package.json
-    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/custom-packages
-      type: npm
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:
@@ -212,3 +73,4 @@ spec:
     secret:
       secretName: '{{ git_auth_secret }}'
 status: {}
+#restart

--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -113,6 +113,10 @@ spec:
     description: RHOAI version of the form X.Y.Z (e.g., 3.2.1)
     name: rhoai-version
     type: string
+  - name: rhel-subscription-activation-key
+    default: 'custom-activation-key'
+    type: string
+    description: The name of the Kubernetes secret containing org and activationkey for RHEL subscription (used by prefetch-dependencies and buildah for hermetic RPM fetch and builds). See https://konflux-ci.dev/docs/building/activation-keys-subscription/
   - default: 'false'
     description: Disable all slack notifications
     name: disable-slack-notifications
@@ -207,6 +211,8 @@ spec:
     params:
     - name: input
       value: $(params.prefetch-input)
+    - name: ACTIVATION_KEY
+      value: $(params.rhel-subscription-activation-key)
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     - name: ociStorage
@@ -269,7 +275,7 @@ spec:
     - name: PRIVILEGED_NESTED
       value: $(params.privileged-nested)
     - name: ACTIVATION_KEY
-      value: custom-activation-key
+      value: $(params.rhel-subscription-activation-key)
     - name: LABELS
       value:
       - $(params.additional-labels[*])


### PR DESCRIPTION
## Summary
- Add `rhel-subscription-activation-key` pipeline param to `multi-arch-container-build.yaml` on `rhoai-3.3`, matching the working `rhoai-3.5` configuration.
- Pass `ACTIVATION_KEY` into `prefetch-dependencies` and `build-images` so hermeto can authenticate against `cdn.redhat.com` when prefetching RHDS RPMs.

## Problem
Hermetic builds on `rhoai-3.3` were failing during `prefetch-dependencies` with `403 Forbidden` when downloading aarch64 RPMs from `cdn.redhat.com`. PipelineRuns already set `rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6`, but the `rhoai-3.3` pipeline never forwarded that secret to `prefetch-dependencies` (it used a hardcoded `custom-activation-key` only in `build-images`).

## Test plan
- [ ] Merge and retrigger a hermetic Konflux build that prefetches RHDS RPMs
- [ ] Confirm `prefetch-dependencies` completes RPM download for `aarch64` without 403 errors
- [ ] Confirm multi-arch image build succeeds