### PR TITLE
fix(pipeline): update prefetch-dependencies task to 0.4.1 (hermeto 0.57.0+)

### DIFF
--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -251,7 +251,7 @@ spec:
       - name: name
         value: prefetch-dependencies-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:92956e75cd4714286f9c0c043f5301d1c0df1d750884edeceee87e0a91cc1975
+        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.4.1@sha256:ba1a3975a1e7b12ee1d11c4885930bf3540f532ddb57b5b66bb8b1122f41fa65
       - name: kind
         value: task
       resolver: bundles

--- a/renovate/pipelines-renovate.json5
+++ b/renovate/pipelines-renovate.json5
@@ -54,7 +54,7 @@
         // Allow minor version update for prefetch-dependencies task
         "matchPackageNames": ["quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta"],
         "matchUpdateTypes": ["minor"],
-        "allowedVersions": "<=0.3",
+        "allowedVersions": "<=0.4",
         "enabled": true,
       },
       {

--- a/renovate/pipelines-renovate.json5
+++ b/renovate/pipelines-renovate.json5
@@ -54,7 +54,7 @@
         // Allow minor version update for prefetch-dependencies task
         "matchPackageNames": ["quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta"],
         "matchUpdateTypes": ["minor"],
-        "allowedVersions": "<=0.4",
+        "allowedVersions": "<0.5",
         "enabled": true,
       },
       {


### PR DESCRIPTION
## Summary

- Hermeto 0.55.0 has a known bug where custom `--index-url` is ignored when the Nexus proxy is active
- Packages with PEP 440 local version identifiers (e.g. `+rhaiv.2`) fail to resolve
- Task 0.4.1 includes hermeto 0.57.0+ which fixes this
- Lightspeed resolved the same issue with this update

## Impact

- Fixes v3-4 training prefetch failures (kubeflow, mlflow, torchao with `+rhaiv` versions)
- Should also fix mlserver AIPCC index resolution (v3-5)
- Any component using custom `--index-url` with local version packages benefits

## References

- Hermeto fix: https://github.com/hermetoproject/hermeto/commit/f153a136ec
- Confirmed by tmadore in #forum-konflux-build
- Lightspeed reference: `quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.4.1@sha256:ba1a3975a1e7b12ee1d11c4885930bf3540f532ddb57b5b66bb8b1122f41fa65`

## Test plan

- [ ] Trigger build on affected component and verify prefetch-dependencies passes
- [ ] Confirm packages with local version identifiers resolve correctly