### PR TITLE
fix(mlserver): align MLServer naming and PR PipelineRuns on main

### DIFF
--- a/.github/workflows/run-renovate.yml
+++ b/.github/workflows/run-renovate.yml
@@ -10,6 +10,7 @@ on:
         description: Target repository
         options:
           - all
+          - MLServer
           - NeMo-Guardrails
           - RHOAI-Build-Config
           - agents-operator
@@ -42,7 +43,6 @@ on:
           - ml-metadata
           - mlflow
           - mlflow-operator
-          - mlserver
           - model-registry
           - model-registry-operator
           - modelmesh

--- a/config.yaml
+++ b/config.yaml
@@ -25,7 +25,7 @@
     - name: "red-hat-data-services/mlflow"
     - name: "red-hat-data-services/mlflow-operator"
     - name: "red-hat-data-services/vllm-gaudi"
-    - name: "red-hat-data-services/mlserver"
+    - name: "red-hat-data-services/MLServer"
     - name: "red-hat-data-services/models-as-a-service"
     - name: "red-hat-data-services/NeMo-Guardrails"
     - name: "red-hat-data-services/eval-hub"

--- a/pipelineruns/MLServer/.tekton/odh-mlserver-cuda-pull-request.yaml
+++ b/pipelineruns/MLServer/.tekton/odh-mlserver-cuda-pull-request.yaml
@@ -5,11 +5,12 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/MLServer?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-event: '[pull_request]'
-    pipelinesascode.tekton.dev/on-comment: '^/build-konflux'
-    pipelinesascode.tekton.dev/on-target-branch: '[{{target_branch}}]'
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation
     appstudio.openshift.io/component: pull-request-pipelines-odh-mlserver-cuda
@@ -22,6 +23,13 @@ spec:
     value: '{{source_url}}'
   - name: revision
     value: '{{revision}}'
+  - name: additional-tags
+    value:
+    - 'pr-{{pull_request_number}}-into-{{target_branch}}'
+  - name: additional-labels
+    value:
+    - version=on-pr-{{revision}}
+    - io.openshift.tags=odh-mlserver-cuda
   - name: output-image
     value: quay.io/rhoai/pull-request-pipelines:odh-mlserver-cuda-{{revision}}
   - name: dockerfile
@@ -58,6 +66,7 @@ spec:
   - name: enable-package-registry-proxy
     value: "false"
   pipelineRef:
+    resolver: git
     params:
     - name: url
       value: https://github.com/red-hat-data-services/konflux-central.git
@@ -65,7 +74,6 @@ spec:
       value: '{{ target_branch }}'
     - name: pathInRepo
       value: pipelines/multi-arch-container-build.yaml
-    resolver: git
   taskRunTemplate:
     serviceAccountName: build-pipeline-pull-request-pipelines
     podTemplate:
@@ -77,3 +85,4 @@ spec:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/MLServer/.tekton/odh-mlserver-pull-request.yaml
+++ b/pipelineruns/MLServer/.tekton/odh-mlserver-pull-request.yaml
@@ -77,6 +77,11 @@ spec:
       value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-pull-request-pipelines
+    podTemplate:
+      imagePullSecrets:
+      - name: redhat-appstudio-staginguser-pull-secret
+  timeouts:
+    pipeline: 8h
   workspaces:
   - name: git-auth
     secret:

--- a/script/multi-arch-tracking/exceptions.toml
+++ b/script/multi-arch-tracking/exceptions.toml
@@ -111,12 +111,6 @@ reason = "https://redhat-internal.slack.com/archives/C0961HQ858Q/p17730762204046
 issue = "https://redhat.atlassian.net/browse/RHAISTRAT-1756"
 
 [[exception]]
-component = "odh-mlserver-rhel9"
-architectures = ["ppc64le"]
-reason = "Not yet implemented, see Jira issue"
-issue = "https://issues.redhat.com/browse/RHOAIENG-45486"
-
-[[exception]]
 component = "odh-trustyai-nemo-guardrails-server-rhel9"
 architectures = ["ppc64le"]
 reason = "Not yet implemented, see Jira issue"


### PR DESCRIPTION
fix(mlserver): align MLServer naming and PR PipelineRuns on main

Use the canonical GitHub repo name MLServer in config/Renovate, bring CPU
and CUDA PR pipelines in sync (tags, labels, pull secret, timeout), and
drop the stale ppc64le arch exception.

Signed-off-by: Syed Nomaan Ali <syedali@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

Jira-Link : https://redhat.atlassian.net/browse/RHOAIENG-76663