### PR TITLE
fix(pipeline): update prefetch-dependencies task to 0.4.1 (hermeto 0.57.0+) [rhoai-3.4]

### DIFF
--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -234,7 +234,7 @@ spec:
       - name: name
         value: prefetch-dependencies-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:92956e75cd4714286f9c0c043f5301d1c0df1d750884edeceee87e0a91cc1975
+        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.4.1@sha256:ba1a3975a1e7b12ee1d11c4885930bf3540f532ddb57b5b66bb8b1122f41fa65
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
## Summary

Cherry-pick of #2852 to `rhoai-3.4` branch.

- Updates prefetch-dependencies task from 0.4.0 to 0.4.1, which includes hermeto 0.57.0+
- Fixes PEP 440 local version identifier resolution failures (e.g. `+rhaiv.2` suffixes)
- Only the task bump commit is cherry-picked; renovate config commits were skipped (file does not exist on release branches)

## Test plan

- [ ] Verify prefetch-dependencies task resolves to 0.4.1 in affected pipelines
- [ ] Confirm builds with PEP 440 local versions succeed (e.g. odh-th06-cuda130-torch210-py312)