### PR TITLE
fix(mlserver): consolidate and fix rhoai-3.5 push PipelineRuns

### DIFF
--- a/.github/workflows/sync-pipelineruns.yml
+++ b/.github/workflows/sync-pipelineruns.yml
@@ -56,7 +56,6 @@ on:
           - ml-metadata
           - mlflow
           - mlflow-operator
-          - mlserver
           - model-metadata-collection
           - model-registry
           - model-registry-operator

--- a/pipelineruns/MLServer/.tekton/odh-mlserver-cuda-v3-5-push.yaml
+++ b/pipelineruns/MLServer/.tekton/odh-mlserver-cuda-v3-5-push.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
@@ -12,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && ( files.all.exists(p, !p.matches('^\.tekton/')) || ".tekton/odh-mlserver-cuda-v3-5-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-mlserver-cuda-v3-5-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5
     appstudio.openshift.io/component: odh-mlserver-cuda-v3-5
@@ -38,12 +37,31 @@ spec:
     value: .
   - name: hermetic
     value: true
-
+  - name: enable-package-registry-proxy
+    value: "false"
+  - name: prefetch-input
+    value: |
+      {
+        "type": "pip",
+        "path": ".",
+        "requirements_files": [
+          "requirements/requirements-cuda.txt"
+        ],
+        "binary": {
+          "arch": "x86_64,aarch64",
+          "os": "linux"
+        }
+      }
+  - name: build-source-image
+    value: true
+  - name: build-image-index
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
   pipelineRef:
+    resolver: git
     params:
     - name: url
       value: https://github.com/red-hat-data-services/konflux-central.git
@@ -51,11 +69,15 @@ spec:
       value: '{{ target_branch }}'
     - name: pathInRepo
       value: pipelines/multi-arch-container-build.yaml
-    resolver: git
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-mlserver-cuda-v3-5
     podTemplate:
       imagePullSecrets:
       - name: redhat-appstudio-staginguser-pull-secret
   timeouts:
-    pipeline: 2h
+    pipeline: 8h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/MLServer/.tekton/odh-mlserver-v3-5-push.yaml
+++ b/pipelineruns/MLServer/.tekton/odh-mlserver-v3-5-push.yaml
@@ -37,6 +37,8 @@ spec:
     value: .
   - name: hermetic
     value: true
+  - name: enable-package-registry-proxy
+    value: "false"
   - name: prefetch-input
     value: |
       {
@@ -70,6 +72,11 @@ spec:
       value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-mlserver-v3-5
+    podTemplate:
+      imagePullSecrets:
+      - name: redhat-appstudio-staginguser-pull-secret
+  timeouts:
+    pipeline: 8h
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
fix(mlserver): consolidate and fix rhoai-3.5 push PipelineRuns

Move the CPU push under pipelineruns/MLServer, complete the CUDA hermetic
push (prefetch, git-auth, source/index), disable the package-registry
proxy for AIPCC indexes, and align timeouts/pull secrets.

Signed-off-by: Syed Nomaan Ali <syedali@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

Jira-Link : https://redhat.atlassian.net/browse/RHOAIENG-76663