### PR TITLE
RHAIENG-6200: Hybrid non-hermetic codeserver push for Conforma (rhoai-2.25)

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v2-25-push.yaml
@@ -46,8 +46,12 @@ spec:
     value: .
   - name: enable-cache-proxy
     value: true
+  # rhoai-2.25: hermetic waiver (hermetic_task.hermetic until 2027-05-03). Keep npm
+  # prefetch for the large VS Code tree; install pip / X.org / oc at build time so
+  # Hermeto does not emit Conforma-failing binary-wheel / generic / openshift-clients SBOM attrs.
+  # Mirrors notebooks PR #2533 (RHAIENG-6200).
   - name: hermetic
-    value: true
+    value: false
   - name: build-image-index
     value: true
   - name: build-platforms
@@ -62,15 +66,6 @@ spec:
     value: "rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6"
   - name: prefetch-input
     value:
-    - path: codeserver/ubi9-python-3.12/prefetch-input/rhds
-      type: rpm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/rhds
-      type: generic
-    - path: codeserver/ubi9-python-3.12
-      type: pip
-      binary:
-        arch: "x86_64,aarch64,ppc64le,s390x"
-      requirements_files: ["requirements.cpu.txt"]
     - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/.vscode/extensions/vscode-selfhost-import-aid
       type: npm
     - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/.vscode/extensions/vscode-selfhost-test-provider


### PR DESCRIPTION
## Summary
- Update codeserver `*-v2-25-push.yaml` to `hermetic: false` with **npm-only** prefetch (drop rpm/generic/pip Hermeto inputs).
- Uses the existing `hermetic_task.hermetic` waiver through 2027-05-03 so release builds avoid Conforma failures from Hermeto binary-wheel / X.org generic / `openshift-clients` SBOM attributes.
- Mirrors notebooks [PR #2533](https://github.com/red-hat-data-services/notebooks/pull/2533) (Dockerfile + PR pipeline already hybrid there).

## Test plan
- [ ] Merge after notebooks #2533 (hybrid Dockerfile) is on `rhoai-2.25`
- [ ] Confirm sync of this PipelineRun into `red-hat-data-services/notebooks` `.tekton/`
- [ ] Push build for `odh-workbench-codeserver-datascience-cpu-py312-v2-25` succeeds
- [ ] Conforma / `registry-rhoai-prod` no longer reports the prior binary-wheel / allowed_package_sources / openshift-clients repo-id hits


Made with [Cursor](https://cursor.com)