### PR TITLE
fix(trainer-operator): add workspaces git-auth to push pipeline

### DIFF
--- a/pipelineruns/trainer-operator/.tekton/odh-trainer-operator-v3-5-push.yaml
+++ b/pipelineruns/trainer-operator/.tekton/odh-trainer-operator-v3-5-push.yaml
@@ -63,3 +63,7 @@ spec:
       - name: redhat-appstudio-staginguser-pull-secret
   timeouts:
     pipeline: 2h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'


### PR DESCRIPTION
## Summary
- Adds the missing `workspaces` section with `git-auth` secret to the trainer-operator v3-5 push pipeline
- This is required for PAC to authenticate with GitHub and trigger on push events
- Without it, push builds only work via the incoming webhook

## Root cause
The workspaces section was accidentally omitted when the pipeline was generated by the onboarding automation.

## Test plan
- [ ] After merge and sync to trainer-operator repo, push to rhoai-3.5 branch should trigger a build automatically (without needing incoming webhook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)