### PR TITLE
test(trainer-operator): fix CEL regex escaping, revert workspaces

### DIFF
--- a/pipelineruns/trainer-operator/.tekton/odh-trainer-operator-v3-5-push.yaml
+++ b/pipelineruns/trainer-operator/.tekton/odh-trainer-operator-v3-5-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && ( files.all.exists(p, !p.matches('^\.tekton/')) || ".tekton/odh-trainer-operator-v3-5-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-trainer-operator-v3-5-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5
     appstudio.openshift.io/component: odh-trainer-operator-v3-5
@@ -63,7 +63,3 @@ spec:
       - name: redhat-appstudio-staginguser-pull-secret
   timeouts:
     pipeline: 2h
-  workspaces:
-  - name: git-auth
-    secret:
-      secretName: '{{ git_auth_secret }}'


### PR DESCRIPTION
## Summary
- Fix the backslash escaping in the on-cel-expression regex: `'^\.tekton/'` → `'^\\.tekton/'`
- Revert workspaces section to isolate whether the CEL fix alone enables push event triggering

## Why
The double backslash is needed because YAML consumes one level of escaping. Without it, the regex may not match .tekton paths correctly, preventing PAC from triggering on push events.

This is a test to determine if the CEL escaping issue is the root cause of push builds not triggering.

## Test plan
- [ ] After merge and sync to trainer-operator repo, push to rhoai-3.5 should trigger a build automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)