### PR TITLE
test: trigger rebuild to verify CEL fix

### DIFF
--- a/pipelineruns/trainer-operator/.tekton/odh-trainer-operator-v3-5-push.yaml
+++ b/pipelineruns/trainer-operator/.tekton/odh-trainer-operator-v3-5-push.yaml
@@ -1,4 +1,5 @@
 
+#rebuild
 apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:


### PR DESCRIPTION
Testing that the CEL regex escaping fix enables push builds without the workspaces section.