### PR TITLE
revert: remove rebuild comment from trainer-operator pipeline

### DIFF
--- a/pipelineruns/trainer-operator/.tekton/odh-trainer-operator-v3-5-push.yaml
+++ b/pipelineruns/trainer-operator/.tekton/odh-trainer-operator-v3-5-push.yaml
@@ -1,5 +1,4 @@
 
-#rebuild
 apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:


### PR DESCRIPTION
Removes the #rebuild comment added for testing.