### PR TITLE
fix: correct CEL regex escaping in v3-5 push pipelines

### DIFF
--- a/pipelineruns/agents-operator/.tekton/odh-authbridge-proxy-v3-5-push.yaml
+++ b/pipelineruns/agents-operator/.tekton/odh-authbridge-proxy-v3-5-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && ( files.all.exists(p, !p.matches('^\.tekton/')) || ".tekton/odh-authbridge-proxy-v3-5-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-authbridge-proxy-v3-5-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5
     appstudio.openshift.io/component: odh-authbridge-proxy-v3-5

--- a/pipelineruns/feast-module-operator/.tekton/odh-feast-module-operator-v3-5-push.yaml
+++ b/pipelineruns/feast-module-operator/.tekton/odh-feast-module-operator-v3-5-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && ( files.all.exists(p, !p.matches('^\.tekton/')) || ".tekton/odh-feast-module-operator-v3-5-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-feast-module-operator-v3-5-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5
     appstudio.openshift.io/component: odh-feast-module-operator-v3-5

--- a/pipelineruns/kserve/.tekton/odh-kserve-localmodelnode-agent-v3-5-push.yaml
+++ b/pipelineruns/kserve/.tekton/odh-kserve-localmodelnode-agent-v3-5-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && ( files.all.exists(p, !p.matches('^\.tekton/')) || ".tekton/odh-kserve-localmodelnode-agent-v3-5-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-kserve-localmodelnode-agent-v3-5-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5
     appstudio.openshift.io/component: odh-kserve-localmodelnode-agent-v3-5

--- a/pipelineruns/kserve/.tekton/odh-kserve-module-operator-v3-5-on-push.yaml
+++ b/pipelineruns/kserve/.tekton/odh-kserve-module-operator-v3-5-on-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && ( files.all.exists(p, !p.matches('^\.tekton/')) || ".tekton/odh-kserve-module-operator-v3-5-on-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-kserve-module-operator-v3-5-on-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5
     appstudio.openshift.io/component: odh-kserve-module-operator-v3-5

--- a/pipelineruns/llm-d-async/.tekton/odh-llm-d-async-v3-5-push.yaml
+++ b/pipelineruns/llm-d-async/.tekton/odh-llm-d-async-v3-5-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && ( files.all.exists(p, !p.matches('^\.tekton/')) || ".tekton/odh-llm-d-async-v3-5-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-llm-d-async-v3-5-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5
     appstudio.openshift.io/component: odh-llm-d-async-v3-5

--- a/pipelineruns/llm-d-router/.tekton/odh-llm-d-router-disagg-sidecar-v3-5-push.yaml
+++ b/pipelineruns/llm-d-router/.tekton/odh-llm-d-router-disagg-sidecar-v3-5-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && ( files.all.exists(p, !p.matches('^\.tekton/')) || ".tekton/odh-llm-d-router-disagg-sidecar-v3-5-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-llm-d-router-disagg-sidecar-v3-5-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5
     appstudio.openshift.io/component: odh-llm-d-router-disagg-sidecar-v3-5

--- a/pipelineruns/llm-d-router/.tekton/odh-llm-d-router-endpoint-picker-v3-5-push.yaml
+++ b/pipelineruns/llm-d-router/.tekton/odh-llm-d-router-endpoint-picker-v3-5-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && ( files.all.exists(p, !p.matches('^\.tekton/')) || ".tekton/odh-llm-d-router-endpoint-picker-v3-5-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-llm-d-router-endpoint-picker-v3-5-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5
     appstudio.openshift.io/component: odh-llm-d-router-endpoint-picker-v3-5

--- a/pipelineruns/mcp-lifecycle-module-operator/.tekton/odh-mcp-lifecycle-module-operator-v3-5-push.yaml
+++ b/pipelineruns/mcp-lifecycle-module-operator/.tekton/odh-mcp-lifecycle-module-operator-v3-5-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && ( files.all.exists(p, !p.matches('^\.tekton/')) || ".tekton/odh-mcp-lifecycle-module-operator-v3-5-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-mcp-lifecycle-module-operator-v3-5-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5
     appstudio.openshift.io/component: odh-mcp-lifecycle-module-operator-v3-5

--- a/pipelineruns/mcp-lifecycle-operator/.tekton/odh-mcp-lifecycle-operator-v3-5-push.yaml
+++ b/pipelineruns/mcp-lifecycle-operator/.tekton/odh-mcp-lifecycle-operator-v3-5-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && ( files.all.exists(p, !p.matches('^\.tekton/')) || ".tekton/odh-mcp-lifecycle-operator-v3-5-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-mcp-lifecycle-operator-v3-5-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5
     appstudio.openshift.io/component: odh-mcp-lifecycle-operator-v3-5

--- a/pipelineruns/odh-dashboard/.tekton/odh-core-bff-v3-5-push.yaml
+++ b/pipelineruns/odh-dashboard/.tekton/odh-core-bff-v3-5-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && ( files.all.exists(p, !p.matches('^\.tekton/')) || ".tekton/odh-core-bff-v3-5-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-core-bff-v3-5-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5
     appstudio.openshift.io/component: odh-core-bff-v3-5

--- a/pipelineruns/odh-dashboard/.tekton/odh-dashboard-operator-v3-5-push.yaml
+++ b/pipelineruns/odh-dashboard/.tekton/odh-dashboard-operator-v3-5-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && ( files.all.exists(p, !p.matches('^\.tekton/')) || ".tekton/odh-dashboard-operator-v3-5-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-dashboard-operator-v3-5-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5
     appstudio.openshift.io/component: odh-dashboard-operator-v3-5

--- a/pipelineruns/workbenches-operator/.tekton/odh-workbenches-operator-v3-5-push.yaml
+++ b/pipelineruns/workbenches-operator/.tekton/odh-workbenches-operator-v3-5-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && ( files.all.exists(p, !p.matches('^\.tekton/')) || ".tekton/odh-workbenches-operator-v3-5-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-workbenches-operator-v3-5-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5
     appstudio.openshift.io/component: odh-workbenches-operator-v3-5


### PR DESCRIPTION
## Summary
Fix the backslash escaping in the on-cel-expression regex for all affected v3-5 push pipelines:
- Change `'^\.tekton/'` to `'^\\.tekton/'`

## Why
The double backslash is needed because YAML consumes one level of escaping. Without it, the regex doesn't correctly match .tekton paths, preventing PAC from triggering on push events.

Verified with trainer-operator that this fix enables automatic push builds.

## Affected components (12 files)
- agents-operator (authbridge-proxy)
- feast-module-operator
- kserve (module-operator, localmodelnode-agent)
- llm-d-async
- llm-d-router (disagg-sidecar, endpoint-picker)
- mcp-lifecycle-module-operator
- mcp-lifecycle-operator
- odh-dashboard (core-bff, dashboard-operator)
- workbenches-operator

## Test plan
- [ ] After merge and sync, pushes to these component repos on rhoai-3.5 should trigger builds automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)