### PR TITLE
Increase odh-workbenches-operator-v3-5 push timeout to 4h

### DIFF
--- a/pipelineruns/workbenches-operator/.tekton/odh-workbenches-operator-v3-5-push.yaml
+++ b/pipelineruns/workbenches-operator/.tekton/odh-workbenches-operator-v3-5-push.yaml
@@ -62,4 +62,4 @@ spec:
       imagePullSecrets:
       - name: redhat-appstudio-staginguser-pull-secret
   timeouts:
-    pipeline: 2h
+    pipeline: 4h


### PR DESCRIPTION
## Summary

- Increase pipeline timeout from 2h to 4h for odh-workbenches-operator-v3-5 push builds

## Reason

This component builds for 4 architectures (x86_64, arm64, ppc64le, s390x) and
depends on registry.redhat.io which is prone to 503/504 errors. The 2h timeout
is insufficient — the build on 2026-07-17 completed all 4 arch images successfully
but timed out because registry retries consumed ~10 min per arch.

All other 4-arch components in RHOAI have at least 4h timeout. This is the only
one at 2h.

## Evidence

- Build failure: odh-workbenches-operator-v3-5-on-push-kmv4c (PipelineRunTimeout)
- All 4 arch images built successfully — timeout was consumed by registry.redhat.io
  503/504 retry loops during base image pulls