### PR TITLE
fix: inject version/build metadata into ai-gateway-operator v3-5 build

### DIFF
--- a/pipelineruns/ai-gateway-operator/.tekton/odh-ai-gateway-operator-v3-5-push.yaml
+++ b/pipelineruns/ai-gateway-operator/.tekton/odh-ai-gateway-operator-v3-5-push.yaml
@@ -39,6 +39,10 @@ spec:
   - name: build-args
     value:
     - BUILD_TYPE=CI
+    - GIT_COMMIT={{revision}}
+    - GIT_BRANCH={{target_branch}}
+    - GIT_REPO={{source_url}}
+    - VERSION=3.5.0
   - name: hermetic
     value: true
   - name: prefetch-input


### PR DESCRIPTION
## Problem

`oc get aigateway` reports `VERSION: 0.0.0-dev` and `buildSource: unknown@unknown/unknown` on RHOAI `rhoai-3.5` builds (opendatahub-io/ai-gateway-operator#63).

Root cause: the `rhoai-3.5` push pipeline passed only `BUILD_TYPE=CI` as a build-arg. `Containerfile.konflux` guards its ldflags injection on `GIT_COMMIT` being non-empty, so with no `GIT_COMMIT` the injection was skipped and the binary kept its compile-time defaults from `pkg/version`.

## Fix

Pass the git/version build-args to the `odh-ai-gateway-operator-v3-5` push pipeline:

- `GIT_COMMIT` / `GIT_BRANCH` / `GIT_REPO` → populate `status.module.buildSource`
- `VERSION=3.5.0` → populate `status.module.version` (matches the existing `rhoai-version` param)

`VERSION` must be a **valid semver**: `pkg/version.Version` is parsed via `semver.ParseTolerant` at operator startup and a parse failure is fatal (crashloop). A git SHA (`{{revision}}`) or a label (`rhoai-v3-5`) would fail to parse — `3.5.0` is used deliberately.

Fixes opendatahub-io/ai-gateway-operator#63

🤖 Generated with [Claude Code](https://claude.com/claude-code)