### PR TITLE
RHOAIENG-77914/77915: Prefetch rollback, Renovate config fixes, and dry-run reporting

### DIFF
--- a/.github/workflows/renovate-dry-run.yml
+++ b/.github/workflows/renovate-dry-run.yml
@@ -1,13 +1,9 @@
-name: "PR Check: Renovate Dry Run"
+name: "Test Renovate Config"
+
+run-name: "Test Renovate Config${{ github.ref_name != 'main' && format(' [{0}]', github.ref_name) || '' }}"
 
 on:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - 'renovate/**'
-      - 'config.yaml'
-      - '.github/renovate.json'
+  workflow_dispatch:
 
 env:
   GITHUB_ORG: "red-hat-data-services"
@@ -37,8 +33,18 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          changed=$(gh pr diff "${{ github.event.pull_request.number }}" --name-only)
-          affected=$(echo "$changed" | python3 script/detect-affected-renovate-repos.py)
+          # If the branch has an open PR, detect affected repos from the diff.
+          # Otherwise default to konflux-central.
+          pr_number=$(gh pr list --head "${{ github.ref_name }}" --json number --jq '.[0].number' || true)
+
+          if [[ -n "$pr_number" ]]; then
+            echo "Found PR #$pr_number for branch ${{ github.ref_name }}"
+            changed=$(gh pr diff "$pr_number" --name-only)
+            affected=$(echo "$changed" | python3 script/detect-affected-renovate-repos.py)
+          else
+            echo "No PR found for branch ${{ github.ref_name }}, defaulting to konflux-central"
+            affected="konflux-central"
+          fi
 
           echo "Affected repos: $affected"
 
@@ -105,7 +111,7 @@ jobs:
       - name: Install dependencies
         run: pip install json5
 
-      - name: Run Renovate dry-run
+      - name: Run Renovate dry-run (local platform)
         env:
           RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}
           RENOVATE_HOST_RULES: >-
@@ -115,73 +121,26 @@ jobs:
             ]
         run: |
           set -o pipefail
-          script/run-renovate.sh \
-            --repo "${{ matrix.config.repo }}" \
+          script/run-renovate-local.sh \
             --config-file "${{ matrix.config.config_file }}" \
             --image "${{ env.RENOVATE_IMAGE }}" \
-            --branches '${{ toJSON(matrix.config.base_branches) }}' \
-            --log-level debug \
-            --log-format json \
-            --dry-run \
             2>&1 | tee /tmp/renovate.log
 
-      - name: Extract dry-run results
+      - name: Report results
         if: always()
         run: |
-          mkdir -p /tmp/results
           python3 script/extract-renovate-dry-run-results.py \
             --repo "${{ matrix.config.short_name }}" \
             --config "${{ matrix.config.config_file }}" \
-            --branches '${{ toJSON(matrix.config.base_branches) }}' \
+            --branches '["local"]' \
             --log /tmp/renovate.log \
-            --output "/tmp/results/${{ matrix.config.short_name }}.md"
+            --output /tmp/dry-run-summary.md
 
-      - name: Upload results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: "renovate-dry-run-${{ matrix.config.short_name }}"
-          path: /tmp/results/
-          if-no-files-found: ignore
-
-  report:
-    needs: [setup, dry-run]
-    if: always() && needs.setup.outputs.skip != 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download all results
-        uses: actions/download-artifact@v4
-        with:
-          pattern: renovate-dry-run-*
-          merge-multiple: true
-          path: results
-
-      - name: Build consolidated comment
-        run: |
           {
-            echo "<!-- renovate-dry-run-comment -->"
-            echo "## PR Check: Renovate Dry Run Results"
+            echo "### ${{ matrix.config.short_name }}"
             echo ""
-            echo "| Repo | Config | Branches | Result |"
-            echo "|------|--------|----------|--------|"
-
-            for f in results/*.md; do
-              [[ -f "$f" ]] && cat "$f"
-              echo ""
-            done
-
+            echo "- **Branch:** \`${{ github.ref_name }}\`"
+            echo "- **Config:** \`${{ matrix.config.config_file }}\`"
             echo ""
-            echo "*Triggered by commit \`${{ github.event.pull_request.head.sha }}\`*"
-          } > renovate-comment.md
-
-          echo "${{ github.event.pull_request.number }}" > pr-number.txt
-
-          cat renovate-comment.md
-
-      - name: Upload comment artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: renovate-dry-run-comment
-          path: |
-            renovate-comment.md
-            pr-number.txt
+            cat /tmp/dry-run-summary.md
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/run-renovate.yml
+++ b/.github/workflows/run-renovate.yml
@@ -76,13 +76,6 @@ on:
         description: 'Dry run (no PRs created)'
         required: true
         default: true
-      log_level:
-        type: choice
-        description: 'Renovate log level'
-        options:
-          - debug
-          - info
-          - warn
 
 env:
   GITHUB_ORG: "red-hat-data-services"
@@ -176,7 +169,8 @@ jobs:
             --config-file "${{ matrix.config.config_file }}" \
             --image "${{ env.RENOVATE_IMAGE }}" \
             --branches '${{ toJSON(matrix.config.base_branches) }}' \
-            --log-level "${{ inputs.log_level }}" \
+            --log-level debug \
+            --log-format json \
             ${{ inputs.dry_run == true && '--dry-run' || '' }} \
             2>&1 | tee /tmp/renovate.log
 
@@ -209,14 +203,13 @@ jobs:
             elif [[ "$dry_run" == "true" ]]; then
               echo "#### Dry Run Complete"
               echo ""
-              dry_run_prs=$(grep -E 'DRY-RUN.*Would (create|update|commit)' /tmp/renovate.log || true)
-              if [[ -n "$dry_run_prs" ]]; then
-                echo '```'
-                echo "$dry_run_prs"
-                echo '```'
-              else
-                echo "No changes detected."
-              fi
+              python3 script/extract-renovate-dry-run-results.py \
+                --repo "${{ matrix.config.short_name }}" \
+                --config "${{ matrix.config.config_file }}" \
+                --branches '${{ toJSON(matrix.config.base_branches) }}' \
+                --log /tmp/renovate.log \
+                --output /tmp/dry-run-summary.md
+              cat /tmp/dry-run-summary.md
             else
               echo "#### No PRs Created"
               echo ""

--- a/renovate/pipelines-renovate.json5
+++ b/renovate/pipelines-renovate.json5
@@ -8,7 +8,6 @@
   "enabledManagers": ["tekton", "custom.regex"],
   "customManagers": [
     {
-      "schedule": ["at any time"],
       "customType": "regex",
       "fileMatch": ["pipelines/.*\\.yaml$"],
       "matchStrings": [
@@ -24,6 +23,7 @@
     {
       // Group with tekton task bundle updates (MintMaker uses the same groupName)
       "matchManagers": ["custom.regex"],
+      "schedule": ["at any time"],
       "groupName": "Konflux references",
       "automerge": true
     },
@@ -34,28 +34,40 @@
         "https://github.com/konflux-ci/konflux-operator-tasks",
       ],
       "enabled": true
-    }
+    },
   ],
   "tekton": {
     "schedule": ["at any time"],
     "fileMatch": ["\\.yaml$", "\\.yml$"],
-    "includePaths": ["pipelineruns/**", "pipelines/**", "tasks/**"],
+    "includePaths": [".tekton/**", "pipelineruns/**", "pipelines/**", "tasks/**"],
     "automerge": true,
+    "baseBranchPatterns": ["/.*/"],
     // Group all tekton updates into one PR per branch (matches MintMaker)
     "groupName": "Konflux references",
     "packageRules": [
       {
-        // Only allow digest (patch-level) updates — disable major/minor/pin changes
-        // to avoid accidentally pulling in breaking task bundle updates
+        // Only allow digest and patch updates — disable major/minor/pin changes
+        // to avoid accidentally pulling in breaking task bundle updates.
+        // matchPackageNames is required so this rule has equal specificity to
+        // MintMaker's "enabled: true" rule (which also matches by package name).
         "matchUpdateTypes": ["major", "minor", "pin", "pinDigest"],
         "enabled": false
       },
       {
-        // Allow minor version update for prefetch-dependencies task
+        // Pin prefetch-dependencies to 0.4.x — update allowedVersions to move to a new minor
         "matchPackageNames": ["quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta"],
         "matchUpdateTypes": ["minor"],
-        "allowedVersions": "<0.5",
         "enabled": true,
+      },
+      {
+        "matchPackageNames": ["quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta"],
+        "allowedVersions": ">=0.4.0 <0.5.0",
+      },
+      {
+        // Force rollback from 0.5.0 to 0.4.1 — remove this rule after the rollback PR merges
+        "matchPackageNames": ["quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta"],
+        "matchCurrentValue": "/(0\\.5\\.0)/",
+        "replacementVersion": "0.4.1",
       },
       {
         // Allow minor version update for buildah-remote-oci-ta to pick up
@@ -63,8 +75,12 @@
         "matchPackageNames": ["quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta"],
         "matchUpdateTypes": ["minor"],
         "matchBaseBranches": ["main", "rhoai-3.5"],
-        "allowedVersions": "<=0.10",
         "enabled": true,
+      },
+      {
+        "matchPackageNames": ["quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta"],
+        "matchBaseBranches": ["main", "rhoai-3.5"],
+        "allowedVersions": "<=0.10",
       },
     ]
   }

--- a/script/extract-renovate-dry-run-results.py
+++ b/script/extract-renovate-dry-run-results.py
@@ -7,6 +7,71 @@ import sys
 from collections import defaultdict
 
 
+def truncate_digest(digest, length=12):
+    """Truncate a hex digest for display, preserving sha256: prefix if present."""
+    if digest.startswith("sha256:"):
+        return f"sha256:{digest[7:7+length]}.."
+    return f"{digest[:length]}.."
+
+
+def format_version(dep, update):
+    """Format the From and To columns for an update."""
+    current_value = dep.get("currentValue", "")
+    current_digest = dep.get("currentDigest", "")
+    new_value = update.get("newValue", "")
+    new_digest = update.get("newDigest", "")
+    update_type = update.get("updateType", "")
+
+    if update_type == "digest" and not new_value:
+        from_str = truncate_digest(current_digest) if current_digest else "-"
+        to_str = truncate_digest(new_digest) if new_digest else "-"
+    elif new_value and new_value != current_value:
+        from_str = current_value or "-"
+        to_str = new_value or "-"
+        if current_digest and new_digest:
+            from_str += f" ({truncate_digest(current_digest)})"
+            to_str += f" ({truncate_digest(new_digest)})"
+    elif new_digest:
+        from_str = current_value or ""
+        to_str = from_str
+        if current_digest:
+            from_str += f" ({truncate_digest(current_digest)})"
+        if new_digest:
+            to_str += f" ({truncate_digest(new_digest)})"
+    else:
+        from_str = current_value or current_digest or "-"
+        to_str = new_value or new_digest or "-"
+
+    return from_str, to_str
+
+
+def extract_updates_from_package_files(entry):
+    """Extract detailed updates from a 'packageFiles with updates' log entry."""
+    updates = []
+    config = entry.get("config", {})
+    base_branch = entry.get("baseBranch", "unknown")
+
+    for manager_name, package_files in config.items():
+        if not isinstance(package_files, list):
+            continue
+        for pf in package_files:
+            package_file = pf.get("packageFile", "")
+            for dep in pf.get("deps", []):
+                if dep.get("skipReason"):
+                    continue
+                for update in dep.get("updates", []):
+                    from_str, to_str = format_version(dep, update)
+                    updates.append({
+                        "depName": dep.get("depName", "unknown"),
+                        "packageFile": package_file,
+                        "updateType": update.get("updateType", "unknown"),
+                        "from": from_str,
+                        "to": to_str,
+                        "baseBranch": base_branch,
+                    })
+    return updates
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Extract dependency updates from a Renovate JSON log (dry-run mode)."
@@ -20,29 +85,32 @@ def main():
 
     branches_display = ", ".join(json.loads(args.branches))
 
-    # Parse JSON log lines looking for "flattened updates found" messages
     dep_branches = defaultdict(set)
+    detailed_updates = []
 
     try:
         with open(args.log) as f:
             for line in f:
                 line = line.strip()
-                if "flattened updates found" not in line:
+                if not line:
                     continue
                 try:
                     entry = json.loads(line)
                 except json.JSONDecodeError:
                     continue
 
-                branch = entry.get("baseBranch", "unknown")
                 msg = entry.get("msg", "")
 
-                # msg format: "2 flattened updates found: dep1, dep2"
-                match = re.match(r"\d+ flattened updates found: (.+)", msg)
-                if match:
-                    deps = [d.strip() for d in match.group(1).split(",")]
-                    for dep in deps:
-                        dep_branches[dep].add(branch)
+                if msg == "packageFiles with updates":
+                    detailed_updates.extend(extract_updates_from_package_files(entry))
+
+                if "flattened updates found" in msg:
+                    branch = entry.get("baseBranch", "unknown")
+                    match = re.match(r"\d+ flattened updates found: (.+)", msg)
+                    if match:
+                        deps = [d.strip() for d in match.group(1).split(",")]
+                        for dep in deps:
+                            dep_branches[dep].add(branch)
     except FileNotFoundError:
         print(f"warning: log file not found: {args.log}", file=sys.stderr)
 
@@ -57,12 +125,37 @@ def main():
         if dep_branches:
             f.write("\n")
             f.write(f"<details><summary>{args.repo} — updated dependencies</summary>\n\n")
-            f.write("| Dependency | Branches |\n")
-            f.write("|------------|----------|\n")
-            for dep in sorted(dep_branches):
-                branches = ", ".join(sorted(dep_branches[dep]))
-                f.write(f"| `{dep}` | {branches} |\n")
-            f.write("\n</details>\n")
+
+            if detailed_updates:
+                branches_with_updates = sorted(
+                    set(u["baseBranch"] for u in detailed_updates)
+                )
+                for branch in branches_with_updates:
+                    branch_updates = [
+                        u for u in detailed_updates if u["baseBranch"] == branch
+                    ]
+                    if len(branches_with_updates) > 1:
+                        f.write(f"**{branch}**\n\n")
+
+                    f.write("| Dependency | File | Update | From | To |\n")
+                    f.write("|------------|------|--------|------|---------|\n")
+                    for u in branch_updates:
+                        dep = f"`{u['depName']}`"
+                        pkg = f"`{u['packageFile']}`"
+                        f.write(
+                            f"| {dep} | {pkg} | {u['updateType']} "
+                            f"| {u['from']} | {u['to']} |\n"
+                        )
+                    f.write("\n")
+            else:
+                f.write("| Dependency | Branches |\n")
+                f.write("|------------|----------|\n")
+                for dep in sorted(dep_branches):
+                    branches = ", ".join(sorted(dep_branches[dep]))
+                    f.write(f"| `{dep}` | {branches} |\n")
+                f.write("\n")
+
+            f.write("</details>\n")
 
 
 if __name__ == "__main__":

--- a/script/run-renovate-local.sh
+++ b/script/run-renovate-local.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# Run Renovate in local platform mode for dry-run testing.
+#
+# Uses --platform=local so Renovate reads files from the current checkout
+# instead of cloning from GitHub. This allows testing config changes on
+# feature branches before merging.
+#
+# Config layering matches production:
+#   - MintMaker's config as RENOVATE_CONFIG_FILE (base, lower priority)
+#   - Our config mounted as .github/renovate.json (repo config, overrides base)
+#
+# Usage:
+#   RENOVATE_TOKEN=<token> ./script/run-renovate-local.sh \
+#     --config-file renovate/pipelines-renovate.json5 \
+#     [--image <renovate-image>]
+#
+# For local dev with ARM Mac:
+#   RENOVATE_TOKEN=$(gh auth token) ./script/run-renovate-local.sh \
+#     --config-file renovate/pipelines-renovate.json5 \
+#     --image localhost/mintmaker-renovate:local
+
+set -euo pipefail
+
+# Defaults
+IMAGE="quay.io/konflux-ci/mintmaker-renovate-image:latest"
+LOG_LEVEL=debug
+LOG_FORMAT=json
+NO_PULL=false
+
+MINTMAKER_CONFIG_URL="https://raw.githubusercontent.com/konflux-ci/mintmaker/main/config/renovate/renovate.json"
+
+usage() {
+    echo "Usage: RENOVATE_TOKEN=<token> $0 --config-file PATH [options]"
+    echo ""
+    echo "Environment:"
+    echo "  RENOVATE_TOKEN       GitHub token (required for version lookups)"
+    echo "  RENOVATE_HOST_RULES  JSON array of hostRules for registry auth"
+    echo ""
+    echo "Required:"
+    echo "  --config-file    Path to the Renovate config file (e.g. renovate/pipelines-renovate.json5)"
+    echo ""
+    echo "Optional:"
+    echo "  --image          Renovate container image (default: $IMAGE)"
+    echo "  --no-pull        Don't pull the image (use local build)"
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --config-file)  CONFIG_FILE="$2"; shift 2 ;;
+        --image)        IMAGE="$2"; shift 2 ;;
+        --no-pull)      NO_PULL=true; shift ;;
+        -h|--help)      usage ;;
+        *)              echo "Unknown option: $1"; usage ;;
+    esac
+done
+
+if [[ -z "${RENOVATE_TOKEN:-}" ]]; then
+    echo "error: RENOVATE_TOKEN environment variable is required" >&2
+    usage
+fi
+
+if [[ -z "${CONFIG_FILE:-}" ]]; then
+    echo "error: --config-file is required" >&2
+    usage
+fi
+
+CONFIG_FILE=$(realpath "$CONFIG_FILE")
+
+# Download MintMaker's config as base (matches RENOVATE_CONFIG_FILE in production)
+MINTMAKER_BASE=$(mktemp)
+curl -sL "$MINTMAKER_CONFIG_URL" > "$MINTMAKER_BASE"
+chmod 644 "$MINTMAKER_BASE"
+
+# Convert JSON5 config to JSON for mounting as repo config.
+# Try bare python3 first (CI has json5 installed); fall back to uv for local dev.
+REPO_CONFIG=$(mktemp)
+if python3 -c "import json5" 2>/dev/null; then
+    PYTHON=python3
+else
+    PYTHON="uv run --with json5 python3"
+fi
+$PYTHON -c "
+import json, json5, sys
+with open(sys.argv[1]) as f:
+    config = json5.loads(f.read())
+json.dump(config, sys.stdout, indent=2)
+" "$CONFIG_FILE" > "$REPO_CONFIG"
+chmod 644 "$REPO_CONFIG"
+
+# Build docker flags
+docker_flags=()
+docker_flags+=(-e "RENOVATE_TOKEN=$RENOVATE_TOKEN")
+docker_flags+=(-e "RENOVATE_CONFIG_FILE=/tmp/mintmaker-base.json")
+docker_flags+=(-e "LOG_LEVEL=$LOG_LEVEL")
+docker_flags+=(-e "LOG_FORMAT=$LOG_FORMAT")
+
+if [[ -n "${RENOVATE_HOST_RULES:-}" ]]; then
+    docker_flags+=(-e "RENOVATE_HOST_RULES=$RENOVATE_HOST_RULES")
+fi
+
+# Mount workspace and config files
+docker_flags+=(-v "$(pwd):/workspace:ro")
+docker_flags+=(-v "$REPO_CONFIG:/workspace/.github/renovate.json:ro")
+docker_flags+=(-v "$MINTMAKER_BASE:/tmp/mintmaker-base.json:ro")
+docker_flags+=(-w /workspace)
+
+pull_policy="missing"
+if [[ "$NO_PULL" == "true" ]]; then
+    pull_policy="never"
+fi
+
+podman run --rm --pull="$pull_policy" "${docker_flags[@]}" "$IMAGE" \
+    renovate --platform=local --dry-run=lookup

--- a/script/run-renovate.sh
+++ b/script/run-renovate.sh
@@ -66,40 +66,34 @@ if [[ -z "${RENOVATE_TOKEN:-}" ]]; then
     usage
 fi
 
-if [[ -z "${REPO:-}" || -z "${CONFIG_FILE:-}" ]]; then
-    echo "error: --repo and --config-file are required" >&2
+if [[ -z "${REPO:-}" ]]; then
+    echo "error: --repo is required" >&2
     usage
 fi
 
-CONFIG_FILE=$(realpath "$CONFIG_FILE")
+# Match production: MintMaker's config is RENOVATE_CONFIG_FILE (base),
+# and .github/renovate.json from the repo overrides it at repo level.
+MINTMAKER_CONFIG_URL="https://raw.githubusercontent.com/konflux-ci/mintmaker/main/config/renovate/renovate.json"
 
-# Our source config is RENOVATE_CONFIG_FILE (mounted into the container).
-# MintMaker's global config is the base via RENOVATE_EXTENDS.
-# RENOVATE_FORCE overrides only enabledManagers (MintMaker's extends sets
-# ~60 managers) and baseBranchPatterns (when --branches is provided).
-MINTMAKER_EXTENDS="github>konflux-ci/mintmaker//config/renovate/renovate.json"
+# Download MintMaker's config as the base.
+MINTMAKER_BASE=$(mktemp)
+curl -sL "$MINTMAKER_CONFIG_URL" > "$MINTMAKER_BASE"
+chmod 644 "$MINTMAKER_BASE"
 
-# Build force config with only the fields that need overriding.
-FORCE_CONFIG=$(python3 -c "
-import json, json5, sys
-with open(sys.argv[1]) as f:
-    config = json5.loads(f.read())
-force = {}
-if 'enabledManagers' in config:
-    force['enabledManagers'] = config['enabledManagers']
-branches = sys.argv[2]
-if branches != '[]':
-    force['baseBranchPatterns'] = json.loads(branches)
-json.dump(force, sys.stdout)
-" "$CONFIG_FILE" "$BRANCHES_JSON")
+# Force is only used to override baseBranchPatterns when --branches is specified.
+FORCE_CONFIG='{}'
+if [[ "$BRANCHES_JSON" != "[]" ]]; then
+    FORCE_CONFIG=$(python3 -c "
+import json, sys
+print(json.dumps({'baseBranchPatterns': json.loads(sys.argv[1])}))
+" "$BRANCHES_JSON")
+fi
 
 # Build docker flags
 docker_flags=()
 docker_flags+=(-e "RENOVATE_TOKEN=$RENOVATE_TOKEN")
 docker_flags+=(-e "RENOVATE_REPOSITORIES=[\"$REPO\"]")
-docker_flags+=(-e "RENOVATE_REQUIRE_CONFIG=ignored")
-docker_flags+=(-e "RENOVATE_CONFIG_FILE=/tmp/renovate-config.json")
-docker_flags+=(-e "RENOVATE_EXTENDS=[\"$MINTMAKER_EXTENDS\"]")
+docker_flags+=(-e "RENOVATE_CONFIG_FILE=/tmp/mintmaker-base.json")
 docker_flags+=(-e "RENOVATE_FORCE=$FORCE_CONFIG")
 docker_flags+=(-e "LOG_LEVEL=$LOG_LEVEL")
 docker_flags+=(-e "RENOVATE_PR_HOURLY_LIMIT=20")
@@ -115,7 +109,7 @@ if [[ "$DRY_RUN" == "true" ]]; then
     docker_flags+=(-e "RENOVATE_DRY_RUN=full")
 fi
 
-docker_flags+=(-v "$CONFIG_FILE:/tmp/renovate-config.json:ro")
+docker_flags+=(-v "$MINTMAKER_BASE:/tmp/mintmaker-base.json:ro")
 
 if [[ -n "${RENOVATE_HOST_RULES:-}" ]]; then
     docker_flags+=(-e "RENOVATE_HOST_RULES=$RENOVATE_HOST_RULES")

--- a/script/test_extract_renovate_dry_run_results.py
+++ b/script/test_extract_renovate_dry_run_results.py
@@ -1,0 +1,143 @@
+"""Tests for extract-renovate-dry-run-results.py."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = str(Path(__file__).parent / "extract-renovate-dry-run-results.py")
+
+
+def run_extract(tmp_path, log_lines, repo="test-repo", config="renovate.json5", branches='["main"]'):
+    log_file = tmp_path / "renovate.log"
+    log_file.write_text("\n".join(json.dumps(l) for l in log_lines) + "\n")
+    output_file = tmp_path / "result.md"
+
+    result = subprocess.run(
+        [
+            sys.executable, SCRIPT,
+            "--repo", repo,
+            "--config", config,
+            "--branches", branches,
+            "--log", str(log_file),
+            "--output", str(output_file),
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, f"Script failed: {result.stderr}"
+    return output_file.read_text()
+
+
+class TestNoChanges:
+    def test_empty_log(self, tmp_path):
+        output = run_extract(tmp_path, [])
+        assert "No changes" in output
+        assert "<details>" not in output
+
+    def test_zero_updates(self, tmp_path):
+        log = [{"msg": "packageFiles with updates", "baseBranch": "main", "config": {
+            "tekton": [{"packageFile": "pipelines/build.yaml", "deps": [
+                {"depName": "some-task", "updates": []}
+            ]}]
+        }}]
+        output = run_extract(tmp_path, log)
+        assert "No changes" in output
+
+
+class TestDigestUpdate:
+    def test_git_ref_digest(self, tmp_path):
+        log = [
+            {"msg": "packageFiles with updates", "baseBranch": "main", "config": {
+                "regex": [{"packageFile": "pipelines/multi-arch.yaml", "deps": [
+                    {
+                        "depName": "org/repo",
+                        "currentValue": "main",
+                        "currentDigest": "aaaa1111bbbb2222cccc3333dddd4444eeee5555",
+                        "updates": [{"updateType": "digest", "newValue": "main",
+                                     "newDigest": "ffff6666aaaa7777bbbb8888cccc9999dddd0000"}],
+                    }
+                ]}]
+            }},
+            {"msg": "1 flattened updates found: org/repo", "baseBranch": "main"},
+        ]
+        output = run_extract(tmp_path, log)
+        assert "1 dependency update(s)" in output
+        assert "`org/repo`" in output
+        assert "`pipelines/multi-arch.yaml`" in output
+        assert "digest" in output
+        assert "aaaa1111bbbb" in output
+        assert "ffff6666aaaa" in output
+
+
+class TestVersionUpdate:
+    def test_patch_update(self, tmp_path):
+        log = [
+            {"msg": "packageFiles with updates", "baseBranch": "main", "config": {
+                "tekton": [{"packageFile": "pipelines/build.yaml", "deps": [
+                    {
+                        "depName": "quay.io/org/task-foo",
+                        "currentValue": "0.4.0",
+                        "currentDigest": "sha256:aaa111",
+                        "updates": [{"updateType": "patch", "newValue": "0.4.1",
+                                     "newDigest": "sha256:bbb222"}],
+                    }
+                ]}]
+            }},
+            {"msg": "1 flattened updates found: quay.io/org/task-foo", "baseBranch": "main"},
+        ]
+        output = run_extract(tmp_path, log)
+        assert "patch" in output
+        assert "0.4.0" in output
+        assert "0.4.1" in output
+
+
+class TestMultiBranch:
+    def test_separate_tables_per_branch(self, tmp_path):
+        base = {
+            "tekton": [{"packageFile": "pipelines/build.yaml", "deps": [
+                {"depName": "task-a", "currentValue": "1.0", "updates": [
+                    {"updateType": "patch", "newValue": "1.1"}
+                ]}
+            ]}]
+        }
+        log = [
+            {"msg": "packageFiles with updates", "baseBranch": "main", "config": base},
+            {"msg": "1 flattened updates found: task-a", "baseBranch": "main"},
+            {"msg": "packageFiles with updates", "baseBranch": "rhoai-3.5", "config": base},
+            {"msg": "1 flattened updates found: task-a", "baseBranch": "rhoai-3.5"},
+        ]
+        output = run_extract(tmp_path, log, branches='["main","rhoai-3.5"]')
+        assert "**main**" in output
+        assert "**rhoai-3.5**" in output
+
+
+class TestFallback:
+    def test_no_package_files_entry(self, tmp_path):
+        """When only flattened-updates lines exist, fall back to dep-name-only table."""
+        log = [
+            {"msg": "1 flattened updates found: some-dep", "baseBranch": "main"},
+        ]
+        output = run_extract(tmp_path, log)
+        assert "1 dependency update(s)" in output
+        assert "| Dependency | Branches |" in output
+        assert "`some-dep`" in output
+
+
+class TestSkippedDeps:
+    def test_skip_reason_excluded(self, tmp_path):
+        log = [
+            {"msg": "packageFiles with updates", "baseBranch": "main", "config": {
+                "tekton": [{"packageFile": "pipelines/build.yaml", "deps": [
+                    {"depName": "skipped-task", "skipReason": "invalid-value",
+                     "updates": []},
+                    {"depName": "good-task", "currentValue": "1.0",
+                     "updates": [{"updateType": "patch", "newValue": "1.1"}]},
+                ]}]
+            }},
+            {"msg": "1 flattened updates found: good-task", "baseBranch": "main"},
+        ]
+        output = run_extract(tmp_path, log)
+        assert "skipped-task" not in output
+        assert "good-task" in output


### PR DESCRIPTION
## Summary

- **RHOAIENG-77914**: Fix Renovate config to pin prefetch-dependencies to 0.4.x, force rollback from 0.5.0 via `replacementVersion`, fix broken `matchUpdateTypes + allowedVersions` rules, and match production config layering (`RENOVATE_CONFIG_FILE` = MintMaker base)
- **RHOAIENG-77915**: Enhance dry-run reports with detailed update info (dependency, file, update type, version changes). Add `run-renovate-local.sh` using `--platform local` for testing branch config changes. Split production runs (`run-renovate.sh`) from dry-run testing (`run-renovate-local.sh`)

## Key changes

### Renovate config (`renovate/pipelines-renovate.json5`)
- Split `matchUpdateTypes + allowedVersions` combos into separate rules (Renovate rejects the combo)
- Add `replacementVersion` rule to force prefetch 0.5.0 → 0.4.1 rollback (remove after merge)
- Add `allowedVersions: ">=0.4.0 <0.5.0"` to constrain prefetch to 0.4.x
- Add `baseBranchPatterns` for `matchBaseBranches` support
- Move `schedule` from `customManagers` to `packageRules` (fixes warning)
- Add `.tekton/**` to `includePaths`

### Scripts
- `run-renovate.sh` — match production: MintMaker config as `RENOVATE_CONFIG_FILE`, repo's `.github/renovate.json` overrides at repo level. No `RENOVATE_EXTENDS`, `RENOVATE_FORCE` only for branch override
- `run-renovate-local.sh` — new, `--platform local` for dry-run testing. MintMaker base + branch config as repo override. Works in CI and local dev
- `extract-renovate-dry-run-results.py` — parse `packageFiles with updates` JSON for detailed tables

### Workflows
- `run-renovate.yml` — JSON log format, extraction script for dry-run summary, removed `log_level` input
- `renovate-dry-run.yml` — renamed to "Test Renovate Config", `workflow_dispatch` only, uses `run-renovate-local.sh`

## Test plan
- [x] Local dry-run with `--platform local` shows correct results (minor blocked, prefetch rollback proposed)
- [x] CI `run-renovate.yml` dry-run matches production behavior
- [ ] CI `renovate-dry-run.yml` workflow_dispatch works with detailed reporting
- [ ] After merge: verify MintMaker creates rollback PR for prefetch 0.5.0 → 0.4.1

## Before merging
Squash into two commits: one for RHOAIENG-77914, one for RHOAIENG-77915.

🤖 Generated with [Claude Code](https://claude.com/claude-code)