### PR TITLE
RHOAIENG-77914: Remove temporary replacementVersion rule

### DIFF
--- a/renovate/pipelines-renovate.json5
+++ b/renovate/pipelines-renovate.json5
@@ -64,15 +64,6 @@
         "allowedVersions": ">=0.4.0 <0.5.0",
       },
       {
-        // Force rollback from 0.5.0 to 0.4.1 — remove this rule after the rollback PR merges.
-        // additionalBranchPrefix adds baseBranch to the branch name so replacement PRs
-        // for different branches (main, rhoai-3.5, etc.) don't collide.
-        "matchPackageNames": ["quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta"],
-        "matchCurrentValue": "/(0\\.5\\.0)/",
-        "replacementVersion": "0.4.1",
-        "additionalBranchPrefix": "{{baseBranch}}/",
-      },
-      {
         // Allow minor version update for buildah-remote-oci-ta to pick up
         // cross-platform image support (ALLOW_CROSS_PLATFORM_IMAGES param, STONEBLD-4817)
         "matchPackageNames": ["quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta"],


### PR DESCRIPTION
## Summary

The prefetch 0.5.0 → 0.4.1 rollback PRs (#2892, #2893, #2894) have been merged. Remove the temporary `replacementVersion` rule. The `allowedVersions: ">=0.4.0 <0.5.0"` constraint remains to prevent future bumps past 0.4.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)