### PR TITLE
fix(odh-dashboard): pass OPERATOR_VERSION build arg to dashboard-operator pipeline

### DIFF
--- a/pipelineruns/odh-dashboard/.tekton/odh-dashboard-operator-pull-request.yaml
+++ b/pipelineruns/odh-dashboard/.tekton/odh-dashboard-operator-pull-request.yaml
@@ -35,6 +35,9 @@ spec:
   - name: prefetch-input
     value: |
       [{"type": "npm", "path": "."} , {"type": "gomod", "path": "dashboard-operator"}]
+  - name: build-args
+    value:
+    - OPERATOR_VERSION={{revision}}
   - name: build-platforms
     value:
     - linux/x86_64


### PR DESCRIPTION
## Summary

- Pass `OPERATOR_VERSION={{revision}}` as a build arg to the dashboard-operator Konflux pipeline so the built binary reports the git SHA instead of `"unknown"`.
- The `Dockerfile.konflux.dashboard-operator` already accepts `ARG OPERATOR_VERSION=unknown` and injects it via `-ldflags -X` (added in [red-hat-data-services/odh-dashboard#2202](https://github.com/red-hat-data-services/odh-dashboard/pull/2202)).
- Without this change, the dashboard-operator binary always reports `version: "unknown"` in the Dashboard CR status.

## Test plan

- [ ] Trigger a Konflux PR build for dashboard-operator and verify the built image contains the git SHA as the version string

🤖 Generated with [Claude Code](https://claude.com/claude-code)