### PR TITLE
Fix codeserver prefetch paths for v4.112.0 upgrade

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-5-push.yaml
@@ -1,6 +1,5 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# manual trigger
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}
@@ -76,6 +75,8 @@ spec:
     - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/build
       type: npm
     - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/build/npm/gyp
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/build/vite
       type: npm
     - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions
       type: npm
@@ -166,20 +167,22 @@ spec:
     - path: codeserver/ubi9-python-3.12/prefetch-input/code-server
       type: npm
     # patches/ overlay (overwrites code-server at build); use these so Cachi2 prefetches registry-only lockfiles
-    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.106.3/lib/vscode
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode
       type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.106.3/lib/vscode/remote
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/remote
       type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.106.3/lib/vscode/extensions
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/extensions
       type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.106.3/lib/vscode/extensions/emmet
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/build/vite
       type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.106.3/test
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/extensions/emmet
       type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.106.3/lib/vscode/extensions/microsoft-authentication
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/test
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/extensions/microsoft-authentication
       type: npm
     # Registry-only npm deps (ProdSec); @parcel/watcher, @emmetio/css-parser, @playwright/browser-chromium in custom-packages/package.json
-    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.106.3/custom-packages
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/custom-packages
       type: npm
   pipelineRef:
     resolver: git


### PR DESCRIPTION
## Summary
- Update prefetch-input paths in the v3-5-push pipeline to match the
  code-server v4.106.3 → v4.112.0 upgrade (commit 06ae21d47)
- Add new `build/vite` npm prefetch entries for both the code-server
  submodule and the patches overlay

## Context
The prefetch-dependencies step fails with `package path does not exist`
because the patches directory was renamed from `code-server-v4.106.3`
to `code-server-v4.112.0` but the tekton YAML was not updated.

Upstream fix: https://github.com/opendatahub-io/notebooks/pull/4022
Konflux build failure: https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhoai-tenant/applications/rhoai-v3-5/pipelineruns/odh-workbench-codeserver-datascience-cpu-py312-v3-5-on-pusfpt5d