### PR TITLE
Update nemo-guardrails pull-request PipelineRun: add s390x, pip prefetch, hermetic build

### DIFF
--- a/pipelineruns/NeMo-Guardrails/.tekton/odh-trustyai-nemo-guardrails-server-pull-request.yaml
+++ b/pipelineruns/NeMo-Guardrails/.tekton/odh-trustyai-nemo-guardrails-server-pull-request.yaml
@@ -43,11 +43,21 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+    - linux/s390x
   - name: prefetch-input
     value: |
-      [{"type": "generic", "path": "."}]
+      [{
+        "type": "pip",
+        "path": ".",
+        "requirements_files": ["requirements.txt", "requirements-models.txt"],
+        "binary": {"arch": "x86_64,aarch64,ppc64le,s390x"}
+      },
+      {
+        "type": "generic",
+        "path": "."
+      }]
   - name: hermetic
-    value: false
+    value: "true"
   - name: enable-slack-failure-notification
     value: "false"
   - name: path-context


### PR DESCRIPTION
## Summary
- Add `linux/s390x` to build-platforms for full multi-arch coverage
- Add pip prefetch configuration for `requirements.txt` and `requirements-models.txt` with binary arch support
- Enable hermetic build (was previously disabled)

These changes sync the pull-request PipelineRun definition with what's in the NeMo-Guardrails component repo.

## Test plan
- [x] Verify PipelineRun YAML is valid
- [ ] Confirm build triggers correctly on a test PR to NeMo-Guardrails

🤖 Generated with [Claude Code](https://claude.com/claude-code)