### PR TITLE
Update nemo-guardrails v3-5 push PipelineRun: add s390x, pip prefetch, hermetic build

### DIFF
--- a/pipelineruns/NeMo-Guardrails/.tekton/odh-trustyai-nemo-guardrails-server-v3-5-push.yaml
+++ b/pipelineruns/NeMo-Guardrails/.tekton/odh-trustyai-nemo-guardrails-server-v3-5-push.yaml
@@ -39,34 +39,19 @@ spec:
   - name: path-context
     value: .
   - name: hermetic
-    value: false
+    value: "true"
   - name: prefetch-input
-    # value: |
-    #   [
-    #     {
-    #       "type": "pip",
-    #       "path": ".",
-    #       "requirements_files": [
-    #         "requirements.txt",
-    #         "requirements-torch.txt"
-    #       ],
-    #       "allow_binary": true,
-    #       "binary": {
-    #         "os": "linux"
-    #       }
-    #     },
-    #     {
-    #       "type": "generic",
-    #       "path": "."
-    #     }
-    #   ]
     value: |
-      [
-        {
-          "type": "generic",
-          "path": "."
-        }
-      ]
+      [{
+        "type": "pip",
+        "path": ".",
+        "requirements_files": ["requirements.txt", "requirements-models.txt"],
+        "binary": {"arch": "x86_64,aarch64,ppc64le,s390x"}
+      },
+      {
+        "type": "generic",
+        "path": "."
+      }]
   - name: build-source-image
     value: true
   - name: build-image-index
@@ -76,6 +61,7 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+    - linux/s390x
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Summary
- Add `linux/s390x` to build-platforms for full multi-arch coverage
- Add pip prefetch configuration for `requirements.txt` and `requirements-models.txt` with binary arch support
- Enable hermetic build (was previously disabled)
- Remove commented-out prefetch block

## Test plan
- [x] Verify PipelineRun YAML is valid
- [ ] Confirm push build triggers correctly on next merge to rhoai-3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)