### PR TITLE
[rhoai-3.5] Fix llmcompressor-cuda OOM in prepare-sboms step

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-wb-jupyter-pytorch-llmcompressor-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-wb-jupyter-pytorch-llmcompressor-cuda-py312-v3-5-push.yaml
@@ -22,8 +22,8 @@ metadata:
   namespace: rhoai-tenant
 spec:
   timeouts:
-    pipeline: "12h0m0s"
-    tasks: "8h0m0s"
+    pipeline: "3h0m0s"
+    tasks: "2h0m0s"
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -83,9 +83,9 @@ spec:
     - name: prepare-sboms
       computeResources:
         requests:
-          memory: 8Gi
+          memory: 12Gi
         limits:
-          memory: 8Gi
+          memory: 12Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-wb-jupyter-pytorch-llmcompressor-cuda-py312-v3-5
   workspaces:


### PR DESCRIPTION
## Summary

- Increase `prepare-sboms` (mobster) memory from 8Gi to 12Gi — the step was being OOM-killed (exit 137, SIGKILL) after ~17 seconds
- Reduce pipeline timeout from 12h to 3h and task timeout from 8h to 2h — the previous values were excessive for a single-arch amd64 build

## Root cause

The `prepare-sboms` step runs mobster to generate SBOMs. With an 8Gi memory limit, the kernel OOM-kills it almost immediately (exit code 137). This was confirmed via build logs from the last successful build attempt where the step failed in 17 seconds.

The odh-dashboard component had the same issue and was fixed with 16Gi (PR #2219). Starting with 12Gi here since llmcompressor may have a smaller dependency tree.

## Test plan

- [ ] Run `/build-konflux` on this PR to validate the 12Gi memory is sufficient
- [ ] Verify prepare-sboms step completes without OOM
- [ ] If 12Gi is insufficient, bump to 16Gi

🤖 Generated with [Claude Code](https://claude.com/claude-code)