### PR TITLE
change path context to root

### DIFF
--- a/pipelineruns/ogx-k8s-operator/.tekton/odh-ogx-module-operator-v3-5-push.yaml
+++ b/pipelineruns/ogx-k8s-operator/.tekton/odh-ogx-module-operator-v3-5-push.yaml
@@ -35,7 +35,7 @@ spec:
   - name: dockerfile
     value: Dockerfile.konflux
   - name: path-context
-    value: ogx-module/
+    value: .
   - name: hermetic
     value: true
   - name: prefetch-input


### PR DESCRIPTION
attending to the following build failure https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhoai-tenant/applications/rhoai-v3-5/pipelineruns/odh-ogx-module-operator-v3-5-on-push-v9wz8