### PR TITLE
RHAIENG-6201: Hybrid non-hermetic codeserver push for Conforma (rhoai-3.3)

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-3-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-3-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# retrigger build 2026-05-14T02:30:00Z
+# konflux build manual retrigger - 2026-05-29 15:32:03
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}
@@ -21,10 +21,11 @@ metadata:
     pipelines.appstudio.openshift.io/type: build
   name: odh-workbench-codeserver-datascience-cpu-py312-v3-3-on-push
   namespace: rhoai-tenant
+# https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1768318252639689
 spec:
   timeouts:
-    pipeline: "8h0m0s"
-    tasks: "4h0m0s"
+    pipeline: 8h0m0s
+    tasks: 4h0m0s
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -32,17 +33,22 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9:{{target_branch}}
-  - name: rhoai-version
-    value: "3.3.5"
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
+  - name: rhoai-version
+    value: "3.3.5"
   - name: dockerfile
     value: codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
   - name: build-args-file
     value: codeserver/ubi9-python-3.12/build-args/konflux.cpu.conf
   - name: path-context
     value: .
+  - name: enable-cache-proxy
+    value: true
+  # rhoai-3.3: hermetic waiver (same hybrid model as rhoai-2.25). Keep npm
+  # prefetch for the large VS Code tree; install pip / X.org / oc at build time so
+  # Hermeto does not emit Conforma-failing binary-wheel / generic / openshift-clients SBOM attrs.
   - name: hermetic
     value: false
   - name: build-image-index
@@ -56,7 +62,136 @@ spec:
   - name: fips-check-blocking
     value: "false"
   - name: rhel-subscription-activation-key
-    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
+    value: "rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6"
+  - name: prefetch-input
+    value:
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/.vscode/extensions/vscode-selfhost-import-aid
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/.vscode/extensions/vscode-selfhost-test-provider
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/build
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/build/npm/gyp
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/build/vite
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/.vscode/extensions/vscode-extras
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/configuration-editing
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/css-language-features
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/css-language-features/server
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/debug-auto-launch
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/debug-server-ready
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/extension-editing
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/git
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/git-base
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/github
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/github-authentication
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/grunt
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/gulp
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/html-language-features
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/html-language-features/server
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/ipynb
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/jake
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/json-language-features
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/json-language-features/server
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/markdown-language-features
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/markdown-math
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/media-preview
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/merge-conflict
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/mermaid-chat-features
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/notebook-renderers
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/npm
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/php-language-features
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/references-view
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/search-result
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/simple-browser
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/terminal-suggest
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/tunnel-forwarding
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/typescript-language-features
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/vscode-api-tests
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/vscode-colorize-perf-tests
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/vscode-colorize-tests
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/vscode-test-resolver
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/remote
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/remote/web
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/test/automation
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/test/integration/browser
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/test/mcp
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/test/monaco
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/test/smoke
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/test/sanity
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/src/vs/sessions/test/e2e
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/test/e2e/extensions/test-extension
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server
+      type: npm
+    # patches/ overlay (codeserver/ubi9-python-3.12/prefetch-input/patches/) — Cachi2 prefetches registry-only lockfiles; keep in sync with patches that have package.json
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/remote
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/extensions
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/extensions/emmet
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/build/vite
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/test
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/extensions/microsoft-authentication
+      type: npm
+    # Registry-only npm deps (ProdSec); @parcel/watcher, @emmetio/css-parser, @playwright/browser-chromium in custom-packages/package.json
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/custom-packages
+      type: npm
+
   pipelineRef:
     resolver: git
     params:
@@ -73,4 +208,3 @@ spec:
     secret:
       secretName: '{{ git_auth_secret }}'
 status: {}
-#restart


### PR DESCRIPTION
## Summary
- Sync codeserver `*-v3-3-push.yaml` from notebooks [PR #2523](https://github.com/red-hat-data-services/notebooks/pull/2523): `hermetic: false`, `enable-cache-proxy: true`, and **npm-only** prefetch (VS Code tree + patches overlay).
- Same hybrid model as rhoai-2.25 ([konflux-central #2862](https://github.com/red-hat-data-services/konflux-central/pull/2862) / RHAIENG-6200) so release builds avoid Conforma failures from Hermeto binary-wheel / X.org generic / `openshift-clients` SBOM attributes.
- Keeps konflux-central as the source of truth for downstream notebooks `.tekton/` sync on `rhoai-3.3`.

## Test plan
- [x] Notebooks #2523 merged to `rhoai-3.3` (codeserver hybrid Dockerfile + PR/push PipelineRuns)
- [ ] Confirm this PipelineRun syncs into `red-hat-data-services/notebooks` `.tekton/` without drift
- [ ] Push build for `odh-workbench-codeserver-datascience-cpu-py312-v3-3` succeeds
- [ ] Conforma / `registry-rhoai-prod` no longer reports binary-wheel / allowed_package_sources / openshift-clients repo-id hits


Made with [Cursor](https://cursor.com)