### PR TITLE
RHAIENG-4246: chore(notebooks): enable arm64 for PyTorch CUDA images

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-pull-request.yaml
@@ -48,6 +48,7 @@ spec:
   - name: build-platforms
     value:
     - linux-extra-fast/amd64
+    - linux-d160-m2xlarge/arm64
   - name: image-expires-after
     value: 5d
   - name: enable-slack-failure-notification
@@ -61,7 +62,7 @@ spec:
     - path: runtimes/pytorch/ubi9-python-3.12
       type: pip
       binary:
-        arch: "x86_64"
+        arch: "x86_64,aarch64"
       requirements_files: [requirements.cuda.txt]
   pipelineRef:
     resolver: git

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-pull-request.yaml
@@ -48,6 +48,7 @@ spec:
   - name: build-platforms
     value:
     - linux-extra-fast/amd64
+    - linux-d160-m2xlarge/arm64
   - name: image-expires-after
     value: 5d
   - name: enable-slack-failure-notification
@@ -61,7 +62,7 @@ spec:
     - path: runtimes/pytorch+llmcompressor/ubi9-python-3.12
       type: pip
       binary:
-        arch: "x86_64"
+        arch: "x86_64,aarch64"
       requirements_files: [requirements.cuda.txt]
   pipelineRef:
     resolver: git

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-pull-request.yaml
@@ -48,6 +48,7 @@ spec:
   - name: build-platforms
     value:
     - linux-d160-m8xlarge/amd64
+    - linux-d160-m8xlarge/arm64
   - name: image-expires-after
     value: 5d
   - name: enable-slack-failure-notification
@@ -63,7 +64,7 @@ spec:
     - path: jupyter/pytorch/ubi9-python-3.12
       type: pip
       binary:
-        arch: "x86_64"
+        arch: "x86_64,aarch64"
       requirements_files: [requirements.cuda.txt]
   pipelineRef:
     resolver: git

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-pull-request.yaml
@@ -48,6 +48,7 @@ spec:
   - name: build-platforms
     value:
     - linux-d160-m8xlarge/amd64
+    - linux-d160-m8xlarge/arm64
   - name: image-expires-after
     value: 5d
   - name: enable-slack-failure-notification
@@ -63,7 +64,7 @@ spec:
     - path: jupyter/pytorch+llmcompressor/ubi9-python-3.12
       type: pip
       binary:
-        arch: "x86_64"
+        arch: "x86_64,aarch64"
       requirements_files: [requirements.cuda.txt]
   pipelineRef:
     resolver: git

--- a/script/multi-arch-tracking/exceptions.toml
+++ b/script/multi-arch-tracking/exceptions.toml
@@ -87,30 +87,6 @@ reason = "Proposed in RFE"
 issue = "https://issues.redhat.com/browse/RHAIRFE-145"
 
 [[exception]]
-component = "odh-workbench-jupyter-pytorch-cuda-py312-rhel9"
-architectures = ["arm64"]
-reason = "https://redhat-internal.slack.com/archives/C0961HQ858Q/p1773076220404649"
-issue = "https://redhat.atlassian.net/browse/RHAISTRAT-1756"
-
-[[exception]]
-component = "odh-pipeline-runtime-pytorch-cuda-py312-rhel9"
-architectures = ["arm64"]
-reason = "https://redhat-internal.slack.com/archives/C0961HQ858Q/p1773076220404649"
-issue = "https://redhat.atlassian.net/browse/RHAISTRAT-1756"
-
-[[exception]]
-component = "odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9"
-architectures = ["arm64"]
-reason = "https://redhat-internal.slack.com/archives/C0961HQ858Q/p1773076220404649"
-issue = "https://redhat.atlassian.net/browse/RHAISTRAT-1756"
-
-[[exception]]
-component = "odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-rhel9"
-architectures = ["arm64"]
-reason = "https://redhat-internal.slack.com/archives/C0961HQ858Q/p1773076220404649"
-issue = "https://redhat.atlassian.net/browse/RHAISTRAT-1756"
-
-[[exception]]
 component = "odh-trustyai-nemo-guardrails-server-rhel9"
 architectures = ["ppc64le"]
 reason = "Not yet implemented, see Jira issue"


### PR DESCRIPTION
## Summary
- Same notebooks PipelineRun enablement as [RHDS notebooks#2578](https://github.com/red-hat-data-services/notebooks/pull/2578): add arm64 + hermetic `aarch64` for the four PyTorch CUDA family PR PipelineRuns under `pipelineruns/notebooks/.tekton/`.
- Remove the four corresponding `[[exception]]` blocks from `script/multi-arch-tracking/exceptions.toml`.
- This is the durable source of truth; RHDS `.tekton/` is synced from here.

Jira: [RHAIENG-4246](https://redhat.atlassian.net/browse/RHAIENG-4246)

## Test plan
- [ ] Review platform labels match TF peers (workbench `linux-d160-m8xlarge/arm64`, runtime `linux-d160-m2xlarge/arm64`)
- [ ] After merge/sync, RHDS main `.tekton/` matches
- [ ] Validate via RHDS notebooks PR Konflux Internal builds