### PR TITLE
[rhoai-3.6-ea.1] RHAIENG-4246: chore(notebooks): enable arm64 on PyTorch CUDA push pipelines

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-v3-6-ea-1-push.yaml
@@ -50,6 +50,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux-d160-m2xlarge/arm64
   - name: build-args-file
     value: runtimes/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
   - name: rhel-subscription-activation-key
@@ -61,7 +62,7 @@ spec:
     - path: runtimes/pytorch/ubi9-python-3.12
       type: pip
       binary:
-        arch: "x86_64"
+        arch: "x86_64,aarch64"
       requirements_files: [requirements.cuda.txt]
   pipelineRef:
     resolver: git

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-6-ea-1-push.yaml
@@ -50,6 +50,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux-d160-m2xlarge/arm64
   - name: build-args-file
     value: runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
   - name: rhel-subscription-activation-key
@@ -61,7 +62,7 @@ spec:
     - path: runtimes/pytorch+llmcompressor/ubi9-python-3.12
       type: pip
       binary:
-        arch: "x86_64"
+        arch: "x86_64,aarch64"
       requirements_files: [requirements.cuda.txt]
   pipelineRef:
     resolver: git

--- a/pipelineruns/notebooks/.tekton/odh-wb-jupyter-pytorch-llmcompressor-cuda-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-wb-jupyter-pytorch-llmcompressor-cuda-py312-v3-6-ea-1-push.yaml
@@ -53,6 +53,7 @@ spec:
   - name: build-platforms
     value:
     - linux-d160-m8xlarge/amd64
+    - linux-d160-m8xlarge/arm64
   - name: disable-slack-notifications
     value: true
   - name: rhel-subscription-activation-key

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-v3-6-ea-1-push.yaml
@@ -51,6 +51,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux-d160-m4xlarge/arm64
   - name: build-args-file
     value: jupyter/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
   - name: rhel-subscription-activation-key
@@ -64,7 +65,7 @@ spec:
     - path: jupyter/pytorch/ubi9-python-3.12
       type: pip
       binary:
-        arch: "x86_64"
+        arch: "x86_64,aarch64"
       requirements_files: [requirements.cuda.txt]
   pipelineRef:
     resolver: git


### PR DESCRIPTION
## Summary
- Follow-up to [konflux-central#2942](https://github.com/red-hat-data-services/konflux-central/pull/2942) / [notebooks#2578](https://github.com/red-hat-data-services/notebooks/pull/2578) (PR PipelineRuns on `main`).
- Enable arm64 on the four PyTorch CUDA **push** PipelineRuns under `pipelineruns/notebooks/.tekton/` for **rhoai-3.6-ea.1** (the only non-ROCm images still missing arm64 on this branch).
- Platform labels match existing TensorFlow / minimal CUDA peers on this branch:
  - workbench pytorch CUDA: `linux-d160-m4xlarge/arm64` (+ hermetic `x86_64,aarch64`)
  - workbench llmcompressor: `linux-d160-m8xlarge/arm64` (hermetic already had aarch64)
  - runtime pytorch CUDA ± llmcompressor: `linux-d160-m2xlarge/arm64` (+ hermetic `x86_64,aarch64`)

Note: `konflux-central` `main` only carries PR PipelineRuns; push YAMLs live on the release branch. RHDS `rhoai-3.6-ea.1` currently has no push YAMLs in-repo yet — they will appear after sync from this change.

**Rebase:** rebased onto `rhoai-3.6-ea.1` after [#2944](https://github.com/red-hat-data-services/konflux-central/pull/2944) (CEL `manifests/rhoai/base/params-latest.env`). That should clear the 18 notebooks pathChanged validate warnings that appeared on the pre-rebase tip; remaining validate noise (ai-gateway / kserve `v3-5` branch targeting, kserve Dockerfile warning) is pre-existing / out of scope.

Jira: [RHAIENG-4246](https://redhat.atlassian.net/browse/RHAIENG-4246)

## Test plan
- [x] Review platform labels vs TF peers on the same branch
- [ ] After rebase: `validate` has no notebooks `params-latest.env` pathChanged warnings
- [ ] After merge, confirm sync lands push YAMLs on RHDS `rhoai-3.6-ea.1`
- [ ] Trigger push builds / inspect multi-arch image index includes arm64

## Related
- [#2944](https://github.com/red-hat-data-services/konflux-central/pull/2944) (merged) — params-latest CEL path fix on `rhoai-3.6-ea.1`
- [#2945](https://github.com/red-hat-data-services/konflux-central/pull/2945) — same params-latest fix on `rhoai-3.5`