### PR TITLE
[rhoai-3.6-ea.1] RHAIENG-4246: fix(notebooks): CEL pathChanged for params-latest.env

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-datascience-cpu-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-datascience-cpu-py312-v3-6-ea-1-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.6-ea.1"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( "runtimes/datascience/ubi9-python-3.12/**".pathChanged() || ".tekton/odh-pipeline-runtime-datascience-cpu-py312-v3-6-ea-1-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-6-ea-1

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-minimal-cpu-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-minimal-cpu-py312-v3-6-ea-1-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.6-ea.1"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( "runtimes/minimal/ubi9-python-3.12/**".pathChanged() || ".tekton/odh-pipeline-runtime-minimal-cpu-py312-v3-6-ea-1-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-6-ea-1

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-v3-6-ea-1-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.6-ea.1"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-pipeline-runtime-pytorch-cuda-py312-v3-6-ea-1-push.yaml".pathChanged() || "runtimes/pytorch/ubi9-python-3.12/**".pathChanged() || "cuda/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-6-ea-1

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-6-ea-1-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.6-ea.1"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-6-ea-1-push.yaml".pathChanged() || "runtimes/pytorch+llmcompressor/ubi9-python-3.12/**".pathChanged())
   labels:
     appstudio.openshift.io/application: rhoai-v3-6-ea-1

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v3-6-ea-1-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.6-ea.1"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && (".tekton/odh-pipeline-runtime-pytorch-rocm-py312-v3-6-ea-1-push.yaml".pathChanged() || "runtimes/rocm-pytorch/ubi9-python-3.12/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-6-ea-1

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-v3-6-ea-1-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.6-ea.1"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && (".tekton/odh-pipeline-runtime-tensorflow-cuda-py312-v3-6-ea-1-push.yaml".pathChanged() || "runtimes/tensorflow/ubi9-python-3.12/**".pathChanged() || "cuda/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-6-ea-1

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v3-6-ea-1-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.6-ea.1"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v3-6-ea-1-push.yaml".pathChanged() || "runtimes/rocm-tensorflow/ubi9-python-3.12/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-6-ea-1

--- a/pipelineruns/notebooks/.tekton/odh-wb-jupyter-pytorch-llmcompressor-cuda-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-wb-jupyter-pytorch-llmcompressor-cuda-py312-v3-6-ea-1-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.6-ea.1"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-wb-jupyter-pytorch-llmcompressor-cuda-py312-v3-6-ea-1-push.yaml".pathChanged() || "jupyter/pytorch+llmcompressor/ubi9-python-3.12/**".pathChanged() || "cuda/**".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mongodb-org-6.0.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mssql-2022.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/setup-elyra.sh".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-6-ea-1

--- a/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-6-ea-1-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.6-ea.1"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-6-ea-1-push.yaml".pathChanged() ||
            "codeserver/ubi9-python-3.12/**".pathChanged() ||
            "codeserver/ubi9-python-3.12/build-args/konflux.cpu.conf".pathChanged() )

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v3-6-ea-1-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.6-ea.1"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-workbench-jupyter-datascience-cpu-py312-v3-6-ea-1-push.yaml".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() || "jupyter/datascience/ubi9-python-3.12/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf".pathChanged() || "prefetch-input/rhds/**".pathChanged() || "prefetch-input/mongocli/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-6-ea-1

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cpu-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cpu-py312-v3-6-ea-1-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.6-ea.1"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-workbench-jupyter-minimal-cpu-py312-v3-6-ea-1-push.yaml".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-6-ea-1

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cuda-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cuda-py312-v3-6-ea-1-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.6-ea.1"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-workbench-jupyter-minimal-cuda-py312-v3-6-ea-1-push.yaml".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/**".pathChanged() || "cuda/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-6-ea-1

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v3-6-ea-1-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.6-ea.1"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-workbench-jupyter-minimal-rocm-py312-v3-6-ea-1-push.yaml".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-6-ea-1

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-v3-6-ea-1-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.6-ea.1"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-workbench-jupyter-pytorch-cuda-py312-v3-6-ea-1-push.yaml".pathChanged() || "jupyter/pytorch/ubi9-python-3.12/**".pathChanged() || "cuda/**".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mongodb-org-6.0.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mssql-3.6.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/setup-elyra.sh".pathChanged() || "prefetch-input/rhds/**".pathChanged() || "prefetch-input/mongocli/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-6-ea-1

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v3-6-ea-1-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.6-ea.1"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-workbench-jupyter-pytorch-rocm-py312-v3-6-ea-1-push.yaml".pathChanged() || "jupyter/rocm/pytorch/ubi9-python-3.12/**".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mongodb-org-6.0.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mssql-3.6.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/setup-elyra.sh".pathChanged() || "prefetch-input/rhds/**".pathChanged() || "prefetch-input/mongocli/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-6-ea-1

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v3-6-ea-1-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.6-ea.1"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v3-6-ea-1-push.yaml".pathChanged() || "jupyter/tensorflow/ubi9-python-3.12/**".pathChanged() || "cuda/**".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mongodb-org-6.0.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mssql-3.6.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/setup-elyra.sh".pathChanged() || "prefetch-input/rhds/**".pathChanged() || "prefetch-input/mongocli/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-6-ea-1

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v3-6-ea-1-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.6-ea.1"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v3-6-ea-1-push.yaml".pathChanged() || "jupyter/rocm/tensorflow/ubi9-python-3.12/**".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mongodb-org-6.0.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mssql-3.6.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/setup-elyra.sh".pathChanged() || "prefetch-input/rhds/**".pathChanged() || "prefetch-input/mongocli/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-6-ea-1

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-v3-6-ea-1-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.6-ea.1"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-workbench-jupyter-trustyai-cpu-py312-v3-6-ea-1-push.yaml".pathChanged() || "jupyter/trustyai/ubi9-python-3.12/**".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mongodb-org-6.0.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mssql-3.6.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/setup-elyra.sh".pathChanged() || "prefetch-input/rhds/**".pathChanged() || "prefetch-input/mongocli/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-6-ea-1


### PR DESCRIPTION
## Summary
- Fix all 18 notebooks push PipelineRuns on `rhoai-3.6-ea.1` so CEL `pathChanged()` references `manifests/rhoai/base/params-latest.env` instead of the stale `manifests/base/params-latest.env`.
- Clears the 18 validate `UserWarning`s seen on #2943 (`CEL .pathChanged() references file(s) not found in repo 'red-hat-data-services/notebooks'`).

## Context
Separate from the arm64 push work in #2943. The notebooks repo keeps `params-latest.env` under `manifests/rhoai/base/` (and `manifests/odh/base/`); the old `manifests/base/` path no longer exists.

## Test plan
- [x] `validate` job on this PR: no notebooks `params-latest.env` pathChanged warnings
  - Confirmed in [run 30217018025](https://github.com/red-hat-data-services/konflux-central/actions/runs/30217018025): warnings dropped from **18 notebooks** (#2943) to **0**; only remaining pathChanged warning is unrelated kserve `Dockerfile.konflux.autogluon`.
  - Bot comment: **1 warning** total (kserve). `validate` still fails on pre-existing `test_branch_repo_targeting` for ai-gateway / kserve `v3-5` files (out of scope).
- [x] Confirm CEL still excludes param bumps from triggering image rebuilds when that file changes
  - All 18 files keep `!("manifests/rhoai/base/params-latest.env".pathChanged())` (negated).
  - File exists on RHDS `rhoai-3.6-ea.1` at `manifests/rhoai/base/params-latest.env`; `manifests/base/params-latest.env` does not.

## Comments reviewed
- Only conversation comment is the PipelineRun Validation bot post (no human/review comments).