### PR TITLE
[rhoai-3.5] fix(notebooks): CEL pathChanged for params-latest.env on rhoai-3.5

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-datascience-cpu-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-datascience-cpu-py312-v3-5-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( "runtimes/datascience/ubi9-python-3.12/**".pathChanged() || ".tekton/odh-pipeline-runtime-datascience-cpu-py312-v3-5-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-minimal-cpu-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-minimal-cpu-py312-v3-5-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( "runtimes/minimal/ubi9-python-3.12/**".pathChanged() || ".tekton/odh-pipeline-runtime-minimal-cpu-py312-v3-5-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-v3-5-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-pipeline-runtime-pytorch-cuda-py312-v3-5-push.yaml".pathChanged() || "runtimes/pytorch/ubi9-python-3.12/**".pathChanged() || "cuda/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-5-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-5-push.yaml".pathChanged() || "runtimes/pytorch+llmcompressor/ubi9-python-3.12/**".pathChanged())
   labels:
     appstudio.openshift.io/application: rhoai-v3-5

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v3-5-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && (".tekton/odh-pipeline-runtime-pytorch-rocm-py312-v3-5-push.yaml".pathChanged() || "runtimes/rocm-pytorch/ubi9-python-3.12/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-v3-5-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && (".tekton/odh-pipeline-runtime-tensorflow-cuda-py312-v3-5-push.yaml".pathChanged() || "runtimes/tensorflow/ubi9-python-3.12/**".pathChanged() || "cuda/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v3-5-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v3-5-push.yaml".pathChanged() || "runtimes/rocm-tensorflow/ubi9-python-3.12/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5

--- a/pipelineruns/notebooks/.tekton/odh-wb-jupyter-pytorch-llmcompressor-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-wb-jupyter-pytorch-llmcompressor-cuda-py312-v3-5-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-wb-jupyter-pytorch-llmcompressor-cuda-py312-v3-5-push.yaml".pathChanged() || "jupyter/pytorch+llmcompressor/ubi9-python-3.12/**".pathChanged() || "cuda/**".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mongodb-org-6.0.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mssql-2022.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/setup-elyra.sh".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5

--- a/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-5-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-5-push.yaml".pathChanged() ||
            "codeserver/ubi9-python-3.12/**".pathChanged() ||
            "codeserver/ubi9-python-3.12/build-args/konflux.cpu.conf".pathChanged() )

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v3-5-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-workbench-jupyter-datascience-cpu-py312-v3-5-push.yaml".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() || "jupyter/datascience/ubi9-python-3.12/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf".pathChanged() || "prefetch-input/rhds/**".pathChanged() || "prefetch-input/mongocli/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cpu-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cpu-py312-v3-5-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-workbench-jupyter-minimal-cpu-py312-v3-5-push.yaml".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cuda-py312-v3-5-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-workbench-jupyter-minimal-cuda-py312-v3-5-push.yaml".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/**".pathChanged() || "cuda/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v3-5-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-workbench-jupyter-minimal-rocm-py312-v3-5-push.yaml".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-v3-5-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-workbench-jupyter-pytorch-cuda-py312-v3-5-push.yaml".pathChanged() || "jupyter/pytorch/ubi9-python-3.12/**".pathChanged() || "cuda/**".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mongodb-org-6.0.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mssql-3.5.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/setup-elyra.sh".pathChanged() || "prefetch-input/rhds/**".pathChanged() || "prefetch-input/mongocli/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v3-5-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-workbench-jupyter-pytorch-rocm-py312-v3-5-push.yaml".pathChanged() || "jupyter/rocm/pytorch/ubi9-python-3.12/**".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mongodb-org-6.0.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mssql-3.5.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/setup-elyra.sh".pathChanged() || "prefetch-input/rhds/**".pathChanged() || "prefetch-input/mongocli/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v3-5-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v3-5-push.yaml".pathChanged() || "jupyter/tensorflow/ubi9-python-3.12/**".pathChanged() || "cuda/**".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mongodb-org-6.0.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mssql-3.5.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/setup-elyra.sh".pathChanged() || "prefetch-input/rhds/**".pathChanged() || "prefetch-input/mongocli/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v3-5-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v3-5-push.yaml".pathChanged() || "jupyter/rocm/tensorflow/ubi9-python-3.12/**".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mongodb-org-6.0.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mssql-3.5.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/setup-elyra.sh".pathChanged() || "prefetch-input/rhds/**".pathChanged() || "prefetch-input/mongocli/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-v3-5-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && !("manifests/base/params-latest.env".pathChanged())
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-workbench-jupyter-trustyai-cpu-py312-v3-5-push.yaml".pathChanged() || "jupyter/trustyai/ubi9-python-3.12/**".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mongodb-org-6.0.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mssql-3.5.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/setup-elyra.sh".pathChanged() || "prefetch-input/rhds/**".pathChanged() || "prefetch-input/mongocli/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5


### PR DESCRIPTION
## Summary
- Same fix as #2944 (merged on `rhoai-3.6-ea.1`): update all 18 notebooks push PipelineRuns so CEL `pathChanged()` references `manifests/rhoai/base/params-latest.env` instead of stale `manifests/base/params-latest.env`.
- Clears validate `UserWarning`s for missing `manifests/base/params-latest.env` in `red-hat-data-services/notebooks`.

## Context
Confirmed on `rhoai-3.5`: notebooks tekton still pointed at `manifests/base/…`, while RHDS `rhoai-3.5` only has `manifests/rhoai/base/params-latest.env`.

## Test plan
- [x] `validate` job: no notebooks `params-latest.env` pathChanged warnings
  - Confirmed in [run 30217184343](https://github.com/red-hat-data-services/konflux-central/actions/runs/30217184343): **validate passed** (1159 passed, 0 failed). Only remaining pathChanged warning is unrelated kserve `Dockerfile.konflux.autogluon`.
- [x] CEL still uses negated `!("manifests/rhoai/base/params-latest.env".pathChanged())` so param bumps alone do not rebuild images
  - All 18 files keep the negated clause; file exists on RHDS `rhoai-3.5` at `manifests/rhoai/base/params-latest.env`.

## Comments reviewed
- Only conversation comment is the PipelineRun Validation bot post (passed). No human/review comments.