### PR TITLE
fix(notebooks): repair invalid YAML in llmcompressor cuda push PipelineRun

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v3-3-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v3-3-push.yaml
@@ -55,6 +55,17 @@ spec:
     - linux/x86_64
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ target_branch }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
   timeouts:
     pipeline: 8h
     tasks: 4h
@@ -75,17 +86,6 @@ spec:
         limits:
           cpu: '16'
           memory: 32Gi
-  - name: rhel-subscription-activation-key
-    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
-  pipelineRef:
-    resolver: git
-    params:
-    - name: url
-      value: https://github.com/red-hat-data-services/konflux-central.git
-    - name: revision
-      value: '{{ target_branch }}'
-    - name: pathInRepo
-      value: pipelines/multi-arch-container-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v3-3
   workspaces:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v3-3-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v3-3-push.yaml
@@ -93,4 +93,3 @@ spec:
     secret:
       secretName: '{{ git_auth_secret }}'
 status: {}
-#restart


### PR DESCRIPTION
## Summary
- Restore valid YAML order in `odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v3-3-push.yaml` by placing `rhel-subscription-activation-key` and `pipelineRef` before `timeouts`/`taskRunSpecs` (matching sibling PipelineRuns).
- Unblocks `pytest-tests` on red-hat-data-services/notebooks (see [PR #2538](https://github.com/red-hat-data-services/notebooks/pull/2538) / [failed job](https://github.com/red-hat-data-services/notebooks/actions/runs/30144969578/job/89644919715)).

## Test plan
- [x] `yaml.safe_load` succeeds on the fixed file
- [ ] Sync lands on notebooks `rhoai-3.3` and `test_rhds_pipelines_use_rhds_args` stays green


Made with [Cursor](https://cursor.com)