### PR TITLE
fix(cel): backport on-cel-expression fixes to rhoai-2.25

### DIFF
--- a/pipelineruns/RHOAI-Build-Config/.tekton/odh-operator-bundle-v2-25-push.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/odh-operator-bundle-v2-25-push.yaml
@@ -8,10 +8,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     build.appstudio.openshift.io/build-nudge-files: "catalog/catalog-patch.yaml"
+    # Trigger on bundle/ changes (or this tekton file)
+    # No trigger if bundle/bundle-patch.yaml is the only change
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" && target_branch
-      == "rhoai-2.25" && ( "bundle/**".pathChanged() || ".tekton/odh-operator-bundle-v2-25-push.yaml".pathChanged()
-      ) && !"bundle/bundle-patch.yaml".pathChanged() && !".github/workflows/**".pathChanged()
+      event == "push"
+      && target_branch == "rhoai-2.25"
+      && ( "bundle/**".pathChanged() || ".tekton/odh-operator-bundle-v2-25-push.yaml".pathChanged() )
+      && files.all.exists(p, !p.matches('^bundle/bundle-patch\\.yaml$'))
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: rhoai-v2-25

--- a/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v2-25-push.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v2-25-push.yaml
@@ -7,10 +7,13 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    # Trigger on catalog/ changes (or this tekton file)
+    # No trigger if catalog/catalog-patch.yaml is the only change
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" && target_branch
-      == "rhoai-2.25" && ( "catalog/**".pathChanged() || ".tekton/rhoai-fbc-fragment-v2-25-push.yaml".pathChanged()
-      ) && !"catalog/catalog-patch.yaml".pathChanged() && !".github/workflows/**".pathChanged()
+      event == "push"
+      && target_branch == "rhoai-2.25"
+      && ( "catalog/**".pathChanged() || ".tekton/rhoai-fbc-fragment-v2-25-push.yaml".pathChanged() )
+      && files.all.exists(p, !p.matches('^catalog/catalog-patch\\.yaml$'))
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: rhoai-fbc-fragment-v2-25

--- a/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-argoexec-v2-25-push.yaml
+++ b/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-argoexec-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-data-science-pipelines-argo-argoexec-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-data-science-pipelines-argo-argoexec-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-data-science-pipelines-argo-argoexec-v2-25

--- a/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-workflowcontroller-v2-25-push.yaml
+++ b/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-workflowcontroller-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-data-science-pipelines-argo-workflowcontroller-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-data-science-pipelines-argo-workflowcontroller-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-data-science-pipelines-argo-workflowcontroller-v2-25

--- a/pipelineruns/caikit-nlp/.tekton/odh-caikit-nlp-v2-25-push.yaml
+++ b/pipelineruns/caikit-nlp/.tekton/odh-caikit-nlp-v2-25-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-caikit-nlp-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-caikit-nlp-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-caikit-nlp-v2-25

--- a/pipelineruns/caikit-tgis-serving/.tekton/odh-caikit-tgis-serving-v2-25-push.yaml
+++ b/pipelineruns/caikit-tgis-serving/.tekton/odh-caikit-tgis-serving-v2-25-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-caikit-tgis-serving-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-caikit-tgis-serving-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-caikit-tgis-serving-v2-25

--- a/pipelineruns/codeflare-operator/.tekton/odh-codeflare-operator-v2-25-push.yaml
+++ b/pipelineruns/codeflare-operator/.tekton/odh-codeflare-operator-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-codeflare-operator-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-codeflare-operator-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-codeflare-operator-v2-25

--- a/pipelineruns/data-science-pipelines-operator/.tekton/odh-data-science-pipelines-operator-controller-v2-25-push.yaml
+++ b/pipelineruns/data-science-pipelines-operator/.tekton/odh-data-science-pipelines-operator-controller-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-data-science-pipelines-operator-controller-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-data-science-pipelines-operator-controller-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-data-science-pipelines-operator-controller-v2-25

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-api-server-v2-v2-25-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-api-server-v2-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-ml-pipelines-api-server-v2-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-ml-pipelines-api-server-v2-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-ml-pipelines-api-server-v2-v2-25

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-driver-v2-25-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-driver-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-ml-pipelines-driver-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-ml-pipelines-driver-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-ml-pipelines-driver-v2-25

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-launcher-v2-25-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-launcher-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-ml-pipelines-launcher-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-ml-pipelines-launcher-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-ml-pipelines-launcher-v2-25

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-persistenceagent-v2-v2-25-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-persistenceagent-v2-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-ml-pipelines-persistenceagent-v2-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-ml-pipelines-persistenceagent-v2-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-ml-pipelines-persistenceagent-v2-v2-25

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-scheduledworkflow-v2-v2-25-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-scheduledworkflow-v2-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-ml-pipelines-scheduledworkflow-v2-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-ml-pipelines-scheduledworkflow-v2-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-ml-pipelines-scheduledworkflow-v2-v2-25

--- a/pipelineruns/fms-guardrails-orchestrator/.tekton/odh-fms-guardrails-orchestrator-v2-25-push.yaml
+++ b/pipelineruns/fms-guardrails-orchestrator/.tekton/odh-fms-guardrails-orchestrator-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-fms-guardrails-orchestrator-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-fms-guardrails-orchestrator-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-fms-guardrails-orchestrator-v2-25

--- a/pipelineruns/guardrails-detectors/.tekton/odh-guardrails-detector-huggingface-runtime-v2-25-push.yaml
+++ b/pipelineruns/guardrails-detectors/.tekton/odh-guardrails-detector-huggingface-runtime-v2-25-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-guardrails-detector-huggingface-runtime-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-guardrails-detector-huggingface-runtime-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-guardrails-detector-huggingface-runtime-v2-25

--- a/pipelineruns/kserve/.tekton/odh-kserve-agent-v2-25-push.yaml
+++ b/pipelineruns/kserve/.tekton/odh-kserve-agent-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-kserve-agent-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-kserve-agent-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-kserve-agent-v2-25

--- a/pipelineruns/kserve/.tekton/odh-kserve-controller-v2-25-push.yaml
+++ b/pipelineruns/kserve/.tekton/odh-kserve-controller-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-kserve-controller-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-kserve-controller-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-kserve-controller-v2-25

--- a/pipelineruns/kserve/.tekton/odh-kserve-router-v2-25-push.yaml
+++ b/pipelineruns/kserve/.tekton/odh-kserve-router-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-kserve-router-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-kserve-router-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-kserve-router-v2-25

--- a/pipelineruns/kubeflow/.tekton/odh-kf-notebook-controller-v2-25-push.yaml
+++ b/pipelineruns/kubeflow/.tekton/odh-kf-notebook-controller-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-kf-notebook-controller-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-kf-notebook-controller-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-kf-notebook-controller-v2-25

--- a/pipelineruns/kubeflow/.tekton/odh-notebook-controller-v2-25-push.yaml
+++ b/pipelineruns/kubeflow/.tekton/odh-notebook-controller-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-notebook-controller-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-notebook-controller-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-notebook-controller-v2-25

--- a/pipelineruns/kuberay/.tekton/odh-kuberay-operator-controller-v2-25-push.yaml
+++ b/pipelineruns/kuberay/.tekton/odh-kuberay-operator-controller-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-kuberay-operator-controller-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-kuberay-operator-controller-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-kuberay-operator-controller-v2-25

--- a/pipelineruns/kueue/.tekton/odh-kueue-controller-v2-25-push.yaml
+++ b/pipelineruns/kueue/.tekton/odh-kueue-controller-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-kueue-controller-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-kueue-controller-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-kueue-controller-v2-25

--- a/pipelineruns/llm-d-inference-scheduler/.tekton/odh-llm-d-inference-scheduler-v2-25-push.yaml
+++ b/pipelineruns/llm-d-inference-scheduler/.tekton/odh-llm-d-inference-scheduler-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-llm-d-inference-scheduler-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-llm-d-inference-scheduler-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-llm-d-inference-scheduler-v2-25

--- a/pipelineruns/llm-d-routing-sidecar/.tekton/odh-llm-d-routing-sidecar-v2-25-push.yaml
+++ b/pipelineruns/llm-d-routing-sidecar/.tekton/odh-llm-d-routing-sidecar-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-llm-d-routing-sidecar-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-llm-d-routing-sidecar-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-llm-d-routing-sidecar-v2-25

--- a/pipelineruns/lm-evaluation-harness/.tekton/odh-ta-lmes-job-v2-25-push.yaml
+++ b/pipelineruns/lm-evaluation-harness/.tekton/odh-ta-lmes-job-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-ta-lmes-job-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-ta-lmes-job-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-ta-lmes-job-v2-25

--- a/pipelineruns/ml-metadata/.tekton/odh-mlmd-grpc-server-v2-25-push.yaml
+++ b/pipelineruns/ml-metadata/.tekton/odh-mlmd-grpc-server-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-mlmd-grpc-server-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-mlmd-grpc-server-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-mlmd-grpc-server-v2-25

--- a/pipelineruns/model-metadata-collection/.tekton/odh-model-metadata-collection-v2-25-push.yaml
+++ b/pipelineruns/model-metadata-collection/.tekton/odh-model-metadata-collection-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-model-metadata-collection-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-model-metadata-collection-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-model-metadata-collection-v2-25

--- a/pipelineruns/model-registry-operator/.tekton/odh-model-registry-operator-v2-25-push.yaml
+++ b/pipelineruns/model-registry-operator/.tekton/odh-model-registry-operator-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-model-registry-operator-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-model-registry-operator-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-model-registry-operator-v2-25

--- a/pipelineruns/model-registry/.tekton/odh-model-registry-v2-25-push.yaml
+++ b/pipelineruns/model-registry/.tekton/odh-model-registry-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-model-registry-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-model-registry-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-model-registry-v2-25

--- a/pipelineruns/modelmesh-runtime-adapter/.tekton/odh-modelmesh-runtime-adapter-v2-25-push.yaml
+++ b/pipelineruns/modelmesh-runtime-adapter/.tekton/odh-modelmesh-runtime-adapter-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-modelmesh-runtime-adapter-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-modelmesh-runtime-adapter-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-modelmesh-runtime-adapter-v2-25

--- a/pipelineruns/modelmesh-serving/.tekton/odh-modelmesh-serving-controller-v2-25-push.yaml
+++ b/pipelineruns/modelmesh-serving/.tekton/odh-modelmesh-serving-controller-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-modelmesh-serving-controller-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-modelmesh-serving-controller-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-modelmesh-serving-controller-v2-25

--- a/pipelineruns/odh-dashboard/.tekton/odh-dashboard-v2-25-push.yaml
+++ b/pipelineruns/odh-dashboard/.tekton/odh-dashboard-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-dashboard-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-dashboard-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-dashboard-v2-25

--- a/pipelineruns/odh-model-controller/.tekton/odh-model-controller-v2-25-push.yaml
+++ b/pipelineruns/odh-model-controller/.tekton/odh-model-controller-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-model-controller-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-model-controller-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-model-controller-v2-25

--- a/pipelineruns/ogx-k8s-operator/.tekton/odh-llama-stack-k8s-operator-v2-25-push.yaml
+++ b/pipelineruns/ogx-k8s-operator/.tekton/odh-llama-stack-k8s-operator-v2-25-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-llama-stack-k8s-operator-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-llama-stack-k8s-operator-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-llama-stack-k8s-operator-v2-25

--- a/pipelineruns/openvino_model_server/.tekton/odh-openvino-model-server-v2-25-push.yaml
+++ b/pipelineruns/openvino_model_server/.tekton/odh-openvino-model-server-v2-25-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-openvino-model-server-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-openvino-model-server-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-openvino-model-server-v2-25

--- a/pipelineruns/rest-proxy/.tekton/odh-mm-rest-proxy-v2-25-push.yaml
+++ b/pipelineruns/rest-proxy/.tekton/odh-mm-rest-proxy-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-mm-rest-proxy-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-mm-rest-proxy-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-mm-rest-proxy-v2-25

--- a/pipelineruns/rhods-operator/.tekton/odh-operator-v2-25-push.yaml
+++ b/pipelineruns/rhods-operator/.tekton/odh-operator-v2-25-push.yaml
@@ -8,11 +8,18 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     build.appstudio.openshift.io/build-nudge-files: "bundle/bundle-patch.yaml"
+    # Skip trigger when only these files/folders change:
+    #   bundle/, build/, .tekton/, .github/workflows/, Dockerfiles/bundle.Dockerfile
+    # Exception: always trigger for:
+    #   build/operands-map.yaml, .tekton/odh-operator-v2-25-push.yaml
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" && target_branch == "rhoai-2.25" && !"bundle/**".pathChanged()
-      && !"Dockerfiles/bundle.Dockerfile".pathChanged() && (!"build/**".pathChanged()
-      || "build/operands-map.yaml".pathChanged() || ".tekton/odh-operator-v2-25-push.yaml".pathChanged()
-      ) && !".github/workflows/**".pathChanged()
+      event == "push"
+      && target_branch == "rhoai-2.25"
+      && ( files.all.exists(p, !(
+        p.matches('^bundle/') || p.matches('^build/') || p.matches('^\\.tekton/')
+          || p.matches('^\\.github/workflows/')
+          || p.matches('^Dockerfiles/bundle\\.Dockerfile$')
+      ) || "build/operands-map.yaml".pathChanged() || ".tekton/odh-operator-v2-25-push.yaml".pathChanged()) )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-operator-v2-25

--- a/pipelineruns/training-operator/.tekton/odh-training-operator-v2-25-push.yaml
+++ b/pipelineruns/training-operator/.tekton/odh-training-operator-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-training-operator-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-training-operator-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-training-operator-v2-25

--- a/pipelineruns/trustyai-service-operator/.tekton/odh-ta-lmes-driver-v2-25-push.yaml
+++ b/pipelineruns/trustyai-service-operator/.tekton/odh-ta-lmes-driver-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-ta-lmes-driver-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-ta-lmes-driver-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-ta-lmes-driver-v2-25

--- a/pipelineruns/trustyai-service-operator/.tekton/odh-trustyai-service-operator-v2-25-push.yaml
+++ b/pipelineruns/trustyai-service-operator/.tekton/odh-trustyai-service-operator-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-trustyai-service-operator-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-trustyai-service-operator-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-trustyai-service-operator-v2-25

--- a/pipelineruns/vllm-cpu/.tekton/odh-vllm-cpu-v2-25-push.yaml
+++ b/pipelineruns/vllm-cpu/.tekton/odh-vllm-cpu-v2-25-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-vllm-cpu-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-vllm-cpu-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-vllm-cpu-v2-25

--- a/pipelineruns/vllm-gaudi/.tekton/odh-vllm-gaudi-v2-25-push.yaml
+++ b/pipelineruns/vllm-gaudi/.tekton/odh-vllm-gaudi-v2-25-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-vllm-gaudi-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-vllm-gaudi-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-vllm-gaudi-v2-25

--- a/pipelineruns/vllm-orchestrator-gateway/.tekton/odh-trustyai-vllm-orchestrator-gateway-v2-25-push.yaml
+++ b/pipelineruns/vllm-orchestrator-gateway/.tekton/odh-trustyai-vllm-orchestrator-gateway-v2-25-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-trustyai-vllm-orchestrator-gateway-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-trustyai-vllm-orchestrator-gateway-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-trustyai-vllm-orchestrator-gateway-v2-25

--- a/pipelineruns/vllm-rocm/.tekton/odh-vllm-rocm-v2-25-push.yaml
+++ b/pipelineruns/vllm-rocm/.tekton/odh-vllm-rocm-v2-25-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-vllm-rocm-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-vllm-rocm-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-vllm-rocm-v2-25

--- a/pipelineruns/vllm/.tekton/odh-vllm-cuda-v2-25-push.yaml
+++ b/pipelineruns/vllm/.tekton/odh-vllm-cuda-v2-25-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-2.25"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-vllm-cuda-v2-25-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-vllm-cuda-v2-25-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-vllm-cuda-v2-25


### PR DESCRIPTION
## Summary

Backport of [RHOAIENG-55165](https://redhat.atlassian.net/browse/RHOAIENG-55165) CEL expression fixes from `rhoai-3.4` to `rhoai-2.25`.

- Convert buggy `!".tekton/**".pathChanged()` negation patterns to `files.all.exists(p, !p.matches('^\\.tekton/'))` across all pipelineruns push YAML files
- Fix RHOAI-Build-Config files (`odh-operator-bundle`, `rhoai-fbc-fragment`) to use `files.all.exists()` for exclusion patterns
- Fix rhods-operator to combine all exclusions into a single `files.all.exists()` call with proper `.tekton/` exclusion

The old patterns incorrectly prevented pipeline triggers when both excluded and non-excluded files changed in the same commit.

## Original PRs (rhoai-3.4)

- https://github.com/red-hat-data-services/konflux-central/pull/1722
- https://github.com/red-hat-data-services/konflux-central/pull/1723
- https://github.com/red-hat-data-services/konflux-central/pull/1724

## Test plan

- [x] Verify CEL expressions are syntactically valid
- [ ] Confirm pipeline triggers fire correctly when non-excluded files change alongside excluded files

🤖 Generated with [Claude Code](https://claude.com/claude-code)