### PR TITLE
fix(cel): backport on-cel-expression fixes to rhoai-3.3

### DIFF
--- a/pipelineruns/NeMo-Guardrails/.tekton/odh-trustyai-nemo-guardrails-server-v3-3-push.yaml
+++ b/pipelineruns/NeMo-Guardrails/.tekton/odh-trustyai-nemo-guardrails-server-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-trustyai-nemo-guardrails-server-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-trustyai-nemo-guardrails-server-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-trustyai-nemo-guardrails-server-v3-3

--- a/pipelineruns/RHOAI-Build-Config/.tekton/odh-operator-bundle-v3-3-push.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/odh-operator-bundle-v3-3-push.yaml
@@ -8,10 +8,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     build.appstudio.openshift.io/build-nudge-files: "catalog/catalog-patch.yaml"
+    # Trigger on bundle/ changes (or this tekton file)
+    # No trigger if bundle/bundle-patch.yaml is the only change
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" && target_branch == "rhoai-3.3" && ( "bundle/**".pathChanged()
-      || ".tekton/odh-operator-bundle-v3-3-push.yaml".pathChanged() ) && !"bundle/bundle-patch.yaml".pathChanged()
-      && !".github/workflows/**".pathChanged()
+      event == "push"
+      && target_branch == "rhoai-3.3"
+      && ( "bundle/**".pathChanged() || ".tekton/odh-operator-bundle-v3-3-push.yaml".pathChanged() )
+      && files.all.exists(p, !p.matches('^bundle/bundle-patch\\.yaml$'))
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-operator-bundle-v3-3

--- a/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v3-3-push.yaml
+++ b/pipelineruns/RHOAI-Build-Config/.tekton/rhoai-fbc-fragment-v3-3-push.yaml
@@ -7,10 +7,13 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    # Trigger on catalog/ changes (or this tekton file)
+    # No trigger if catalog/catalog-patch.yaml is the only change
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" && target_branch == "rhoai-3.3" && ( "catalog/**".pathChanged()
-      || ".tekton/rhoai-fbc-fragment-v3-3-push.yaml".pathChanged() ) && !"catalog/catalog-patch.yaml".pathChanged()
-      && !".github/workflows/**".pathChanged()
+      event == "push"
+      && target_branch == "rhoai-3.3"
+      && ( "catalog/**".pathChanged() || ".tekton/rhoai-fbc-fragment-v3-3-push.yaml".pathChanged() )
+      && files.all.exists(p, !p.matches('^catalog/catalog-patch\\.yaml$'))
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: rhoai-fbc-fragment-v3-3

--- a/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-argoexec-v3-3-push.yaml
+++ b/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-argoexec-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-data-science-pipelines-argo-argoexec-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-data-science-pipelines-argo-argoexec-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-data-science-pipelines-argo-argoexec-v3-3

--- a/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-workflowcontroller-v3-3-push.yaml
+++ b/pipelineruns/argo-workflows/.tekton/odh-data-science-pipelines-argo-workflowcontroller-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-data-science-pipelines-argo-workflowcontroller-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-data-science-pipelines-argo-workflowcontroller-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-data-science-pipelines-argo-workflowcontroller-v3-3

--- a/pipelineruns/data-science-pipelines-operator/.tekton/odh-data-science-pipelines-operator-controller-v3-3-push.yaml
+++ b/pipelineruns/data-science-pipelines-operator/.tekton/odh-data-science-pipelines-operator-controller-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-data-science-pipelines-operator-controller-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-data-science-pipelines-operator-controller-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-data-science-pipelines-operator-controller-v3-3

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-api-server-v2-v3-3-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-api-server-v2-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-ml-pipelines-api-server-v2-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-ml-pipelines-api-server-v2-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-ml-pipelines-api-server-v2-v3-3

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-driver-v3-3-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-driver-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-ml-pipelines-driver-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-ml-pipelines-driver-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-ml-pipelines-driver-v3-3

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-launcher-v3-3-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-launcher-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-ml-pipelines-launcher-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-ml-pipelines-launcher-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-ml-pipelines-launcher-v3-3

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-persistenceagent-v2-v3-3-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-persistenceagent-v2-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-ml-pipelines-persistenceagent-v2-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-ml-pipelines-persistenceagent-v2-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-ml-pipelines-persistenceagent-v2-v3-3

--- a/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-scheduledworkflow-v2-v3-3-push.yaml
+++ b/pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-scheduledworkflow-v2-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-ml-pipelines-scheduledworkflow-v2-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-ml-pipelines-scheduledworkflow-v2-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-ml-pipelines-scheduledworkflow-v2-v3-3

--- a/pipelineruns/fms-guardrails-orchestrator/.tekton/odh-fms-guardrails-orchestrator-v3-3-push.yaml
+++ b/pipelineruns/fms-guardrails-orchestrator/.tekton/odh-fms-guardrails-orchestrator-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-fms-guardrails-orchestrator-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-fms-guardrails-orchestrator-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-fms-guardrails-orchestrator-v3-3

--- a/pipelineruns/guardrails-detectors/.tekton/odh-guardrails-detector-huggingface-runtime-v3-3-push.yaml
+++ b/pipelineruns/guardrails-detectors/.tekton/odh-guardrails-detector-huggingface-runtime-v3-3-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-guardrails-detector-huggingface-runtime-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-guardrails-detector-huggingface-runtime-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-guardrails-detector-huggingface-runtime-v3-3

--- a/pipelineruns/kserve/.tekton/odh-kserve-agent-v3-3-push.yaml
+++ b/pipelineruns/kserve/.tekton/odh-kserve-agent-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-kserve-agent-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-kserve-agent-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-kserve-agent-v3-3

--- a/pipelineruns/kserve/.tekton/odh-kserve-controller-v3-3-push.yaml
+++ b/pipelineruns/kserve/.tekton/odh-kserve-controller-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-kserve-controller-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-kserve-controller-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-kserve-controller-v3-3

--- a/pipelineruns/kserve/.tekton/odh-kserve-router-v3-3-push.yaml
+++ b/pipelineruns/kserve/.tekton/odh-kserve-router-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-kserve-router-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-kserve-router-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-kserve-router-v3-3

--- a/pipelineruns/kube-auth-proxy/.tekton/odh-kube-auth-proxy-v3-3-push.yaml
+++ b/pipelineruns/kube-auth-proxy/.tekton/odh-kube-auth-proxy-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-kube-auth-proxy-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-kube-auth-proxy-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-kube-auth-proxy-v3-3

--- a/pipelineruns/kubeflow/.tekton/odh-kf-notebook-controller-v3-3-push.yaml
+++ b/pipelineruns/kubeflow/.tekton/odh-kf-notebook-controller-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-kf-notebook-controller-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-kf-notebook-controller-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-kf-notebook-controller-v3-3

--- a/pipelineruns/kubeflow/.tekton/odh-notebook-controller-v3-3-push.yaml
+++ b/pipelineruns/kubeflow/.tekton/odh-notebook-controller-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-notebook-controller-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-notebook-controller-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-notebook-controller-v3-3

--- a/pipelineruns/kuberay/.tekton/odh-kuberay-operator-controller-v3-3-push.yaml
+++ b/pipelineruns/kuberay/.tekton/odh-kuberay-operator-controller-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-kuberay-operator-controller-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-kuberay-operator-controller-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-kuberay-operator-controller-v3-3

--- a/pipelineruns/llama-stack-provider-trustyai-garak/.tekton/odh-trustyai-garak-lls-provider-dsp-v3-3-push.yaml
+++ b/pipelineruns/llama-stack-provider-trustyai-garak/.tekton/odh-trustyai-garak-lls-provider-dsp-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-trustyai-garak-lls-provider-dsp-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-trustyai-garak-lls-provider-dsp-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-trustyai-garak-lls-provider-dsp-v3-3

--- a/pipelineruns/llm-d-inference-scheduler/.tekton/odh-llm-d-inference-scheduler-v3-3-push.yaml
+++ b/pipelineruns/llm-d-inference-scheduler/.tekton/odh-llm-d-inference-scheduler-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-llm-d-inference-scheduler-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-llm-d-inference-scheduler-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-llm-d-inference-scheduler-v3-3

--- a/pipelineruns/llm-d-inference-scheduler/.tekton/odh-llm-d-routing-sidecar-v3-3-push.yaml
+++ b/pipelineruns/llm-d-inference-scheduler/.tekton/odh-llm-d-routing-sidecar-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-llm-d-routing-sidecar-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-llm-d-routing-sidecar-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-llm-d-routing-sidecar-v3-3

--- a/pipelineruns/lm-evaluation-harness/.tekton/odh-ta-lmes-job-v3-3-push.yaml
+++ b/pipelineruns/lm-evaluation-harness/.tekton/odh-ta-lmes-job-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-ta-lmes-job-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-ta-lmes-job-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-ta-lmes-job-v3-3

--- a/pipelineruns/ml-metadata/.tekton/odh-mlmd-grpc-server-v3-3-push.yaml
+++ b/pipelineruns/ml-metadata/.tekton/odh-mlmd-grpc-server-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-mlmd-grpc-server-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-mlmd-grpc-server-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-mlmd-grpc-server-v3-3

--- a/pipelineruns/mlflow-operator/.tekton/odh-mlflow-operator-v3-3-push.yaml
+++ b/pipelineruns/mlflow-operator/.tekton/odh-mlflow-operator-v3-3-push.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "rhoai-3.3" && ( !".tekton/**".pathChanged() || ".tekton/odh-mlflow-operator-v3-3-push.yaml".pathChanged() )
+      == "rhoai-3.3" && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-mlflow-operator-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-mlflow-operator-v3-3

--- a/pipelineruns/mlflow/.tekton/odh-mlflow-v3-3-push.yaml
+++ b/pipelineruns/mlflow/.tekton/odh-mlflow-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-mlflow-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-mlflow-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-mlflow-v3-3

--- a/pipelineruns/mlserver/.tekton/odh-mlserver-v3-3-push.yaml
+++ b/pipelineruns/mlserver/.tekton/odh-mlserver-v3-3-push.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "rhoai-3.3" && ( !".tekton/**".pathChanged() || ".tekton/odh-mlserver-v3-3-push.yaml".pathChanged() )
+      == "rhoai-3.3" && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-mlserver-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-mlserver-v3-3

--- a/pipelineruns/model-metadata-collection/.tekton/odh-model-metadata-collection-v3-3-push.yaml
+++ b/pipelineruns/model-metadata-collection/.tekton/odh-model-metadata-collection-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-model-metadata-collection-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-model-metadata-collection-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-model-metadata-collection-v3-3

--- a/pipelineruns/model-registry-operator/.tekton/odh-model-registry-operator-v3-3-push.yaml
+++ b/pipelineruns/model-registry-operator/.tekton/odh-model-registry-operator-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-model-registry-operator-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-model-registry-operator-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-model-registry-operator-v3-3

--- a/pipelineruns/model-registry/.tekton/odh-model-registry-v3-3-push.yaml
+++ b/pipelineruns/model-registry/.tekton/odh-model-registry-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-model-registry-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-model-registry-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-model-registry-v3-3

--- a/pipelineruns/models-as-a-service/.tekton/odh-maas-api-v3-3-push.yaml
+++ b/pipelineruns/models-as-a-service/.tekton/odh-maas-api-v3-3-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: | 
       event == "push" 
       && target_branch == "rhoai-3.3" 
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-maas-api-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-maas-api-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-maas-api-v3-3

--- a/pipelineruns/models-perf-benchmark-data/.tekton/odh-model-performance-data-v3-3-push.yaml
+++ b/pipelineruns/models-perf-benchmark-data/.tekton/odh-model-performance-data-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-model-performance-data-v3-3-push.yaml".pathChanged() || "Dockerfile.konflux".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-model-performance-data-v3-3-push.yaml".pathChanged() || "Dockerfile.konflux".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-model-performance-data-v3-3

--- a/pipelineruns/odh-dashboard/.tekton/odh-dashboard-v3-3-push.yaml
+++ b/pipelineruns/odh-dashboard/.tekton/odh-dashboard-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-dashboard-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-dashboard-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-dashboard-v3-3

--- a/pipelineruns/odh-dashboard/.tekton/odh-mod-arch-maas-v3-3-push.yaml
+++ b/pipelineruns/odh-dashboard/.tekton/odh-mod-arch-maas-v3-3-push.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "rhoai-3.3" && ( !".tekton/**".pathChanged() || ".tekton/odh-mod-arch-maas-v3-3-push.yaml".pathChanged() )
+      == "rhoai-3.3" && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-mod-arch-maas-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-mod-arch-maas-v3-3

--- a/pipelineruns/odh-model-controller/.tekton/odh-model-controller-v3-3-push.yaml
+++ b/pipelineruns/odh-model-controller/.tekton/odh-model-controller-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-model-controller-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-model-controller-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-model-controller-v3-3

--- a/pipelineruns/ogx-distribution/.tekton/odh-llama-stack-core-v3-3-push.yaml
+++ b/pipelineruns/ogx-distribution/.tekton/odh-llama-stack-core-v3-3-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-llama-stack-core-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-llama-stack-core-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-llama-stack-core-v3-3

--- a/pipelineruns/ogx-k8s-operator/.tekton/odh-llama-stack-k8s-operator-v3-3-push.yaml
+++ b/pipelineruns/ogx-k8s-operator/.tekton/odh-llama-stack-k8s-operator-v3-3-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-llama-stack-k8s-operator-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-llama-stack-k8s-operator-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-llama-stack-k8s-operator-v3-3

--- a/pipelineruns/openvino_model_server/.tekton/odh-openvino-model-server-v3-3-push.yaml
+++ b/pipelineruns/openvino_model_server/.tekton/odh-openvino-model-server-v3-3-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-openvino-model-server-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-openvino-model-server-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-openvino-model-server-v3-3

--- a/pipelineruns/rhods-operator/.tekton/odh-operator-v3-3-push.yaml
+++ b/pipelineruns/rhods-operator/.tekton/odh-operator-v3-3-push.yaml
@@ -8,11 +8,18 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     build.appstudio.openshift.io/build-nudge-files: "bundle/bundle-patch.yaml"
+    # Skip trigger when only these files/folders change:
+    #   bundle/, build/, .tekton/, .github/workflows/, Dockerfiles/bundle.Dockerfile
+    # Exception: always trigger for:
+    #   build/operands-map.yaml, .tekton/odh-operator-v3-3-push.yaml
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" && target_branch == "rhoai-3.3" && !"bundle/**".pathChanged()
-      && !"Dockerfiles/bundle.Dockerfile".pathChanged() && (!"build/**".pathChanged()
-      || "build/operands-map.yaml".pathChanged() || ".tekton/odh-operator-v3-3-push.yaml".pathChanged()
-      ) && !".github/workflows/**".pathChanged()
+      event == "push"
+      && target_branch == "rhoai-3.3"
+      && ( files.all.exists(p, !(
+        p.matches('^bundle/') || p.matches('^build/') || p.matches('^\\.tekton/')
+          || p.matches('^\\.github/workflows/')
+          || p.matches('^Dockerfiles/bundle\\.Dockerfile$')
+      ) || "build/operands-map.yaml".pathChanged() || ".tekton/odh-operator-v3-3-push.yaml".pathChanged()) )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-operator-v3-3

--- a/pipelineruns/trainer/.tekton/odh-trainer-v3-3-push.yaml
+++ b/pipelineruns/trainer/.tekton/odh-trainer-v3-3-push.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "rhoai-3.3" && ( !".tekton/**".pathChanged() || ".tekton/odh-trainer-v3-3-push.yaml".pathChanged() )
+      == "rhoai-3.3" && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-trainer-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-trainer-v3-3

--- a/pipelineruns/training-operator/.tekton/odh-training-operator-v3-3-push.yaml
+++ b/pipelineruns/training-operator/.tekton/odh-training-operator-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-training-operator-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-training-operator-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-training-operator-v3-3

--- a/pipelineruns/trustyai-service-operator/.tekton/odh-ta-lmes-driver-v3-3-push.yaml
+++ b/pipelineruns/trustyai-service-operator/.tekton/odh-ta-lmes-driver-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-ta-lmes-driver-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-ta-lmes-driver-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-ta-lmes-driver-v3-3

--- a/pipelineruns/trustyai-service-operator/.tekton/odh-trustyai-service-operator-v3-3-push.yaml
+++ b/pipelineruns/trustyai-service-operator/.tekton/odh-trustyai-service-operator-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-trustyai-service-operator-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-trustyai-service-operator-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-trustyai-service-operator-v3-3

--- a/pipelineruns/vllm-cpu/.tekton/odh-vllm-cpu-v3-3-push.yaml
+++ b/pipelineruns/vllm-cpu/.tekton/odh-vllm-cpu-v3-3-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-vllm-cpu-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-vllm-cpu-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-vllm-cpu-v3-3

--- a/pipelineruns/vllm-gaudi/.tekton/odh-vllm-gaudi-v3-3-push.yaml
+++ b/pipelineruns/vllm-gaudi/.tekton/odh-vllm-gaudi-v3-3-push.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-vllm-gaudi-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-vllm-gaudi-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-vllm-gaudi-v3-3

--- a/pipelineruns/vllm-orchestrator-gateway/.tekton/odh-trustyai-vllm-orchestrator-gateway-v3-3-push.yaml
+++ b/pipelineruns/vllm-orchestrator-gateway/.tekton/odh-trustyai-vllm-orchestrator-gateway-v3-3-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.3"
-      && ( !".tekton/**".pathChanged() || ".tekton/odh-trustyai-vllm-orchestrator-gateway-v3-3-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-trustyai-vllm-orchestrator-gateway-v3-3-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-trustyai-vllm-orchestrator-gateway-v3-3


### PR DESCRIPTION
## Summary

Backport of [RHOAIENG-55165](https://redhat.atlassian.net/browse/RHOAIENG-55165) CEL expression fixes from `rhoai-3.4` to `rhoai-3.3`.

- Convert buggy `!".tekton/**".pathChanged()` negation patterns to `files.all.exists(p, !p.matches('^\\.tekton/'))` across all pipelineruns push YAML files
- Fix RHOAI-Build-Config files (`odh-operator-bundle`, `rhoai-fbc-fragment`) to use `files.all.exists()` for exclusion patterns
- Fix rhods-operator to combine all exclusions into a single `files.all.exists()` call with proper `.tekton/` exclusion

The old patterns incorrectly prevented pipeline triggers when both excluded and non-excluded files changed in the same commit.

## Original PRs (rhoai-3.4)

- https://github.com/red-hat-data-services/konflux-central/pull/1722
- https://github.com/red-hat-data-services/konflux-central/pull/1723
- https://github.com/red-hat-data-services/konflux-central/pull/1724

## Test plan

- [x] Verify CEL expressions are syntactically valid
- [ ] Confirm pipeline triggers fire correctly when non-excluded files change alongside excluded files

🤖 Generated with [Claude Code](https://claude.com/claude-code)