### PR TITLE
Add kserve-module-operator push PipelineRun for v3-6-ea-1

### DIFF
--- a/pipelineruns/kserve/.tekton/odh-kserve-module-operator-v3-6-ea-1-push.yaml
+++ b/pipelineruns/kserve/.tekton/odh-kserve-module-operator-v3-6-ea-1-push.yaml
@@ -1,0 +1,68 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/kserve?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push"
+      && target_branch == "rhoai-3.6-ea.1"
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-kserve-module-operator-v3-6-ea-1-push.yaml".pathChanged() )
+  labels:
+    appstudio.openshift.io/application: rhoai-v3-6-ea-1
+    appstudio.openshift.io/component: odh-kserve-module-operator-v3-6-ea-1
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-kserve-module-operator-v3-6-ea-1-on-push
+  namespace: rhoai-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: additional-tags
+    value:
+    - '{{target_branch}}-{{revision}}'
+  - name: output-image
+    value: quay.io/rhoai/odh-kserve-module-operator-rhel9:{{target_branch}}
+  - name: rhoai-version
+    value: "3.6.0-ea.1"
+  - name: dockerfile
+    value: Dockerfiles/Dockerfile.konflux.kserve-module-controller
+  - name: path-context
+    value: .
+  - name: hermetic
+    value: true
+  - name: prefetch-input
+    value: |
+      [{"type": "rpm", "path": "."}, {"type": "gomod", "path": "kserve-module/"}]
+  - name: build-source-image
+    value: true
+  - name: build-image-index
+    value: true
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux-m2xlarge/arm64
+    - linux/ppc64le
+    - linux/s390x
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ target_branch }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-kserve-module-operator-v3-6-ea-1
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
## Summary

- Adds the missing `odh-kserve-module-operator-v3-6-ea-1-push.yaml` push PipelineRun
- The v3-5 version was removed in 434d176 as a stale leftover on this branch, but the v3-6-ea-1 replacement was never created
- Follows the same pattern as the other kserve components on this branch

## Test plan

- [ ] Verify the PipelineRun triggers on push to `rhoai-3.6-ea.1`
- [ ] Confirm component name and service account match the Component CR in the cluster