### PR TITLE
Fix codeserver prefetch paths for v4.112.0 upgrade (rhoai-3.4)

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-4-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-4-push.yaml
@@ -75,6 +75,8 @@ spec:
       type: npm
     - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/build
       type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/build/vite
+      type: npm
     - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/build/npm/gyp
       type: npm
     - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions
@@ -166,20 +168,22 @@ spec:
     - path: codeserver/ubi9-python-3.12/prefetch-input/code-server
       type: npm
     # patches/ overlay (overwrites code-server at build); use these so Cachi2 prefetches registry-only lockfiles
-    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.106.3/lib/vscode
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode
       type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.106.3/lib/vscode/remote
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/remote
       type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.106.3/lib/vscode/extensions
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/extensions
       type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.106.3/lib/vscode/extensions/emmet
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/extensions/emmet
       type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.106.3/test
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/build/vite
       type: npm
-    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.106.3/lib/vscode/extensions/microsoft-authentication
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/test
+      type: npm
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/extensions/microsoft-authentication
       type: npm
     # Registry-only npm deps (ProdSec); @parcel/watcher, @emmetio/css-parser, @playwright/browser-chromium in custom-packages/package.json
-    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.106.3/custom-packages
+    - path: codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/custom-packages
       type: npm
   pipelineRef:
     resolver: git


### PR DESCRIPTION
## Summary
- Update prefetch-input paths in the v3-4-push pipeline to match the code-server v4.106.3 → v4.112.0 upgrade
- Add new `build/vite` npm prefetch entries for both the code-server submodule and the patches overlay

## Context
Notebooks PR https://github.com/red-hat-data-services/notebooks/pull/2545 upgraded codeserver to v4.112.0 on `rhoai-3.4`. The patches directory was renamed from `code-server-v4.106.3` to `code-server-v4.112.0`, and vite npm paths were added. Those `.tekton` edits belong in konflux-central so they sync back correctly.

Same change pattern as https://github.com/red-hat-data-services/konflux-central/pull/2913 (rhoai-3.5).

## Test plan
- [ ] Confirm PipelineRun YAML diffs match notebooks PR #2545 `.tekton` prefetch updates
- [ ] After merge, verify sync into `red-hat-data-services/notebooks` `.tekton/`
- [ ] Trigger / observe codeserver Konflux build on rhoai-3.4 succeeds prefetch-dependencies


Made with [Cursor](https://cursor.com)