### PR TITLE
Disable fips-check blocking for codeserver-datascience-cpu-py312

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-pull-request.yaml
@@ -58,6 +58,8 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
+  - name: fips-check-blocking
+    value: "false"
   - name: rhel-subscription-activation-key
     value: "rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6"
   - name: prefetch-input


### PR DESCRIPTION
## Summary
- Set `fips-check-blocking: "false"` for `odh-workbench-codeserver-datascience-cpu-py312` pull-request pipeline
- FIPS check still runs for visibility but no longer fails the pipeline

## Root Cause
The `check-payload` FIPS scanner flags 4 statically linked `apply-seccomp` binaries from `@anthropic-ai/sandbox-runtime` (bundled with code-server) as FIPS non-compliant. These are false positives — seccomp filter appliers set up kernel syscall filters and do not perform cryptographic operations.

## Failing binaries
- `/usr/lib/code-server/lib/vscode/node_modules/@anthropic-ai/sandbox-runtime/dist/vendor/seccomp/arm64/apply-seccomp`
- `/usr/lib/code-server/lib/vscode/node_modules/@anthropic-ai/sandbox-runtime/dist/vendor/seccomp/x64/apply-seccomp`
- `/usr/lib/code-server/lib/vscode/node_modules/@anthropic-ai/sandbox-runtime/vendor/seccomp/arm64/apply-seccomp`
- `/usr/lib/code-server/lib/vscode/node_modules/@anthropic-ai/sandbox-runtime/vendor/seccomp/x64/apply-seccomp`

## Related PRs
- rhoai-3.5: (separate PR)
- rhoai-3.6-ea.1: (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)