### PR TITLE
Enable Renovate for distributed-workloads

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -54,6 +54,7 @@
     - name: "red-hat-data-services/workbenches-operator"
     - name: "red-hat-data-services/trainer-operator"
     - name: "red-hat-data-services/feast-module-operator"
+    - name: "red-hat-data-services/distributed-workloads"
 
 - renovate-config: "renovate/custom-renovate-distribution.json"
   sync-repositories:


### PR DESCRIPTION
Adds 'red-hat-data-services/distributed-workloads' to the default Renovate distribution in config.yaml.

## Details

| Field | Value |
|-------|-------|
| Component repo | `https://github.com/red-hat-data-services/distributed-workloads` |
| Renovate entry | `red-hat-data-services/distributed-workloads` |
| Distribution | `renovate/default-renovate-distribution.json` |

**Jira:** https://redhat.atlassian.net/browse/RHOAIENG-79950