### PR TITLE
Add universal training images (CPU, CUDA, ROCm) pull-request PipelineRuns

### DIFF
--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-5-pull-request.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-5-pull-request.yaml
@@ -37,7 +37,8 @@ spec:
       [{"type": "gomod", "path": "images/universal/training/th-torch-cpu-py312/"}]
   - name: build-platforms
     value:
-    - linux/x86_64 linux-m2xlarge/arm64
+    - linux/x86_64
+    - linux-m2xlarge/arm64
   pipelineRef:
     params:
     - name: url

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-5-pull-request.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-5-pull-request.yaml
@@ -1,0 +1,60 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/distributed-workloads?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-event: '[pull_request]'
+    pipelinesascode.tekton.dev/on-comment: '^/build-konflux'
+    pipelinesascode.tekton.dev/on-target-branch: '[{{target_branch}}]'
+  labels:
+    appstudio.openshift.io/application: automation
+    appstudio.openshift.io/component: pull-request-pipelines-odh-th-torch-cpu-py312-v3-5
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-th-torch-cpu-py312-v3-5-on-pull-request-{{pull_request_number}}
+  namespace: rhoai-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/rhoai/pull-request-pipelines:odh-th-torch-cpu-py312-v3-5-{{revision}}
+  - name: dockerfile
+    value: Dockerfile.konflux
+  - name: path-context
+    value: images/universal/training/th-torch-cpu-py312/
+  - name: image-expires-after
+    value: 5d
+  - name: enable-slack-failure-notification
+    value: "false"
+  - name: prefetch-input
+    value: |
+      [{"type": "gomod", "path": "images/universal/training/th-torch-cpu-py312/"}]
+  - name: build-platforms
+    value:
+    - linux/x86_64 linux-m2xlarge/arm64
+  pipelineRef:
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ target_branch }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+    resolver: git
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-pull-request-pipelines
+    podTemplate:
+      imagePullSecrets:
+      - name: redhat-appstudio-staginguser-pull-secret
+  timeouts:
+    pipeline: 8h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-pull-request.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-pull-request.yaml
@@ -37,7 +37,8 @@ spec:
       [{"type": "gomod", "path": "images/universal/training/th-torch-cuda-py312/"}]
   - name: build-platforms
     value:
-    - linux/x86_64 linux-m2xlarge/arm64
+    - linux/x86_64
+    - linux-m2xlarge/arm64
   pipelineRef:
     params:
     - name: url

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-pull-request.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-pull-request.yaml
@@ -1,0 +1,60 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/distributed-workloads?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-event: '[pull_request]'
+    pipelinesascode.tekton.dev/on-comment: '^/build-konflux'
+    pipelinesascode.tekton.dev/on-target-branch: '[{{target_branch}}]'
+  labels:
+    appstudio.openshift.io/application: automation
+    appstudio.openshift.io/component: pull-request-pipelines-odh-th-torch-cuda-py312-v3-5
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-th-torch-cuda-py312-v3-5-on-pull-request-{{pull_request_number}}
+  namespace: rhoai-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/rhoai/pull-request-pipelines:odh-th-torch-cuda-py312-v3-5-{{revision}}
+  - name: dockerfile
+    value: Dockerfile.konflux
+  - name: path-context
+    value: images/universal/training/th-torch-cuda-py312/
+  - name: image-expires-after
+    value: 5d
+  - name: enable-slack-failure-notification
+    value: "false"
+  - name: prefetch-input
+    value: |
+      [{"type": "gomod", "path": "images/universal/training/th-torch-cuda-py312/"}]
+  - name: build-platforms
+    value:
+    - linux/x86_64 linux-m2xlarge/arm64
+  pipelineRef:
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ target_branch }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+    resolver: git
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-pull-request-pipelines
+    podTemplate:
+      imagePullSecrets:
+      - name: redhat-appstudio-staginguser-pull-secret
+  timeouts:
+    pipeline: 8h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-5-pull-request.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-5-pull-request.yaml
@@ -1,0 +1,60 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/distributed-workloads?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-event: '[pull_request]'
+    pipelinesascode.tekton.dev/on-comment: '^/build-konflux'
+    pipelinesascode.tekton.dev/on-target-branch: '[{{target_branch}}]'
+  labels:
+    appstudio.openshift.io/application: automation
+    appstudio.openshift.io/component: pull-request-pipelines-odh-th-torch-rocm-py312-v3-5
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-th-torch-rocm-py312-v3-5-on-pull-request-{{pull_request_number}}
+  namespace: rhoai-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/rhoai/pull-request-pipelines:odh-th-torch-rocm-py312-v3-5-{{revision}}
+  - name: dockerfile
+    value: Dockerfile.konflux
+  - name: path-context
+    value: images/universal/training/th-torch-rocm-py312/
+  - name: image-expires-after
+    value: 5d
+  - name: enable-slack-failure-notification
+    value: "false"
+  - name: prefetch-input
+    value: |
+      [{"type": "gomod", "path": "images/universal/training/th-torch-rocm-py312/"}]
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  pipelineRef:
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ target_branch }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+    resolver: git
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-pull-request-pipelines
+    podTemplate:
+      imagePullSecrets:
+      - name: redhat-appstudio-staginguser-pull-secret
+  timeouts:
+    pipeline: 8h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'


### PR DESCRIPTION
Adds pull-request PipelineRun YAMLs for all three universal training images:

- odh-th-torch-cpu-py312-v3-5 (x86_64 + arm64)
- odh-th-torch-cuda-py312-v3-5 (x86_64 + arm64)
- odh-th-torch-rocm-py312-v3-5 (x86_64)

Jira:
- https://redhat.atlassian.net/browse/RHOAIENG-79950
- https://redhat.atlassian.net/browse/RHOAIENG-79951
- https://redhat.atlassian.net/browse/RHOAIENG-79952