### PR TITLE
Fix prefetch-input for universal training images (push)

### DIFF
--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-5-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-5-v3-5-push.yaml
@@ -40,7 +40,7 @@ spec:
     value: true
   - name: prefetch-input
     value: |
-      [{"type": "gomod", "path": "images/universal/training/th-torch-cpu-py312/"}]
+      [{"type": "pip", "path": "images/universal/training/th-torch-cpu-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64,aarch64", "os": "linux"}},{"type": "rpm", "path": "images/universal/training/th-torch-cpu-py312"}]
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-v3-5-push.yaml
@@ -40,7 +40,7 @@ spec:
     value: true
   - name: prefetch-input
     value: |
-      [{"type": "gomod", "path": "images/universal/training/th-torch-cuda-py312/"}]
+      [{"type": "pip", "path": "images/universal/training/th-torch-cuda-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64,aarch64", "os": "linux"}},{"type": "rpm", "path": "images/universal/training/th-torch-cuda-py312"}]
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-5-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-5-v3-5-push.yaml
@@ -40,7 +40,7 @@ spec:
     value: true
   - name: prefetch-input
     value: |
-      [{"type": "gomod", "path": "images/universal/training/th-torch-rocm-py312/"}]
+      [{"type": "pip", "path": "images/universal/training/th-torch-rocm-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64", "os": "linux"}},{"type": "rpm", "path": "images/universal/training/th-torch-rocm-py312"}]
   - name: build-platforms
     value:
     - linux/x86_64


### PR DESCRIPTION
## Summary
- Fix prefetch-input for odh-th-torch-{cpu,cuda,rocm}-py312-v3-5 push PipelineRuns
- Changed from incorrect `gomod` type to `pip` + `rpm` (these are container image builds with requirements.txt, not Go projects)
- CPU/CUDA: `x86_64,aarch64` binary arch; ROCm: `x86_64` only

Fixes Konflux build failure: `LockfileNotFound: Required files not found: .../go.mod`

Jira: RHOAIENG-79950, RHOAIENG-79951, RHOAIENG-79952