### PR TITLE
Fix doubled version in universal training image push pipeline names

### DIFF
--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-5-push.yaml
@@ -12,12 +12,12 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-th-torch-cpu-py312-v3-5-v3-5-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-th-torch-cpu-py312-v3-5-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5
-    appstudio.openshift.io/component: odh-th-torch-cpu-py312-v3-5-v3-5
+    appstudio.openshift.io/component: odh-th-torch-cpu-py312-v3-5
     pipelines.appstudio.openshift.io/type: build
-  name: odh-th-torch-cpu-py312-v3-5-v3-5-on-push
+  name: odh-th-torch-cpu-py312-v3-5-on-push
   namespace: rhoai-tenant
 spec:
   params:
@@ -55,7 +55,7 @@ spec:
       value: pipelines/multi-arch-container-build.yaml
     resolver: git
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-th-torch-cpu-py312-v3-5-v3-5
+    serviceAccountName: build-pipeline-odh-th-torch-cpu-py312-v3-5
     podTemplate:
       imagePullSecrets:
       - name: redhat-appstudio-staginguser-pull-secret

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-push.yaml
@@ -12,12 +12,12 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-th-torch-cuda-py312-v3-5-v3-5-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-th-torch-cuda-py312-v3-5-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5
-    appstudio.openshift.io/component: odh-th-torch-cuda-py312-v3-5-v3-5
+    appstudio.openshift.io/component: odh-th-torch-cuda-py312-v3-5
     pipelines.appstudio.openshift.io/type: build
-  name: odh-th-torch-cuda-py312-v3-5-v3-5-on-push
+  name: odh-th-torch-cuda-py312-v3-5-on-push
   namespace: rhoai-tenant
 spec:
   params:
@@ -55,7 +55,7 @@ spec:
       value: pipelines/multi-arch-container-build.yaml
     resolver: git
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-th-torch-cuda-py312-v3-5-v3-5
+    serviceAccountName: build-pipeline-odh-th-torch-cuda-py312-v3-5
     podTemplate:
       imagePullSecrets:
       - name: redhat-appstudio-staginguser-pull-secret

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-5-push.yaml
@@ -12,12 +12,12 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.5"
-      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-th-torch-rocm-py312-v3-5-v3-5-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-th-torch-rocm-py312-v3-5-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-5
-    appstudio.openshift.io/component: odh-th-torch-rocm-py312-v3-5-v3-5
+    appstudio.openshift.io/component: odh-th-torch-rocm-py312-v3-5
     pipelines.appstudio.openshift.io/type: build
-  name: odh-th-torch-rocm-py312-v3-5-v3-5-on-push
+  name: odh-th-torch-rocm-py312-v3-5-on-push
   namespace: rhoai-tenant
 spec:
   params:
@@ -54,7 +54,7 @@ spec:
       value: pipelines/multi-arch-container-build.yaml
     resolver: git
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-th-torch-rocm-py312-v3-5-v3-5
+    serviceAccountName: build-pipeline-odh-th-torch-rocm-py312-v3-5
     podTemplate:
       imagePullSecrets:
       - name: redhat-appstudio-staginguser-pull-secret


### PR DESCRIPTION
## Summary
- Rename `odh-th-torch-{cpu,cuda,rocm}-py312-v3-5-v3-5-push.yaml` → `*-v3-5-push.yaml`
- Fix all internal refs (component label, name, cel expression, service account) to use single `-v3-5`
- Root cause: component_name already included `-v3-5`, and the script appended it again

Jira: RHOAIENG-79950, RHOAIENG-79951, RHOAIENG-79952