### PR TITLE
Fix output-image quay repo names for training images

### DIFF
--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-5-push.yaml
@@ -30,7 +30,7 @@ spec:
     value:
     - '{{target_branch}}-{{revision}}'
   - name: output-image
-    value: quay.io/rhoai/odh-th-torch-cpu-py312-v3-5-rhel9:{{target_branch}}
+    value: quay.io/rhoai/odh-th-torch-cpu-py312-rhel9:{{target_branch}}
   - name: rhoai-version
     value: "3.5.0"
   - name: dockerfile

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-push.yaml
@@ -30,7 +30,7 @@ spec:
     value:
     - '{{target_branch}}-{{revision}}'
   - name: output-image
-    value: quay.io/rhoai/odh-th-torch-cuda-py312-v3-5-rhel9:{{target_branch}}
+    value: quay.io/rhoai/odh-th-torch-cuda-py312-rhel9:{{target_branch}}
   - name: rhoai-version
     value: "3.5.0"
   - name: dockerfile

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-5-push.yaml
@@ -30,7 +30,7 @@ spec:
     value:
     - '{{target_branch}}-{{revision}}'
   - name: output-image
-    value: quay.io/rhoai/odh-th-torch-rocm-py312-v3-5-rhel9:{{target_branch}}
+    value: quay.io/rhoai/odh-th-torch-rocm-py312-rhel9:{{target_branch}}
   - name: rhoai-version
     value: "3.5.0"
   - name: dockerfile


### PR DESCRIPTION
## Summary
- Remove version suffix (`-v3-5`) from output-image quay repo names in push pipelines for `odh-th-torch-{cpu,cuda,rocm}-py312`
- Fixes 401 Unauthorized build failures caused by image URLs referencing old repo names that were renamed in app-interface

Before: `quay.io/rhoai/odh-th-torch-*-py312-v3-5-rhel9`
After: `quay.io/rhoai/odh-th-torch-*-py312-rhel9`

## Test plan
- [ ] Verify push builds no longer fail with 401 Unauthorized
- [ ] Verify images land in the correct quay repos