### PR TITLE
Remove rpm prefetch from training image pipelines

### DIFF
--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-5-push.yaml
@@ -41,7 +41,7 @@ spec:
     value: true
   - name: prefetch-input
     value: |
-      [{"type": "pip", "path": "images/universal/training/th-torch-cpu-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64,aarch64", "os": "linux"}},{"type": "rpm", "path": "images/universal/training/th-torch-cpu-py312"}]
+      [{"type": "pip", "path": "images/universal/training/th-torch-cpu-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64,aarch64", "os": "linux"}}]
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-5-push.yaml
@@ -30,7 +30,7 @@ spec:
     value:
     - '{{target_branch}}-{{revision}}'
   - name: output-image
-    value: quay.io/rhoai/odh-th-torch-cpu-py312-v3-5-rhel9:{{target_branch}}
+    value: quay.io/rhoai/odh-th-torch-cpu-py312-rhel9:{{target_branch}}
   - name: rhoai-version
     value: "3.5.0"
   - name: dockerfile

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-push.yaml
@@ -41,7 +41,7 @@ spec:
     value: true
   - name: prefetch-input
     value: |
-      [{"type": "pip", "path": "images/universal/training/th-torch-cuda-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64,aarch64", "os": "linux"}},{"type": "rpm", "path": "images/universal/training/th-torch-cuda-py312"}]
+      [{"type": "pip", "path": "images/universal/training/th-torch-cuda-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64,aarch64", "os": "linux"}}]
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-push.yaml
@@ -30,7 +30,7 @@ spec:
     value:
     - '{{target_branch}}-{{revision}}'
   - name: output-image
-    value: quay.io/rhoai/odh-th-torch-cuda-py312-v3-5-rhel9:{{target_branch}}
+    value: quay.io/rhoai/odh-th-torch-cuda-py312-rhel9:{{target_branch}}
   - name: rhoai-version
     value: "3.5.0"
   - name: dockerfile

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-5-push.yaml
@@ -30,7 +30,7 @@ spec:
     value:
     - '{{target_branch}}-{{revision}}'
   - name: output-image
-    value: quay.io/rhoai/odh-th-torch-rocm-py312-v3-5-rhel9:{{target_branch}}
+    value: quay.io/rhoai/odh-th-torch-rocm-py312-rhel9:{{target_branch}}
   - name: rhoai-version
     value: "3.5.0"
   - name: dockerfile

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-5-push.yaml
@@ -41,7 +41,7 @@ spec:
     value: true
   - name: prefetch-input
     value: |
-      [{"type": "pip", "path": "images/universal/training/th-torch-rocm-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64", "os": "linux"}},{"type": "rpm", "path": "images/universal/training/th-torch-rocm-py312"}]
+      [{"type": "pip", "path": "images/universal/training/th-torch-rocm-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64", "os": "linux"}}]
   - name: build-platforms
     value:
     - linux/x86_64


### PR DESCRIPTION
## Summary
- Remove `{"type": "rpm"}` from prefetch-input for `odh-th-torch-{cpu,cuda,rocm}-py312` push pipelines
- Fixes `LockfileNotFound: rpms.lock.yaml` build failures — the Dockerfile uses `dnf install` directly, not via cachi2
- Hermetic pip prefetch is preserved

## Test plan
- [ ] Verify builds pass the prefetch-dependencies step