### PR TITLE
fix: disable hermetic builds for odh-th-torch cpu/cuda/rocm v3-5

### DIFF
--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-5-push.yaml
@@ -38,7 +38,7 @@ spec:
   - name: path-context
     value: images/universal/training/th-torch-cpu-py312/
   - name: hermetic
-    value: true
+    value: false
   - name: prefetch-input
     value: |
       [{"type": "pip", "path": "images/universal/training/th-torch-cpu-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64,aarch64", "os": "linux"}},{"type": "rpm", "path": "images/universal/training/th-torch-cpu-py312"}]

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-push.yaml
@@ -38,7 +38,7 @@ spec:
   - name: path-context
     value: images/universal/training/th-torch-cuda-py312/
   - name: hermetic
-    value: true
+    value: false
   - name: prefetch-input
     value: |
       [{"type": "pip", "path": "images/universal/training/th-torch-cuda-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64,aarch64", "os": "linux"}},{"type": "rpm", "path": "images/universal/training/th-torch-cuda-py312"}]

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-5-push.yaml
@@ -38,7 +38,7 @@ spec:
   - name: path-context
     value: images/universal/training/th-torch-rocm-py312/
   - name: hermetic
-    value: true
+    value: false
   - name: prefetch-input
     value: |
       [{"type": "pip", "path": "images/universal/training/th-torch-rocm-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64", "os": "linux"}},{"type": "rpm", "path": "images/universal/training/th-torch-rocm-py312"}]


### PR DESCRIPTION
Set hermetic: false for odh-th-torch-cpu-py312-v3-5, odh-th-torch-cuda-py312-v3-5, and odh-th-torch-rocm-py312-v3-5 push PipelineRuns.

Made with [Cursor](https://cursor.com)