### PR TITLE
fix: disable hermetic and clear prefetch-input for odh-th-torch pull-request pipelines

### DIFF
--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-pull-request.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-pull-request.yaml
@@ -36,6 +36,9 @@ spec:
     value: 'false'
   - name: prefetch-input
     value: '[]'
+    # TODO: restore once rpms.lock.yaml is committed:
+    # value: |
+    #   [{"type": "pip", "path": "images/universal/training/th-torch-cpu-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64,aarch64", "os": "linux"}},{"type": "rpm", "path": "images/universal/training/th-torch-cpu-py312"}]
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-pull-request.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-pull-request.yaml
@@ -32,9 +32,10 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
+  - name: hermetic
+    value: 'false'
   - name: prefetch-input
-    value: |
-      [{"type": "pip", "path": "images/universal/training/th-torch-cpu-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64,aarch64", "os": "linux"}},{"type": "rpm", "path": "images/universal/training/th-torch-cpu-py312"}]
+    value: '[]'
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-pull-request.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-pull-request.yaml
@@ -32,9 +32,10 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
+  - name: hermetic
+    value: 'false'
   - name: prefetch-input
-    value: |
-      [{"type": "pip", "path": "images/universal/training/th-torch-cuda-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64,aarch64", "os": "linux"}},{"type": "rpm", "path": "images/universal/training/th-torch-cuda-py312"}]
+    value: '[]'
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-pull-request.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-pull-request.yaml
@@ -36,6 +36,9 @@ spec:
     value: 'false'
   - name: prefetch-input
     value: '[]'
+    # TODO: restore once rpms.lock.yaml is committed:
+    # value: |
+    #   [{"type": "pip", "path": "images/universal/training/th-torch-cuda-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64,aarch64", "os": "linux"}},{"type": "rpm", "path": "images/universal/training/th-torch-cuda-py312"}]
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-pull-request.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-pull-request.yaml
@@ -32,9 +32,10 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
+  - name: hermetic
+    value: 'false'
   - name: prefetch-input
-    value: |
-      [{"type": "pip", "path": "images/universal/training/th-torch-rocm-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64", "os": "linux"}},{"type": "rpm", "path": "images/universal/training/th-torch-rocm-py312"}]
+    value: '[]'
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-pull-request.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-pull-request.yaml
@@ -36,6 +36,9 @@ spec:
     value: 'false'
   - name: prefetch-input
     value: '[]'
+    # TODO: restore once rpms.lock.yaml is committed:
+    # value: |
+    #   [{"type": "pip", "path": "images/universal/training/th-torch-rocm-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64", "os": "linux"}},{"type": "rpm", "path": "images/universal/training/th-torch-rocm-py312"}]
   - name: build-platforms
     value:
     - linux/x86_64


### PR DESCRIPTION
Set hermetic: false and prefetch-input: '[]' for odh-th-torch-cpu-py312, odh-th-torch-cuda-py312, and odh-th-torch-rocm-py312 pull-request PipelineRuns.

Made with [Cursor](https://cursor.com)