### PR TITLE
fix: set prefetch-input to empty string to skip prefetch for odh-th-torch v3-5

### DIFF
--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-5-push.yaml
@@ -40,7 +40,7 @@ spec:
   - name: hermetic
     value: false
   - name: prefetch-input
-    value: '[]'
+    value: ""
     # TODO: restore once rpms.lock.yaml is committed:
     # value: |
     #   [{"type": "pip", "path": "images/universal/training/th-torch-cpu-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64,aarch64", "os": "linux"}},{"type": "rpm", "path": "images/universal/training/th-torch-cpu-py312"}]

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-push.yaml
@@ -40,7 +40,7 @@ spec:
   - name: hermetic
     value: false
   - name: prefetch-input
-    value: '[]'
+    value: ""
     # TODO: restore once rpms.lock.yaml is committed:
     # value: |
     #   [{"type": "pip", "path": "images/universal/training/th-torch-cuda-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64,aarch64", "os": "linux"}},{"type": "rpm", "path": "images/universal/training/th-torch-cuda-py312"}]

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-5-push.yaml
@@ -40,7 +40,7 @@ spec:
   - name: hermetic
     value: false
   - name: prefetch-input
-    value: '[]'
+    value: ""
     # TODO: restore once rpms.lock.yaml is committed:
     # value: |
     #   [{"type": "pip", "path": "images/universal/training/th-torch-rocm-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64", "os": "linux"}},{"type": "rpm", "path": "images/universal/training/th-torch-rocm-py312"}]


### PR DESCRIPTION
Fixes odh-th-torch-cpu/cuda/rocm-py312-v3-5 push PipelineRuns: prefetch-input: '[]' still triggered hermeto with an empty packages list (exit 4). Empty string correctly skips the prefetch task.

Made with [Cursor](https://cursor.com)