### PR TITLE
Fix prefetch-input: pip-only hermetic builds for training images

### DIFF
--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-5-push.yaml
@@ -38,12 +38,12 @@ spec:
   - name: path-context
     value: images/universal/training/th-torch-cpu-py312/
   - name: hermetic
-    value: false
+    value: "true"
   - name: prefetch-input
-    value: ""
-    # TODO: restore once rpms.lock.yaml is committed:
-    # value: |
-    #   [{"type": "pip", "path": "images/universal/training/th-torch-cpu-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64,aarch64", "os": "linux"}},{"type": "rpm", "path": "images/universal/training/th-torch-cpu-py312"}]
+    value: |
+      [{"type": "pip", "path": "images/universal/training/th-torch-cpu-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64,aarch64", "os": "linux"}}]
+  - name: build-args
+    value: ["DOWNSTREAM=true"]
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-push.yaml
@@ -38,12 +38,12 @@ spec:
   - name: path-context
     value: images/universal/training/th-torch-cuda-py312/
   - name: hermetic
-    value: false
+    value: "true"
   - name: prefetch-input
-    value: ""
-    # TODO: restore once rpms.lock.yaml is committed:
-    # value: |
-    #   [{"type": "pip", "path": "images/universal/training/th-torch-cuda-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64,aarch64", "os": "linux"}},{"type": "rpm", "path": "images/universal/training/th-torch-cuda-py312"}]
+    value: |
+      [{"type": "pip", "path": "images/universal/training/th-torch-cuda-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64,aarch64", "os": "linux"}}]
+  - name: build-args
+    value: ["DOWNSTREAM=true"]
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-5-push.yaml
@@ -38,12 +38,12 @@ spec:
   - name: path-context
     value: images/universal/training/th-torch-rocm-py312/
   - name: hermetic
-    value: false
+    value: "true"
   - name: prefetch-input
-    value: ""
-    # TODO: restore once rpms.lock.yaml is committed:
-    # value: |
-    #   [{"type": "pip", "path": "images/universal/training/th-torch-rocm-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64", "os": "linux"}},{"type": "rpm", "path": "images/universal/training/th-torch-rocm-py312"}]
+    value: |
+      [{"type": "pip", "path": "images/universal/training/th-torch-rocm-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64", "os": "linux"}}]
+  - name: build-args
+    value: ["DOWNSTREAM=true"]
   - name: build-platforms
     value:
     - linux/x86_64


### PR DESCRIPTION
## Summary
- Set `hermetic: true` with pip-only prefetch-input for `odh-th-torch-{cpu,cuda,rocm}-py312`
- Removes incorrect rpm prefetch entry — Dockerfiles use `dnf install` directly, not via cachi2
- Dockerfiles use cachi2 for pip only (`. /cachi2/cachi2.env && uv pip install`), so pip prefetch is correct

## Test plan
- [ ] Verify prefetch-dependencies step passes
- [ ] Verify builds complete successfully