### PR TITLE
Increase CUDA arm64 builder to m4xlarge for disk space

### DIFF
--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-push.yaml
@@ -47,7 +47,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux-m2xlarge/arm64
+    - linux-m4xlarge/arm64
   pipelineRef:
     params:
     - name: url

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-push.yaml
@@ -47,7 +47,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux-m4xlarge/arm64
+    - linux-d160-m2xlarge/arm64
   pipelineRef:
     params:
     - name: url


### PR DESCRIPTION
## Problem

The `odh-th-torch-cuda-py312-v3-5` arm64 build fails with `no space left on device` during the `COPY --from=builder` step. The site-packages layer is ~7.5GB (PyTorch + CUDA + xformers + vllm + triton) which exceeds the disk on `m2xlarge` ARM instances.

## Fix

Upgrade the arm64 build platform from `linux-m2xlarge/arm64` to `linux-m4xlarge/arm64` which provides more storage.

## Evidence

- Build: `odh-th-torch-cuda-py312-v3-5-on-push-btrrk` (arm64 TaskRun `build-images-1`)
- Error: `no space left on device` at `COPY --from=builder /opt/app-root/lib/python3.12/site-packages`
- The `m4xlarge` platform is a valid Konflux dynamic config (confirmed in `redhat-appstudio/infra-deployments`)