### PR TITLE
th-torch: increase pipeline timeout to 4h and fix CPU arm64 platform

### DIFF
--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-5-push.yaml
@@ -47,7 +47,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux-m2xlarge/arm64
+    - linux-d160-m2xlarge/arm64
   pipelineRef:
     params:
     - name: url
@@ -63,4 +63,5 @@ spec:
       imagePullSecrets:
       - name: redhat-appstudio-staginguser-pull-secret
   timeouts:
-    pipeline: 2h
+    pipeline: 10h
+    tasks: 8h

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-push.yaml
@@ -63,4 +63,5 @@ spec:
       imagePullSecrets:
       - name: redhat-appstudio-staginguser-pull-secret
   timeouts:
-    pipeline: 2h
+    pipeline: 10h
+    tasks: 8h

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-5-push.yaml
@@ -62,4 +62,5 @@ spec:
       imagePullSecrets:
       - name: redhat-appstudio-staginguser-pull-secret
   timeouts:
-    pipeline: 2h
+    pipeline: 10h
+    tasks: 8h


### PR DESCRIPTION
## Summary

- Increase pipeline timeout from 2h to 4h for all 3 th-torch components (CPU, CUDA, ROCm)
- Fix CPU arm64 build-platform from `linux-m2xlarge/arm64` to `linux-d160-m2xlarge/arm64` (160GB disk)

## Context

All three th-torch components timed out at exactly 2h on commit 35105ce (after the base image fix from PR #745). These are large images (7+ GB) where SBOM generation (syft) needs significant time.

The CPU arm64 platform was missing the `d160` prefix for 160GB disk — same fix already applied to CUDA in PR #3017.

## Changes

| File | Change |
|------|--------|
| `odh-th-torch-cpu-py312-v3-5-push.yaml` | timeout 2h→4h + arm64 platform d160 |
| `odh-th-torch-cuda-py312-v3-5-push.yaml` | timeout 2h→4h |
| `odh-th-torch-rocm-py312-v3-5-push.yaml` | timeout 2h→4h |

## Jira

- RHOAIENG-79950 (CPU)
- RHOAIENG-79951 (CUDA)
- RHOAIENG-79952 (ROCm)