### PR TITLE
fix: add computeResources to th-torch builds to prevent OOM at prepare-sboms

### DIFF
--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-5-push.yaml
@@ -57,6 +57,27 @@ spec:
     - name: pathInRepo
       value: pipelines/multi-arch-container-build.yaml
     resolver: git
+  taskRunSpecs:
+  - pipelineTaskName: build-images
+    stepSpecs:
+    - name: build
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 8Gi
+    - name: sbom-syft-generate
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 8Gi
+    - name: prepare-sboms
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 8Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-th-torch-cpu-py312-v3-5
     podTemplate:

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-push.yaml
@@ -57,6 +57,27 @@ spec:
     - name: pathInRepo
       value: pipelines/multi-arch-container-build.yaml
     resolver: git
+  taskRunSpecs:
+  - pipelineTaskName: build-images
+    stepSpecs:
+    - name: build
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 8Gi
+    - name: sbom-syft-generate
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 8Gi
+    - name: prepare-sboms
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 8Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-th-torch-cuda-py312-v3-5
     podTemplate:

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-5-push.yaml
@@ -56,6 +56,27 @@ spec:
     - name: pathInRepo
       value: pipelines/multi-arch-container-build.yaml
     resolver: git
+  taskRunSpecs:
+  - pipelineTaskName: build-images
+    stepSpecs:
+    - name: build
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 8Gi
+    - name: sbom-syft-generate
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 8Gi
+    - name: prepare-sboms
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 8Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-th-torch-rocm-py312-v3-5
     podTemplate:


### PR DESCRIPTION
## Summary

- Add `taskRunSpecs` with `computeResources` to all 3 th-torch PipelineRun YAMLs
- Bumps memory for `build`, `sbom-syft-generate`, and `prepare-sboms` steps in `build-images` task from 256Mi default to 4Gi/8Gi (request/limit)

## Problem

After PR #745 fixed the base image registry issue, builds now succeed at `build-images` (images pushed to quay) but the pipeline times out because `prepare-sboms` (mobster) gets OOMKilled (exit 137) with the default 256Mi memory limit.

Confirmed via Tekton Results:
- `odh-th-torch-cpu-py312-v3-5-on-push-spjdh`: prepare-sboms exit=137
- `odh-th-torch-cuda-py312-v3-5-on-push-qmw8g`: prepare-sboms exit=137
- All 3 components show same pattern — per-arch images pushed OK, but no multi-arch manifest created because pipeline dies at prepare-sboms before reaching build-image-index

Same issue reported for ROCm 7.14 base images (fixed by bumping memory).

## Pattern

Follows the existing pattern used by notebook components that already have this fix:
- `odh-workbench-jupyter-pytorch-rocm-py312-v3-5`
- `odh-workbench-jupyter-minimal-rocm-py312-v3-5`
- `odh-pipeline-runtime-pytorch-rocm-py312-v3-5`
- etc.

## Files changed

- `pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-5-push.yaml`
- `pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-5-push.yaml`
- `pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-5-push.yaml`

## Jira

- RHOAIENG-79950 (cpu)
- RHOAIENG-79951 (cuda)
- RHOAIENG-79952 (rocm)

## Rollback

Remove the `taskRunSpecs:` block from each file (revert this PR's commit).