### PR TITLE
Enable Renovate for rhaii-cluster-validation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -55,6 +55,7 @@
     - name: "red-hat-data-services/trainer-operator"
     - name: "red-hat-data-services/feast-module-operator"
     - name: "red-hat-data-services/distributed-workloads"
+    - name: "red-hat-data-services/rhaii-cluster-validation"
 
 - renovate-config: "renovate/custom-renovate-distribution.json"
   sync-repositories:


### PR DESCRIPTION
## Summary
- Adds `red-hat-data-services/rhaii-cluster-validation` to the default Renovate distribution in `config.yaml`
- This enables Renovate to manage dependency updates for the rhaii-cluster-validation repo

## Details
| Field | Value |
|-------|-------|
| Component repo | `https://github.com/red-hat-data-services/rhaii-cluster-validation` |
| Renovate entry | `red-hat-data-services/rhaii-cluster-validation` |
| Distribution | `renovate/default-renovate-distribution.json` |