### PR TITLE
update sast-unicode-check-oci-ta to pass conforma violation

### DIFF
--- a/pipelines/container-build.yaml
+++ b/pipelines/container-build.yaml
@@ -398,7 +398,7 @@ spec:
       - name: name
         value: sast-unicode-check-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.2@sha256:5a93fe7f1f3990167d87cb3f30bc13293e02cf5a6da88f46cf0368b3328c2d56
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.2@sha256:f31055c9ebab00f58c2bf3964818d3cf3ab924a4d8b65d8f9c9cb6487b549de2
       - name: kind
         value: task
       resolver: bundles

--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -605,7 +605,7 @@ spec:
       - name: name
         value: sast-unicode-check-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.3@sha256:5e46c39508dfb8031102ec4e11ba98edabb1299615cafe174166f8df49ea3215
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.3@sha256:f31055c9ebab00f58c2bf3964818d3cf3ab924a4d8b65d8f9c9cb6487b549de2
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
Bump sha of sast-unicode-check-oci-ta task to address conforma violation with attached log

`[Violation] trusted_task.trusted
  ImageRef: quay.io/rhoai/odh-must-gather-rhel9@sha256:08f3e0197146939fdc0b96839fceee2873ba85b160451518e9c8eb60efaf5df9
  Reason: Untrusted version of PipelineTask "sast-unicode-check" (Task "sast-unicode-check-oci-ta") was included in build chain
  comprised of: clone-repository, prefetch-dependencies, sast-unicode-check. Please upgrade the task version to:
  sha256:f31055c9ebab00f58c2bf3964818d3cf3ab924a4d8b65d8f9c9cb6487b549de2
  Term: sast-unicode-check-oci-ta
  Title: Tasks are trusted`