### PR TITLE
fix(trustyai-service-py): add prefetch-input and git-auth for hermetic build

### DIFF
--- a/pipelineruns/trustyai-service/.tekton/odh-trustyai-service-py-v3-6-ea-1-push.yaml
+++ b/pipelineruns/trustyai-service/.tekton/odh-trustyai-service-py-v3-6-ea-1-push.yaml
@@ -38,7 +38,8 @@ spec:
     value: .
   - name: hermetic
     value: true
-
+  - name: prefetch-input
+    value: '[{"type": "pip", "path": ".", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64,aarch64,ppc64le,s390x"}}, {"type": "rpm", "path": "."}]'
   - name: build-platforms
     value:
     - linux/x86_64
@@ -61,3 +62,7 @@ spec:
       - name: redhat-appstudio-staginguser-pull-secret
   timeouts:
     pipeline: 2h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'


### PR DESCRIPTION
## Summary
- Add `prefetch-input` with pip + rpm types to fix hermetic build failure (microdnf can't resolve cdn-ubi.redhat.com without RPM prefetch)
- Add `git-auth` workspace

Jira-Link : https://redhat.atlassian.net/browse/RHOAIENG-79857

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED