### PR TITLE
Enable Renovate for odh-observability

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -56,6 +56,7 @@
     - name: "red-hat-data-services/feast-module-operator"
     - name: "red-hat-data-services/distributed-workloads"
     - name: "red-hat-data-services/rhaii-cluster-validation"
+    - name: "red-hat-data-services/odh-observability"
 
 - renovate-config: "renovate/custom-renovate-distribution.json"
   sync-repositories:


### PR DESCRIPTION
Adds 'red-hat-data-services/odh-observability' to the default Renovate distribution in config.yaml.

| Field | Value |
|-------|-------|
| Component repo | `https://github.com/red-hat-data-services/odh-observability` |
| Renovate entry | `red-hat-data-services/odh-observability` |
| Distribution   | `renovate/default-renovate-distribution.json` |

**Jira:** https://redhat.atlassian.net/browse/RHOAIENG-80954