### PR TITLE
chore(rhoai-3.5): update sast-unicode-check-oci-ta 0.2 → 0.3

### DIFF
--- a/pipelines/container-build.yaml
+++ b/pipelines/container-build.yaml
@@ -398,7 +398,7 @@ spec:
       - name: name
         value: sast-unicode-check-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.2@sha256:5a93fe7f1f3990167d87cb3f30bc13293e02cf5a6da88f46cf0368b3328c2d56
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.3@sha256:5e46c39508dfb8031102ec4e11ba98edabb1299615cafe174166f8df49ea3215
       - name: kind
         value: task
       resolver: bundles

--- a/pipelines/container-build.yaml
+++ b/pipelines/container-build.yaml
@@ -383,6 +383,8 @@ spec:
     workspaces: []
   - name: sast-unicode-check
     params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     - name: image-url
       value: $(tasks.build-image-index.results.IMAGE_URL)
     - name: SOURCE_ARTIFACT


### PR DESCRIPTION
## Summary

- Updates `sast-unicode-check-oci-ta` task bundle from 0.2 to 0.3 in `pipelines/container-build.yaml`
- Aligns with `multi-arch-container-build.yaml` which already uses 0.3 (`sha256:5e46c39...`)
- Resolves 6 conforma violations (`trusted_task.trusted` + `tasks.required_untrusted_task_found`) on:
  - odh-operator-bundle-v3-5
  - rhai-on-openshift-chart-v3-5
  - rhai-on-xks-chart-v3-5

## Test plan

- [ ] Merge this PR
- [ ] Rebuild odh-operator-bundle, rhai-on-openshift-chart, rhai-on-xks-chart
- [ ] Verify violations clear in next conforma run