### PR TITLE
chore(rhoai-3.5): update sast-unicode-check-oci-ta 0.2 → 0.3 in helm-chart-build

### DIFF
--- a/pipelines/helm-chart-build.yaml
+++ b/pipelines/helm-chart-build.yaml
@@ -255,6 +255,8 @@ spec:
     workspaces: []
   - name: sast-unicode-check
     params:
+    - name: image-digest
+      value: $(tasks.build-helm-chart.results.IMAGE_DIGEST)
     - name: image-url
       value: $(tasks.build-helm-chart.results.IMAGE_URL)
     - name: SOURCE_ARTIFACT
@@ -268,7 +270,7 @@ spec:
       - name: name
         value: sast-unicode-check-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.2@sha256:5a93fe7f1f3990167d87cb3f30bc13293e02cf5a6da88f46cf0368b3328c2d56
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.3@sha256:5e46c39508dfb8031102ec4e11ba98edabb1299615cafe174166f8df49ea3215
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
## Summary
- Bumps `sast-unicode-check-oci-ta` from 0.2 to 0.3 in `helm-chart-build.yaml`
- Adds required `image-digest` param (`$(tasks.build-helm-chart.results.IMAGE_DIGEST)`) for the 0.3 task
- Matches the same fix already merged in `container-build.yaml` via #3064

Same change pattern as multi-arch-container-build.yaml which already uses 0.3 successfully.

## Test plan
- [ ] CI passes (`container-build-on-pull-request`)
- [ ] Helm chart components rebuild successfully after merge