### PR TITLE
Update konflux-ci/konflux-operator-tasks digest to 08f588a (rhoai-3.6-ea.1)

### DIFF
--- a/pipelines/multi-arch-container-build.yaml
+++ b/pipelines/multi-arch-container-build.yaml
@@ -726,7 +726,7 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/konflux-operator-tasks.git
           - name: revision
-            value: dee7049a3aae9294b121faf76af66506cd76f5a0
+            value: 08f588a00ba17570d60f41adfc350b3c4ce88deb
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
       - name: evaluate-result


### PR DESCRIPTION
## Summary

Updates `konflux-ci/konflux-operator-tasks` from `dee7049` to `08f588a` (22 commits ahead).

This brings the `rhoai-3.6-ea.1` branch up to date with `main` and `rhoai-3.5` branches for FIPS compliance checking.

## Changes

**File:** `pipelines/multi-arch-container-build.yaml`

```diff
- value: dee7049a3aae9294b121faf76af66506cd76f5a0
+ value: 08f588a00ba17570d60f41adfc350b3c4ce88deb
```

## What's Included (22 commits)

Key improvements in this update:
- **FIPS check-payload 0.3.17** (latest security compliance)
- **FBC lifecycle improvements** (CLOUDDST-32867: build-arg params)
- **Conforma task reference fixes** (task validation updates)
- **validate-fbc version bumps** (improved catalog validation)
- **Dependency updates** (grpc-gateway v2.29.0, golang.org/x modules)

## Context

The `rhoai-3.6-ea.1` branch was **22 commits behind** due to not being tracked in the Renovate configuration (`renovate/pipelines-renovate.json5`). This manual update brings it current with:
- `main` branch: ✅ Already on `08f588a`
- `rhoai-3.5` branch: ✅ Updated via PR #3063

## Upstream Reference

Latest commit in konflux-operator-tasks:
- **SHA:** `08f588a00ba17570d60f41adfc350b3c4ce88deb`
- **Date:** 2026-08-05
- **Message:** "Update fips tasks to use check-payload 0.3.17"
- **Repo:** https://github.com/konflux-ci/konflux-operator-tasks

## Testing

- ✅ Pre-commit hooks passed
- ✅ Single file change (1 line)
- ✅ Same pattern as automated PRs #3053 (main) and #3063 (rhoai-3.5)

## Related

- Automated update to main: #3053
- Automated update to rhoai-3.5: #3063

🤖 Generated with [Claude Code](https://claude.com/claude-code)