### PR TITLE
Re-enable fips-check blocking for codeserver-datascience-cpu-py312 (main)

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-pull-request.yaml
@@ -58,8 +58,6 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
-  - name: fips-check-blocking
-    value: "false"
   - name: rhel-subscription-activation-key
     value: "rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6"
   - name: prefetch-input


### PR DESCRIPTION
## Summary

Re-enables FIPS check blocking for `odh-workbench-codeserver-datascience-cpu-py312` by removing the parameter override that was disabling it.

## Changes

**File:** `pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-pull-request.yaml`

```diff
- - name: fips-check-blocking
-   value: "false"
```

## Context

This reverts the temporary workaround added in PR #2994 (merged 2026-07-30).

The FIPS check was disabled to unblock builds while investigating an issue. That issue has been resolved, so we can now re-enable the blocking behavior.

## Behavior After This Change

- FIPS check failures will **block** the pipeline (default behavior)
- Pipeline parameter `fips-check-blocking` is removed (defaults to `"true"`)
- The build will fail if FIPS compliance issues are detected

## Related PRs

- #2994 - Disabled FIPS check for main branch (this reverts it)
- #2995 - Disabled FIPS check for rhoai-3.5 branch
- #2996 - Disabled FIPS check for rhoai-3.6-ea.1 branch

**Note:** Companion PRs for rhoai-3.5 and rhoai-3.6-ea.1 will be created separately.

## Testing

- ✅ Pre-commit hooks passed
- ✅ Single file change (2 lines removed)
- ✅ Reverts to pipeline default behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)