### PR TITLE
Re-enable fips-check blocking for codeserver-datascience-cpu-py312 (rhoai-3.5)

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-5-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-5-push.yaml
@@ -57,8 +57,6 @@ spec:
     - linux/s390x
   - name: disable-slack-notifications
     value: "true"
-  - name: fips-check-blocking
-    value: "false"
   - name: rhel-subscription-activation-key
     value: "rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6"
   - name: prefetch-input


### PR DESCRIPTION
## Summary

Re-enables FIPS check blocking for `odh-workbench-codeserver-datascience-cpu-py312-v3-5` by removing the parameter override.

## Changes

**File:** `pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-5-push.yaml`

```diff
- - name: fips-check-blocking
-   value: "false"
```

## Context

This reverts PR #2995 (merged 2026-07-30).

## Related PRs

- #3070 - Re-enable for main branch
- #2995 - Disabled FIPS check (this reverts it)
- #2996 - Disabled for rhoai-3.6-ea.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)