### PR TITLE
Re-enable fips-check blocking for codeserver-datascience-cpu-py312 (rhoai-3.6-ea.1)

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-6-ea-1-push.yaml
@@ -58,8 +58,6 @@ spec:
     - linux/s390x
   - name: disable-slack-notifications
     value: "true"
-  - name: fips-check-blocking
-    value: "false"
   - name: rhel-subscription-activation-key
     value: "rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6"
   - name: prefetch-input


### PR DESCRIPTION
## Summary

Re-enables FIPS check blocking for `odh-workbench-codeserver-datascience-cpu-py312-v3-6-ea-1` by removing the parameter override.

## Changes

**File:** `pipelineruns/notebooks/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-6-ea-1-push.yaml`

```diff
- - name: fips-check-blocking
-   value: "false"
```

## Context

This reverts PR #2996 (merged 2026-07-30).

## Related PRs

- #3070 - Re-enable for main branch
- #3071 - Re-enable for rhoai-3.5 branch
- #2996 - Disabled FIPS check (this reverts it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)