### PR TITLE
RHOAIENG-82007: Enable Renovate minor updates for expiring Tekton task versions

### DIFF
--- a/renovate/pipelines-renovate.json5
+++ b/renovate/pipelines-renovate.json5
@@ -64,17 +64,57 @@
         "allowedVersions": ">=0.4.0 <0.5.0",
       },
       {
-        // Allow minor version update for buildah-remote-oci-ta to pick up
-        // cross-platform image support (ALLOW_CROSS_PLATFORM_IMAGES param, STONEBLD-4817)
-        "matchPackageNames": ["quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta"],
+        // EC policy expiry 2026-09-05: enable minor updates for tasks below required minimums
+        // See https://github.com/release-engineering/rhtap-ec-policy/blob/main/data/trusted_task_rules.yaml
+        "matchPackageNames": [
+          "quay.io/konflux-ci/tekton-catalog/task-init",
+          "quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta",
+          "quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta",
+          "quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta",
+          "quay.io/konflux-ci/tekton-catalog/task-build-image-index",
+          "quay.io/konflux-ci/tekton-catalog/task-clair-scan",
+          "quay.io/konflux-ci/tekton-catalog/task-clamav-scan",
+          "quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta",
+          "quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta",
+        ],
         "matchUpdateTypes": ["minor"],
-        "matchBaseBranches": ["main", "rhoai-3.5"],
         "enabled": true,
       },
       {
         "matchPackageNames": ["quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta"],
-        "matchBaseBranches": ["main", "rhoai-3.5"],
-        "allowedVersions": "<=0.10",
+        "allowedVersions": ">=0.10.0 <0.11.0",
+      },
+      {
+        "matchPackageNames": ["quay.io/konflux-ci/tekton-catalog/task-init"],
+        "allowedVersions": ">=0.4.0 <0.5.0",
+      },
+      {
+        "matchPackageNames": ["quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta"],
+        "allowedVersions": ">=0.2.0 <0.3.0",
+      },
+      {
+        "matchPackageNames": ["quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta"],
+        "allowedVersions": ">=0.10.0 <0.11.0",
+      },
+      {
+        "matchPackageNames": ["quay.io/konflux-ci/tekton-catalog/task-build-image-index"],
+        "allowedVersions": ">=0.3.0 <0.4.0",
+      },
+      {
+        "matchPackageNames": ["quay.io/konflux-ci/tekton-catalog/task-clair-scan"],
+        "allowedVersions": ">=0.3.0 <0.4.0",
+      },
+      {
+        "matchPackageNames": ["quay.io/konflux-ci/tekton-catalog/task-clamav-scan"],
+        "allowedVersions": ">=0.3.0 <0.4.0",
+      },
+      {
+        "matchPackageNames": ["quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta"],
+        "allowedVersions": ">=0.5.0 <0.6.0",
+      },
+      {
+        "matchPackageNames": ["quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta"],
+        "allowedVersions": ">=0.4.0 <0.5.0",
       },
     ]
   }


### PR DESCRIPTION
## Summary
- EC policy ([trusted_task_rules.yaml](https://github.com/release-engineering/rhtap-ec-policy/blob/main/data/trusted_task_rules.yaml)) enforces minimum task versions starting **2026-09-05**
- Enables Renovate minor updates for 9 tasks currently below required minimums, with `allowedVersions` caps to prevent over-updating
- Consolidates the existing `buildah-remote-oci-ta` minor-enable rule into the new EC policy group and expands it to all branches (previously restricted to main/rhoai-3.5)

### Affected tasks

| Task | Required min | Current versions needing update |
|---|---|---|
| task-init | ≥0.4 | 0.2 (main) |
| task-git-clone-oci-ta | ≥0.2 | 0.1 (all branches) |
| task-buildah-oci-ta | ≥0.10 | 0.4 (main), 0.9 (2.25, 3.3, 3.4, 3.5) |
| task-buildah-remote-oci-ta | ≥0.10 | 0.9 (2.25, 3.3, partially 3.4) |
| task-build-image-index | ≥0.3 | 0.1/0.2 (main), 0.2 (release branches) |
| task-clair-scan | ≥0.3 | 0.2 (all branches, some files also have 0.3.2) |
| task-clamav-scan | ≥0.3 | 0.2 (main) |
| task-sast-snyk-check-oci-ta | ≥0.5 | 0.4 (all branches) |
| task-sast-unicode-check-oci-ta | ≥0.4 | 0.2/0.3 (all branches) |

## Test plan
- [x] Run Renovate dry-run to verify the config parses correctly and produces expected update PRs
- [x] Verify `allowedVersions` caps prevent updates beyond the target minor series
- [ ] Confirm the grouped `matchUpdateTypes` rule enables minor updates for all 9 tasks

Jira: [RHOAIENG-82007](https://redhat.atlassian.net/browse/RHOAIENG-82007)

🤖 Generated with [Claude Code](https://claude.com/claude-code)