### PR TITLE
Enable Renovate for notebooks

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -57,6 +57,7 @@
     - name: "red-hat-data-services/distributed-workloads"
     - name: "red-hat-data-services/rhaii-cluster-validation"
     - name: "red-hat-data-services/odh-observability"
+    - name: "red-hat-data-services/notebooks"
 
 - renovate-config: "renovate/custom-renovate-distribution.json"
   sync-repositories:


### PR DESCRIPTION
Adds 'red-hat-data-services/notebooks' to the default Renovate distribution in config.yaml.

| Field | Value |
|-------|-------|
| Component repo | `https://github.com/red-hat-data-services/notebooks` |
| Renovate entry | `red-hat-data-services/notebooks` |
| Distribution   | `renovate/default-renovate-distribution.json` |

**Jira:** https://redhat.atlassian.net/browse/RHOAIENG-81139