### PR TITLE
Increase fbc-fips-check-oci-ta task timeout to 24h

### DIFF
--- a/pipelines/fbc-fragment-build.yaml
+++ b/pipelines/fbc-fragment-build.yaml
@@ -383,7 +383,7 @@ spec:
       values:
       - "true"
   - name: fbc-fips-check-oci-ta
-    timeout: 6h
+    timeout: 24h
     params:
     - name: image-digest
       value: $(tasks.build-image-index.results.IMAGE_DIGEST)


### PR DESCRIPTION
## Summary
- Increases `fbc-fips-check-oci-ta` per-task timeout from 6h → 24h in `pipelines/fbc-fragment-build.yaml`

## Why
The FBC FIPS check is now processing a large number of related images due to new image additions that require scanning all previous z-streams. The 6h task timeout is insufficient.

## Test plan
- [ ] Verify FBC builds on rhoai-2.25 complete successfully after merge