### PR TITLE
feat: add pull request pipeline for `odh-trustyai-service-py`

### DIFF
--- a/pipelineruns/trustyai-service/.tekton/odh-trustyai-service-py-pull-request.yaml
+++ b/pipelineruns/trustyai-service/.tekton/odh-trustyai-service-py-pull-request.yaml
@@ -4,12 +4,15 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/trustyai-service/?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-event: '[pull_request]'
-    pipelinesascode.tekton.dev/on-comment: '^/build-konflux'
-    pipelinesascode.tekton.dev/on-target-branch: '[{{target_branch}}]'
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-trustyai-service-py]"
+    pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: automation
     appstudio.openshift.io/component: pull-request-pipelines-odh-trustyai-service-py
@@ -24,22 +27,40 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/rhoai/pull-request-pipelines:odh-trustyai-service-py-{{revision}}
-  - name: dockerfile
-    value: Dockerfile.konflux
-  - name: path-context
-    value: .
+  - name: additional-tags
+    value:
+    - 'pr-{{pull_request_number}}-into-{{target_branch}}'
+  - name: additional-labels
+    value:
+    - version=on-pr-{{revision}}
+    - io.openshift.tags=odh-trustyai-service-py
   - name: image-expires-after
     value: 5d
-  - name: enable-slack-failure-notification
-    value: "false"
-
+  - name: dockerfile
+    value: Dockerfile.konflux
+  - name: build-args-file
+    value: .konflux/base-images.conf
   - name: build-platforms
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
     - linux/s390x
+  - name: prefetch-input
+    value: '[{"type": "pip", "path": ".", "requirements_files": ["requirements.txt"], "requirements_build_files": ["requirements-build.txt"], "binary": {"arch": "x86_64,aarch64,ppc64le,s390x"}}]'
+  - name: hermetic
+    value: "true"
+  - name: build-image-index
+    value: true
+  - name: enable-slack-failure-notification
+    value: "false"
+  - name: path-context
+    value: .
+  timeouts:
+    pipeline: 4h
+    tasks: 2h
   pipelineRef:
+    resolver: git
     params:
     - name: url
       value: https://github.com/red-hat-data-services/konflux-central.git
@@ -47,15 +68,10 @@ spec:
       value: '{{ target_branch }}'
     - name: pathInRepo
       value: pipelines/multi-arch-container-build.yaml
-    resolver: git
   taskRunTemplate:
     serviceAccountName: build-pipeline-pull-request-pipelines
-    podTemplate:
-      imagePullSecrets:
-      - name: redhat-appstudio-staginguser-pull-secret
-  timeouts:
-    pipeline: 8h
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Add pull request pipeline for [odh-trustyai-service-py](https://github.com/red-hat-data-services/konflux-central/commit/ec0f201ae6a5e3263b57f34ee9400793173b130b) to account for changes in https://github.com/red-hat-data-services/trustyai-service/pull/46

Deals with: https://redhat.atlassian.net/browse/RHOAIENG-69870