### PR TITLE
chore: modify push pipeline on 3.6EA1

### DIFF
--- a/pipelineruns/trustyai-service/.tekton/odh-trustyai-service-py-v3-6-ea-1-push.yaml
+++ b/pipelineruns/trustyai-service/.tekton/odh-trustyai-service-py-v3-6-ea-1-push.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
@@ -20,6 +19,9 @@ metadata:
   name: odh-trustyai-service-py-v3-6-ea-1-on-push
   namespace: rhoai-tenant
 spec:
+  timeouts:
+    pipeline: 4h
+    tasks: 3h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -37,9 +39,15 @@ spec:
   - name: path-context
     value: .
   - name: hermetic
-    value: true
+    value: "true"
+  - name: build-args-file
+    value: .konflux/base-images.conf
   - name: prefetch-input
-    value: '[{"type": "pip", "path": ".", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64,aarch64,ppc64le,s390x"}}, {"type": "rpm", "path": "."}]'
+    value: '[{"type": "pip", "path": ".", "requirements_files": ["requirements.txt"], "requirements_build_files": ["requirements-build.txt"], "binary": {"arch": "x86_64,aarch64,ppc64le,s390x"}}]'
+  - name: build-source-image
+    value: true
+  - name: build-image-index
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64
@@ -47,6 +55,7 @@ spec:
     - linux/ppc64le
     - linux/s390x
   pipelineRef:
+    resolver: git
     params:
     - name: url
       value: https://github.com/red-hat-data-services/konflux-central.git
@@ -54,15 +63,10 @@ spec:
       value: '{{ target_branch }}'
     - name: pathInRepo
       value: pipelines/multi-arch-container-build.yaml
-    resolver: git
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-trustyai-service-py-v3-6-ea-1
-    podTemplate:
-      imagePullSecrets:
-      - name: redhat-appstudio-staginguser-pull-secret
-  timeouts:
-    pipeline: 2h
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
This PR updates the 3.6EA1 branch push pipeline to account for changes in https://github.com/red-hat-data-services/trustyai-service/pull/46

This PR addresses the following [Jira](https://redhat.atlassian.net/browse/RHOAIENG-82296)