### PR TITLE
Add taskRunSpecs to training pipeline builds to prevent OOM

### DIFF
--- a/pipelineruns/distributed-workloads/.tekton/odh-training-cuda128-torch28-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-training-cuda128-torch28-py312-v3-5-push.yaml
@@ -48,6 +48,23 @@ spec:
   - name: build-platforms
     value:
     - linux-extra-fast/amd64
+  taskRunSpecs:
+    - pipelineTaskName: build-images
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 16Gi
+        limits:
+          cpu: '16'
+          memory: 32Gi
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/distributed-workloads/.tekton/odh-training-cuda128-torch29-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-training-cuda128-torch29-py312-v3-5-push.yaml
@@ -48,6 +48,23 @@ spec:
   - name: build-platforms
     value:
     - linux-extra-fast/amd64
+  taskRunSpecs:
+    - pipelineTaskName: build-images
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 16Gi
+        limits:
+          cpu: '16'
+          memory: 32Gi
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/distributed-workloads/.tekton/odh-training-rocm64-torch28-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-training-rocm64-torch28-py312-v3-5-push.yaml
@@ -48,6 +48,23 @@ spec:
   - name: build-platforms
     value:
     - linux-extra-fast/amd64
+  taskRunSpecs:
+    - pipelineTaskName: build-images
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 16Gi
+        limits:
+          cpu: '16'
+          memory: 32Gi
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/distributed-workloads/.tekton/odh-training-rocm64-torch29-py312-v3-5-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-training-rocm64-torch29-py312-v3-5-push.yaml
@@ -48,6 +48,23 @@ spec:
   - name: build-platforms
     value:
     - linux-extra-fast/amd64
+  taskRunSpecs:
+    - pipelineTaskName: build-images
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 16Gi
+        limits:
+          cpu: '16'
+          memory: 32Gi
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Summary
- The four `odh-training-*` pipeline files in `pipelineruns/distributed-workloads/.tekton/` were missing `taskRunSpecs` with compute resource requests/limits
- Without these, builds get default (small) memory limits and OOM-kill silently during GPU kernel compilation (e.g. `flash-attn`, `bitsandbytes` for ROCm/CUDA)
- Adds `taskRunSpecs` matching the upstream configuration in [distributed-workloads/.tekton](https://github.com/red-hat-data-services/distributed-workloads/blob/rhoai-3.5/.tekton/odh-training-rocm64-torch29-py312-push.yaml): 16Gi/32Gi for `build-images`, 32Gi/32Gi for `clair-scan`

### Files changed
- `odh-training-cuda128-torch28-py312-v3-5-push.yaml`
- `odh-training-cuda128-torch29-py312-v3-5-push.yaml`
- `odh-training-rocm64-torch28-py312-v3-5-push.yaml`
- `odh-training-rocm64-torch29-py312-v3-5-push.yaml`

## Test plan
- [ ] Retrigger the `odh-training-rocm64-torch29-py312` build and confirm `flash-attn` compilation completes successfully
- [ ] Verify all four training image builds pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)