### PR TITLE
Enable Renovate for data-connect-hub

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -59,6 +59,7 @@
     - name: "red-hat-data-services/odh-observability"
     - name: "red-hat-data-services/rhoai-mcp"
     - name: "red-hat-data-services/notebooks"
+    - name: "red-hat-data-services/data-connect-hub"
 
 - renovate-config: "renovate/custom-renovate-distribution.json"
   sync-repositories:


### PR DESCRIPTION
Adds 'red-hat-data-services/data-connect-hub' to the default Renovate distribution in config.yaml.

| Field | Value |
|-------|-------|
| Component repo | `https://github.com/red-hat-data-services/data-connect-hub` |
| Renovate entry | `red-hat-data-services/data-connect-hub` |
| Distribution   | `renovate/default-renovate-distribution.json` |

**Jira:** https://redhat.atlassian.net/browse/RHOAIENG-82405