### PR TITLE
RHOAIENG-81140: jupyter-baseline non-hermetic + correct build-args (3.6-ea.1)

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-baseline-cpu-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-baseline-cpu-py312-v3-6-ea-1-push.yaml
@@ -36,10 +36,14 @@ spec:
     value: jupyter/baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
   - name: path-context
     value: .
+  # Phase 1: non-hermetic online RPM + PyPI (no prefetch yet). Proven on
+  # notebooks PR trials for RHOAIENG-81140.
   - name: hermetic
-    value: true
+    value: false
   - name: build-args-file
-    value: codeserver-baseline/ubi9-python-3.12/build-args/konflux.cpu.conf
+    value: jupyter/baseline/ubi9-python-3.12/build-args/konflux.cpu.conf
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   - name: build-platforms
     value:
     - linux/x86_64


### PR DESCRIPTION
## Summary
Follow-up to https://github.com/red-hat-data-services/konflux-central/pull/3155 — same intent, correct values.

- `build-args-file`: `jupyter/baseline/.../konflux.cpu.conf` (was incorrectly `codeserver-baseline/...`)
- `hermetic: false` (phase-1 Dockerfile has no prefetch; matches ODH main)

Validated on notebooks Konflux PR trials ([#2754](https://github.com/red-hat-data-services/notebooks/pull/2754)): build got past the prior `subscription-manager release --set` / unregistered failure.

Companion main PR: (opened next) for the on-PR PipelineRun.

## Test plan
- [ ] Merge → sync to notebooks `rhoai-3.6-ea.1`
- [ ] Confirm push PipelineRun for `odh-workbench-jupyter-baseline-cpu-py312-v3-6-ea-1` uses corrected params
- [ ] Watch next on-push build past RHSM / build-images


Made with [Cursor](https://cursor.com)