### PR TITLE
RHOAIENG-81140: jupyter-baseline PR PipelineRun correct build-args + non-hermetic

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-baseline-cpu-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-baseline-cpu-py312-pull-request.yaml
@@ -28,8 +28,11 @@ spec:
     value: jupyter/baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
   - name: path-context
     value: .
+  # Phase 1: non-hermetic online RPM + PyPI (no prefetch yet).
+  - name: hermetic
+    value: false
   - name: build-args-file
-    value: codeserver-baseline/ubi9-python-3.12/build-args/konflux.cpu.conf
+    value: jupyter/baseline/ubi9-python-3.12/build-args/konflux.cpu.conf
   - name: image-expires-after
     value: 5d
   - name: enable-slack-failure-notification
@@ -40,6 +43,8 @@ spec:
     - linux-m2xlarge/arm64
     - linux/ppc64le
     - linux/s390x
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     params:
     - name: url


### PR DESCRIPTION
## Summary
Follow-up to https://github.com/red-hat-data-services/konflux-central/pull/3154 — same intent, correct values.

- `build-args-file`: `jupyter/baseline/.../konflux.cpu.conf` (was incorrectly `codeserver-baseline/...`)
- `hermetic: false` for phase-1 non-hermetic builds
- Add `rhel-subscription-activation-key` for subscribed online dnf (needed once non-hermetic)

Companion `rhoai-3.6-ea.1` push PipelineRun fix opened in parallel.

## Test plan
- [ ] Merge → sync on-PR PipelineRun to notebooks
- [ ] `/build-konflux` on a notebooks PR touching jupyter-baseline uses corrected params


Made with [Cursor](https://cursor.com)