### PR TITLE
Update rhoai-mcp to use new requirements file (rhoai-3.6-ea.1)

### DIFF
--- a/pipelineruns/rhoai-mcp/.tekton/odh-rhoai-mcp-v3-6-ea-1-push.yaml
+++ b/pipelineruns/rhoai-mcp/.tekton/odh-rhoai-mcp-v3-6-ea-1-push.yaml
@@ -44,7 +44,7 @@ spec:
       [{
         "type": "pip",
         "path": ".",
-        "requirements_files": ["requirements-check.txt"],
+        "requirements_files": ["requirements-cpu.txt"],
         "binary": {"arch": "x86_64,aarch64", "os": "linux"}
       }]
   - name: build-platforms


### PR DESCRIPTION
https://github.com/red-hat-data-services/rhoai-mcp/pull/6