### PR TITLE
Re-enable hermetic build in the v3-4-push pipeline for fms-guardrails-orchestrator

### DIFF
--- a/pipelineruns/fms-guardrails-orchestrator/.tekton/odh-fms-guardrails-orchestrator-v3-4-push.yaml
+++ b/pipelineruns/fms-guardrails-orchestrator/.tekton/odh-fms-guardrails-orchestrator-v3-4-push.yaml
@@ -36,7 +36,9 @@ spec:
   - name: path-context
     value: .
   - name: hermetic
-    value: false
+    value: "true"
+  - name: prefetch-input
+    value: '[{"type":"cargo","path":"."},{"type":"rpm","path":"."}]'
   - name: build-source-image
     value: true
   - name: build-image-index


### PR DESCRIPTION
This is to re-enable hermetic build for fms-guardrails-orchestrator. Originally it was enabled in 3.4.2 (https://github.com/red-hat-data-services/fms-guardrails-orchestrator/pull/257 and https://github.com/red-hat-data-services/fms-guardrails-orchestrator/pull/258) as part or cherry-picking a build fix but since it was done in the repo directly, it got overwritten during the recent 3.4.4 onboarding - see https://github.com/red-hat-data-services/fms-guardrails-orchestrator/commit/b6cdb71a7146f6fdb301508d8762cf897289b0d5. It should have been done here initially, my mistake.