### PR TITLE
fix: pre-fetch required npm module for odh-mod-arch-notebooks hermetic

### DIFF
--- a/pipelineruns/odh-dashboard/.tekton/odh-mod-arch-notebooks-pull-request.yaml
+++ b/pipelineruns/odh-dashboard/.tekton/odh-mod-arch-notebooks-pull-request.yaml
@@ -33,8 +33,9 @@ spec:
   - name: enable-slack-failure-notification
     value: "false"
   - name: prefetch-input
-    value: |
-      [{"type": "npm", "path": "."}]
+    value: '[{"type": "npm", "path": "."}, {"type": "npm", "path": "packages/notebooks/upstream/workspaces/frontend"}, {"type": "gomod", "path": "packages/notebooks/upstream/workspaces/backend"}, {"type": "gomod", "path": "packages/notebooks/upstream/workspaces/controller"}]'
+  - name: build-image-index
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64


### PR DESCRIPTION
Follow-up: https://github.com/red-hat-data-services/konflux-central/pull/3186
JIRA: https://redhat.atlassian.net/browse/RHOAIENG-58837


Notebooks frontend has its own package-lock.json under packages/notebooks/upstream/workspaces/frontend/. The second npm ci tries to resolve that lockfile offline, fails, and npm surfaces the unhelpful Exit handler never called! error.

The log also shows Set up 0 prefetch env var(s) as buildah secret env mounts — consistent with Cachi2 not wiring npm offline config for the module path. In that mode npm cannot reach the registry. Cachi2 must prefetch every lockfile path ahead of time.