### PR TITLE
Add odh-th-torch-{cpu,cuda,rocm}-py312 v3.6-ea.1 push PipelineRuns and workbench nudging

### DIFF
--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-6-ea-1-push.yaml
@@ -12,12 +12,12 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.6-ea.1"
-      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-th-torch-rocm-py312-v3-6-ea-1-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-th-torch-cpu-py312-v3-6-ea-1-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-6-ea-1
-    appstudio.openshift.io/component: odh-th-torch-rocm-py312-v3-6-ea-1
+    appstudio.openshift.io/component: odh-th-torch-cpu-py312-v3-6-ea-1
     pipelines.appstudio.openshift.io/type: build
-  name: odh-th-torch-rocm-py312-v3-6-ea-1-on-push
+  name: odh-th-torch-cpu-py312-v3-6-ea-1-on-push
   namespace: rhoai-tenant
 spec:
   params:
@@ -29,23 +29,24 @@ spec:
     value:
     - '{{target_branch}}-{{revision}}'
   - name: output-image
-    value: quay.io/rhoai/odh-th-torch-rocm-py312-rhel9:{{target_branch}}
+    value: quay.io/rhoai/odh-th-torch-cpu-py312-rhel9:{{target_branch}}
   - name: rhoai-version
     value: "3.6.0-ea.1"
   - name: dockerfile
     value: Dockerfile.konflux
   - name: path-context
-    value: images/universal/training/th-torch-rocm-py312/
+    value: images/universal/training/th-torch-cpu-py312/
   - name: hermetic
     value: "true"
   - name: prefetch-input
     value: |
-      [{"type": "pip", "path": "images/universal/training/th-torch-rocm-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64", "os": "linux"}}]
+      [{"type": "pip", "path": "images/universal/training/th-torch-cpu-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64,aarch64", "os": "linux"}}]
   - name: build-args
     value: ["DOWNSTREAM=true"]
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux-d160-m2xlarge/arm64
   pipelineRef:
     params:
     - name: url
@@ -77,7 +78,7 @@ spec:
         limits:
           memory: 8Gi
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-th-torch-rocm-py312-v3-6-ea-1
+    serviceAccountName: build-pipeline-odh-th-torch-cpu-py312-v3-6-ea-1
     podTemplate:
       imagePullSecrets:
       - name: redhat-appstudio-staginguser-pull-secret

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-6-ea-1-push.yaml
@@ -12,12 +12,12 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.6-ea.1"
-      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-th-torch-rocm-py312-v3-6-ea-1-push.yaml".pathChanged() )
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-th-torch-cuda-py312-v3-6-ea-1-push.yaml".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-6-ea-1
-    appstudio.openshift.io/component: odh-th-torch-rocm-py312-v3-6-ea-1
+    appstudio.openshift.io/component: odh-th-torch-cuda-py312-v3-6-ea-1
     pipelines.appstudio.openshift.io/type: build
-  name: odh-th-torch-rocm-py312-v3-6-ea-1-on-push
+  name: odh-th-torch-cuda-py312-v3-6-ea-1-on-push
   namespace: rhoai-tenant
 spec:
   params:
@@ -29,23 +29,24 @@ spec:
     value:
     - '{{target_branch}}-{{revision}}'
   - name: output-image
-    value: quay.io/rhoai/odh-th-torch-rocm-py312-rhel9:{{target_branch}}
+    value: quay.io/rhoai/odh-th-torch-cuda-py312-rhel9:{{target_branch}}
   - name: rhoai-version
     value: "3.6.0-ea.1"
   - name: dockerfile
     value: Dockerfile.konflux
   - name: path-context
-    value: images/universal/training/th-torch-rocm-py312/
+    value: images/universal/training/th-torch-cuda-py312/
   - name: hermetic
     value: "true"
   - name: prefetch-input
     value: |
-      [{"type": "pip", "path": "images/universal/training/th-torch-rocm-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64", "os": "linux"}}]
+      [{"type": "pip", "path": "images/universal/training/th-torch-cuda-py312", "requirements_files": ["requirements.txt"], "binary": {"arch": "x86_64,aarch64", "os": "linux"}}]
   - name: build-args
     value: ["DOWNSTREAM=true"]
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux-d160-m2xlarge/arm64
   pipelineRef:
     params:
     - name: url
@@ -77,7 +78,7 @@ spec:
         limits:
           memory: 8Gi
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-th-torch-rocm-py312-v3-6-ea-1
+    serviceAccountName: build-pipeline-odh-th-torch-cuda-py312-v3-6-ea-1
     podTemplate:
       imagePullSecrets:
       - name: redhat-appstudio-staginguser-pull-secret

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-6-ea-1-push.yaml
@@ -1,0 +1,62 @@
+
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/distributed-workloads?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push"
+      && target_branch == "rhoai-3.6-ea.1"
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-th-torch-rocm-py312-v3-6-ea-1-push.yaml".pathChanged() )
+  labels:
+    appstudio.openshift.io/application: rhoai-v3-6-ea-1
+    appstudio.openshift.io/component: odh-th-torch-rocm-py312-v3-6-ea-1
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-th-torch-rocm-py312-v3-6-ea-1-on-push
+  namespace: rhoai-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: additional-tags
+    value:
+    - '{{target_branch}}-{{revision}}'
+  - name: output-image
+    value: quay.io/rhoai/odh-th-torch-rocm-py312-rhel9:{{target_branch}}
+  - name: rhoai-version
+    value: "3.6.0-ea.1"
+  - name: dockerfile
+    value: Dockerfile.konflux
+  - name: path-context
+    value: images/universal/training/th-torch-rocm-py312/
+  - name: hermetic
+    value: true
+  - name: prefetch-input
+    value: |
+      [{"type": "gomod", "path": "images/universal/training/th-torch-rocm-py312/"}]
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  pipelineRef:
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ target_branch }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+    resolver: git
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-th-torch-rocm-py312-v3-6-ea-1
+    podTemplate:
+      imagePullSecrets:
+      - name: redhat-appstudio-staginguser-pull-secret
+  timeouts:
+    pipeline: 2h

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cpu-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cpu-py312-v3-6-ea-1-push.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
+    build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml, images/universal/training/th-torch-cpu-py312/Dockerfile.konflux"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.6-ea.1"

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cuda-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cuda-py312-v3-6-ea-1-push.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
+    build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml, images/universal/training/th-torch-cuda-py312/Dockerfile.konflux"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.6-ea.1"

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v3-6-ea-1-push.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
+    build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml, images/universal/training/th-torch-rocm-py312/Dockerfile.konflux"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.6-ea.1"


### PR DESCRIPTION
Adds push PipelineRun YAML for Training Hub torch images (cpu/cuda/rocm py312) targeting `rhoai-3.6-ea.1`, and restores jupyter-minimal `build-nudge-files` so workbench rebuilds nudge the matching torch Dockerfiles (3.5 GA parity).

Torch PipelineRuns are adapted from the 3.5 GA templates (`pip` prefetch, `DOWNSTREAM=true`, resource requests).

Jira:
- https://redhat.atlassian.net/browse/RHOAIENG-83765 (odh-th-torch-cpu-py312)
- https://redhat.atlassian.net/browse/RHOAIENG-83767 (odh-th-torch-cuda-py312)
- https://redhat.atlassian.net/browse/RHOAIENG-83768 (odh-th-torch-rocm-py312)
