### PR TITLE
Add JSON/YAML output to generate-table.py and CI workflow

### DIFF
--- a/.github/workflows/generate-arch-report.yml
+++ b/.github/workflows/generate-arch-report.yml
@@ -1,0 +1,65 @@
+name: Generate Architecture Report
+
+on:
+  push:
+    branches:
+      - 'rhoai-*'
+    paths:
+      - 'pipelineruns/**'
+      - 'pipelines/**'
+      - 'script/multi-arch-tracking/exceptions.toml'
+
+  workflow_dispatch:
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check for architecture-related changes
+        id: check
+        if: github.event_name == 'push'
+        run: |
+          diff=$(git diff HEAD~1 --unified=0 -- 'pipelineruns/**' 'pipelines/**' 'script/multi-arch-tracking/exceptions.toml' || true)
+          if echo "$diff" | grep -qiE 'build-platforms|amd64|arm64|x86_64|ppc64le|s390x|multi-arch|architecture'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "No architecture-related changes detected, skipping report generation."
+          fi
+
+      - name: Set up Python
+        if: steps.check.outcome == 'skipped' || steps.check.outputs.relevant == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        if: steps.check.outcome == 'skipped' || steps.check.outputs.relevant == 'true'
+        run: pip install pyyaml toml
+
+      - name: Generate report
+        if: steps.check.outcome == 'skipped' || steps.check.outputs.relevant == 'true'
+        run: |
+          branch="${GITHUB_REF_NAME}"
+          python3 script/multi-arch-tracking/generate-table.py \
+            --format yaml \
+            --branch "$branch" \
+            --output script/multi-arch-tracking/report.yaml
+
+      - name: Commit report
+        if: steps.check.outcome == 'skipped' || steps.check.outputs.relevant == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add script/multi-arch-tracking/report.yaml
+          if git diff --cached --quiet; then
+            echo "No changes to report.yaml"
+          else
+            git commit -m "chore: regenerate architecture report [skip ci]"
+            git push
+          fi

--- a/script/multi-arch-tracking/README.md
+++ b/script/multi-arch-tracking/README.md
@@ -93,7 +93,7 @@ issue = "https://issues.redhat.com/browse/RHOAIENG-12345"
 
 ```
 --base-dir PATH       Base directory of the repository (default: auto-detected from script location)
---format FORMAT       Output format: markdown, csv, text, or jira (default: markdown)
+--format FORMAT       Output format: markdown, csv, text, jira, json, or yaml (default: markdown)
 --output PATH         Write output to file instead of stdout
 --config PATH         Path to TOML config file (default: exceptions.toml in script directory)
 --branch BRANCH       Git branch to read files from (e.g., rhoai-3.2) instead of filesystem
@@ -117,6 +117,18 @@ issue = "https://issues.redhat.com/browse/RHOAIENG-12345"
 
 ```bash
 ./script/multi-arch-tracking/generate-table.py --format jira
+```
+
+### Generate JSON for machine-readable output
+
+```bash
+./script/multi-arch-tracking/generate-table.py --format json --branch rhoai-3.5
+```
+
+### Generate YAML for human-readable structured output
+
+```bash
+./script/multi-arch-tracking/generate-table.py --format yaml --branch rhoai-3.5
 ```
 
 ### Generate table from a specific git branch
@@ -169,6 +181,76 @@ odh-workbench-pytorch-rocm-py312-rhel9,Y,N/A,N/A,N/A
 ```
 
 In CSV format, issue keys are plain text for easy import into spreadsheets.
+
+### JSON Format
+
+```json
+{
+  "generatedAt": "2026-08-18T12:00:00+00:00",
+  "branch": "rhoai-3.5",
+  "architectures": ["amd64", "arm64", "ppc64le", "s390x"],
+  "components": [
+    {
+      "name": "odh-dashboard-rhel9",
+      "architectures": {
+        "amd64": {"status": "supported"},
+        "arm64": {"status": "supported"},
+        "ppc64le": {"status": "supported"},
+        "s390x": {"status": "supported"}
+      }
+    },
+    {
+      "name": "odh-some-exception-rhel9",
+      "architectures": {
+        "amd64": {"status": "supported"},
+        "arm64": {"status": "supported"},
+        "ppc64le": {"status": "exception", "issueKey": "RHOAIENG-123", "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-123"},
+        "s390x": {"status": "exception", "issueKey": "XXX"}
+      }
+    }
+  ],
+  "summary": {
+    "totalComponents": 85,
+    "fullMultiArch": 60,
+    "withExceptions": 10,
+    "withIncompatible": 12,
+    "withNotBuilt": 3
+  }
+}
+```
+
+Status values: `supported`, `exception` (with `issueKey`/`issueUrl`), `incompatible` (with `accelerator`), `not_built`. The `branch` field is present only when `--branch` is used.
+
+### YAML Format
+
+Same structure as JSON, output as YAML for human readability:
+
+```yaml
+generatedAt: '2026-08-18T12:00:00+00:00'
+branch: rhoai-3.5
+architectures:
+- amd64
+- arm64
+- ppc64le
+- s390x
+components:
+- name: odh-dashboard-rhel9
+  architectures:
+    amd64:
+      status: supported
+    arm64:
+      status: supported
+    ppc64le:
+      status: supported
+    s390x:
+      status: supported
+summary:
+  totalComponents: 85
+  fullMultiArch: 60
+  withExceptions: 10
+  withIncompatible: 12
+  withNotBuilt: 3
+```
 
 ## Understanding the Output
 

--- a/script/multi-arch-tracking/generate-table.py
+++ b/script/multi-arch-tracking/generate-table.py
@@ -8,6 +8,8 @@ and generates a table showing which architectures each component supports.
 
 import sys
 import subprocess
+import json
+import datetime
 from pathlib import Path
 from typing import Dict, List, Set, Optional
 import yaml
@@ -356,6 +358,42 @@ def is_accelerator_incompatible(component_name: str, arch: str, config: dict) ->
     return False
 
 
+def get_structured_cell_value(component_name: str, arch: str, built_archs: Set[str], config: dict) -> dict:
+    """
+    Determine the structured classification for a component/architecture combination.
+
+    Args:
+        component_name: Name of the component
+        arch: Architecture to check
+        built_archs: Set of architectures the component is actually built for
+        config: Configuration dict with exceptions and accelerator rules
+
+    Returns:
+        Dict with 'status' key and optional detail keys
+    """
+    if arch in built_archs:
+        return {'status': 'supported'}
+
+    exception = get_exception_for_arch(component_name, arch, config)
+    if exception:
+        issue_url = exception.get('issue', '')
+        issue_key = extract_issue_key(issue_url)
+        result = {'status': 'exception', 'issueKey': issue_key}
+        if issue_url:
+            result['issueUrl'] = issue_url
+        reason = exception.get('reason', '')
+        if reason:
+            result['reason'] = reason
+        return result
+
+    accelerator_rules = config.get('accelerator_incompatibility_rules', {})
+    detected = detect_accelerator(component_name, accelerator_rules)
+    if detected and is_accelerator_incompatible(component_name, arch, config):
+        return {'status': 'incompatible', 'accelerator': detected}
+
+    return {'status': 'not_built'}
+
+
 def get_cell_value(component_name: str, arch: str, built_archs: Set[str], config: dict, output_format: str) -> str:
     """
     Determine the cell value for a component/architecture combination.
@@ -370,43 +408,37 @@ def get_cell_value(component_name: str, arch: str, built_archs: Set[str], config
     Returns:
         Cell value as string
     """
-    # If component is built for this arch, return Y
-    if arch in built_archs:
+    cell = get_structured_cell_value(component_name, arch, built_archs, config)
+
+    if cell['status'] == 'supported':
         return 'Y'
 
-    # Check for specific exception first
-    exception = get_exception_for_arch(component_name, arch, config)
-    if exception:
-        # Get issue key from exception
-        issue_url = exception.get('issue', '')
-        issue_key = extract_issue_key(issue_url)
-
-        # Format based on output type
+    if cell['status'] == 'exception':
+        issue_key = cell.get('issueKey', 'XXX')
+        issue_url = cell.get('issueUrl', '')
         if output_format == 'markdown' and issue_url and issue_key != 'XXX':
             return f'[{issue_key}]({issue_url})'
         elif output_format == 'jira' and issue_url and issue_key != 'XXX':
             return f'[{issue_key}|{issue_url}]'
         elif output_format == 'csv' and issue_url and issue_key != 'XXX':
             return f'=HYPERLINK("{issue_url}","{issue_key}")'
-        else:
-            return issue_key
+        return issue_key
 
-    # Check for accelerator incompatibility
-    if is_accelerator_incompatible(component_name, arch, config):
+    if cell['status'] == 'incompatible':
         return 'N/A'
 
-    # Not built and no exception
     return ''
 
 
-def generate_table(components: Dict[str, Set[str]], config: dict, output_format: str = 'markdown') -> str:
+def generate_table(components: Dict[str, Set[str]], config: dict, output_format: str = 'markdown', metadata: Optional[dict] = None) -> str:
     """
     Generate architecture support table.
 
     Args:
         components: Dict mapping component names to sets of supported architectures
         config: Configuration dict with exceptions and accelerator rules
-        output_format: 'markdown', 'csv', 'text', or 'jira'
+        output_format: 'markdown', 'csv', 'text', 'jira', 'json', or 'yaml'
+        metadata: Optional dict with extra fields (e.g. {'branch': 'rhoai-3.5'})
 
     Returns:
         Formatted table as string
@@ -417,7 +449,54 @@ def generate_table(components: Dict[str, Set[str]], config: dict, output_format:
     # Sort components alphabetically
     sorted_components = sorted(components.items())
 
-    if output_format == 'csv':
+    if output_format in ('json', 'yaml'):
+        comp_list = []
+        summary = {'totalComponents': 0, 'fullMultiArch': 0, 'withExceptions': 0,
+                    'withIncompatible': 0, 'withNotBuilt': 0}
+
+        for name, archs in sorted_components:
+            summary['totalComponents'] += 1
+            arch_map = {}
+            has_exception = False
+            has_incompatible = False
+            has_not_built = False
+            all_supported = True
+            for arch in arch_columns:
+                cell = get_structured_cell_value(name, arch, archs, config)
+                arch_map[arch] = cell
+                if cell['status'] != 'supported':
+                    all_supported = False
+                if cell['status'] == 'exception':
+                    has_exception = True
+                elif cell['status'] == 'incompatible':
+                    has_incompatible = True
+                elif cell['status'] == 'not_built':
+                    has_not_built = True
+            comp_list.append({'name': name, 'architectures': arch_map})
+            if all_supported:
+                summary['fullMultiArch'] += 1
+            if has_exception:
+                summary['withExceptions'] += 1
+            if has_incompatible:
+                summary['withIncompatible'] += 1
+            if has_not_built:
+                summary['withNotBuilt'] += 1
+
+        result = {
+            'generatedAt': datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            'architectures': arch_columns,
+            'components': comp_list,
+            'summary': summary,
+        }
+        if metadata and metadata.get('branch'):
+            result['branch'] = metadata['branch']
+
+        if output_format == 'json':
+            return json.dumps(result, indent=2)
+        else:
+            return yaml.dump(result, default_flow_style=False, sort_keys=False)
+
+    elif output_format == 'csv':
         lines = ['Component Image,amd64,arm64,ppc64le,s390x']
         for name, archs in sorted_components:
             row = [name]
@@ -564,7 +643,7 @@ def main():
     )
     parser.add_argument(
         '--format',
-        choices=['markdown', 'csv', 'text', 'jira'],
+        choices=['markdown', 'csv', 'text', 'jira', 'json', 'yaml'],
         default='markdown',
         help='Output format (default: markdown)'
     )
@@ -655,7 +734,8 @@ def main():
     print(f"Parsed {len(components)} components", file=sys.stderr)
 
     # Generate table
-    table = generate_table(components, config, args.format)
+    metadata = {'branch': args.branch} if args.branch else None
+    table = generate_table(components, config, args.format, metadata=metadata)
 
     # Output
     if args.output:

--- a/script/multi-arch-tracking/test_generate_table.py
+++ b/script/multi-arch-tracking/test_generate_table.py
@@ -1,0 +1,206 @@
+"""Tests for generate-table.py JSON/YAML output and structured cell values."""
+
+import importlib.util
+import json
+from pathlib import Path
+import yaml
+import pytest
+
+# The script file has a hyphen in its name; load via importlib.util
+_script_path = Path(__file__).parent / 'generate-table.py'
+_spec = importlib.util.spec_from_file_location('generate_table', _script_path)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+get_structured_cell_value = _mod.get_structured_cell_value
+get_cell_value = _mod.get_cell_value
+generate_table = _mod.generate_table
+normalize_architecture = _mod.normalize_architecture
+extract_component_name = _mod.extract_component_name
+
+
+SAMPLE_CONFIG = {
+    'accelerator_incompatibility_rules': {
+        'rocm': ['arm64', 'ppc64le', 's390x'],
+        'cuda': ['ppc64le', 's390x'],
+        'gaudi': ['arm64', 'ppc64le', 's390x'],
+        'cpu': [],
+    },
+    'exception': [
+        {
+            'component': 'odh-mlmd-grpc-server-rhel9',
+            'architectures': ['s390x'],
+            'reason': 'Not yet implemented',
+            'issue': 'https://issues.redhat.com/browse/RHOAIENG-38728',
+        },
+        {
+            'component': 'odh-no-issue-rhel9',
+            'architectures': ['ppc64le'],
+            'reason': 'Missing vendor lib',
+        },
+    ],
+}
+
+
+# --- get_structured_cell_value tests ---
+
+class TestGetStructuredCellValue:
+    def test_supported(self):
+        result = get_structured_cell_value('comp', 'amd64', {'amd64', 'arm64'}, SAMPLE_CONFIG)
+        assert result == {'status': 'supported'}
+
+    def test_exception_with_issue(self):
+        result = get_structured_cell_value('odh-mlmd-grpc-server-rhel9', 's390x', {'amd64'}, SAMPLE_CONFIG)
+        assert result['status'] == 'exception'
+        assert result['issueKey'] == 'RHOAIENG-38728'
+        assert result['issueUrl'] == 'https://issues.redhat.com/browse/RHOAIENG-38728'
+        assert result['reason'] == 'Not yet implemented'
+
+    def test_exception_without_issue(self):
+        result = get_structured_cell_value('odh-no-issue-rhel9', 'ppc64le', {'amd64'}, SAMPLE_CONFIG)
+        assert result['status'] == 'exception'
+        assert result['issueKey'] == 'XXX'
+        assert 'issueUrl' not in result
+
+    def test_incompatible(self):
+        result = get_structured_cell_value('odh-workbench-cuda-rhel9', 's390x', {'amd64'}, SAMPLE_CONFIG)
+        assert result == {'status': 'incompatible', 'accelerator': 'cuda'}
+
+    def test_not_built(self):
+        result = get_structured_cell_value('odh-dashboard-rhel9', 's390x', {'amd64'}, SAMPLE_CONFIG)
+        assert result == {'status': 'not_built'}
+
+    def test_supported_takes_priority_over_exception(self):
+        result = get_structured_cell_value('odh-mlmd-grpc-server-rhel9', 's390x', {'amd64', 's390x'}, SAMPLE_CONFIG)
+        assert result['status'] == 'supported'
+
+
+# --- get_cell_value backward compatibility ---
+
+class TestGetCellValueBackwardCompat:
+    def test_supported_returns_y(self):
+        assert get_cell_value('comp', 'amd64', {'amd64'}, SAMPLE_CONFIG, 'markdown') == 'Y'
+
+    def test_incompatible_returns_na(self):
+        assert get_cell_value('odh-cuda-rhel9', 's390x', {'amd64'}, SAMPLE_CONFIG, 'text') == 'N/A'
+
+    def test_not_built_returns_empty(self):
+        assert get_cell_value('odh-dashboard-rhel9', 's390x', {'amd64'}, SAMPLE_CONFIG, 'text') == ''
+
+    def test_exception_markdown_link(self):
+        result = get_cell_value('odh-mlmd-grpc-server-rhel9', 's390x', {'amd64'}, SAMPLE_CONFIG, 'markdown')
+        assert '[RHOAIENG-38728](' in result
+
+    def test_exception_jira_link(self):
+        result = get_cell_value('odh-mlmd-grpc-server-rhel9', 's390x', {'amd64'}, SAMPLE_CONFIG, 'jira')
+        assert '[RHOAIENG-38728|' in result
+
+    def test_exception_csv_hyperlink(self):
+        result = get_cell_value('odh-mlmd-grpc-server-rhel9', 's390x', {'amd64'}, SAMPLE_CONFIG, 'csv')
+        assert '=HYPERLINK(' in result
+
+    def test_exception_no_issue_returns_xxx(self):
+        result = get_cell_value('odh-no-issue-rhel9', 'ppc64le', {'amd64'}, SAMPLE_CONFIG, 'text')
+        assert result == 'XXX'
+
+
+# --- generate_table JSON/YAML tests ---
+
+SAMPLE_COMPONENTS = {
+    'odh-dashboard-rhel9': {'amd64', 'arm64', 'ppc64le', 's390x'},
+    'odh-cuda-workbench-rhel9': {'amd64', 'arm64'},
+    'odh-mlmd-grpc-server-rhel9': {'amd64', 'arm64', 'ppc64le'},
+}
+
+
+class TestGenerateTableJson:
+    def test_valid_json(self):
+        output = generate_table(SAMPLE_COMPONENTS, SAMPLE_CONFIG, 'json')
+        data = json.loads(output)
+        assert 'generatedAt' in data
+        assert 'architectures' in data
+        assert 'components' in data
+        assert 'summary' in data
+
+    def test_architectures_list(self):
+        output = generate_table(SAMPLE_COMPONENTS, SAMPLE_CONFIG, 'json')
+        data = json.loads(output)
+        assert data['architectures'] == ['amd64', 'arm64', 'ppc64le', 's390x']
+
+    def test_components_sorted(self):
+        output = generate_table(SAMPLE_COMPONENTS, SAMPLE_CONFIG, 'json')
+        data = json.loads(output)
+        names = [c['name'] for c in data['components']]
+        assert names == sorted(names)
+
+    def test_component_has_all_archs(self):
+        output = generate_table(SAMPLE_COMPONENTS, SAMPLE_CONFIG, 'json')
+        data = json.loads(output)
+        for comp in data['components']:
+            assert set(comp['architectures'].keys()) == {'amd64', 'arm64', 'ppc64le', 's390x'}
+
+    def test_summary_total_matches_components(self):
+        output = generate_table(SAMPLE_COMPONENTS, SAMPLE_CONFIG, 'json')
+        data = json.loads(output)
+        assert data['summary']['totalComponents'] == len(data['components'])
+
+    def test_summary_full_multi_arch(self):
+        output = generate_table(SAMPLE_COMPONENTS, SAMPLE_CONFIG, 'json')
+        data = json.loads(output)
+        assert data['summary']['fullMultiArch'] == 1  # only odh-dashboard
+
+    def test_branch_metadata(self):
+        output = generate_table(SAMPLE_COMPONENTS, SAMPLE_CONFIG, 'json', metadata={'branch': 'rhoai-3.5'})
+        data = json.loads(output)
+        assert data['branch'] == 'rhoai-3.5'
+
+    def test_no_branch_without_metadata(self):
+        output = generate_table(SAMPLE_COMPONENTS, SAMPLE_CONFIG, 'json')
+        data = json.loads(output)
+        assert 'branch' not in data
+
+
+class TestGenerateTableYaml:
+    def test_valid_yaml(self):
+        output = generate_table(SAMPLE_COMPONENTS, SAMPLE_CONFIG, 'yaml')
+        data = yaml.safe_load(output)
+        assert 'generatedAt' in data
+        assert 'architectures' in data
+        assert 'components' in data
+        assert 'summary' in data
+
+    def test_yaml_same_structure_as_json(self):
+        json_output = generate_table(SAMPLE_COMPONENTS, SAMPLE_CONFIG, 'json', metadata={'branch': 'test'})
+        yaml_output = generate_table(SAMPLE_COMPONENTS, SAMPLE_CONFIG, 'yaml', metadata={'branch': 'test'})
+        json_data = json.loads(json_output)
+        yaml_data = yaml.safe_load(yaml_output)
+        # generatedAt will differ slightly, so compare everything else
+        del json_data['generatedAt']
+        del yaml_data['generatedAt']
+        assert json_data == yaml_data
+
+
+# --- Existing function tests (regression) ---
+
+class TestNormalizeArchitecture:
+    def test_linux_x86_64(self):
+        assert normalize_architecture('linux/x86_64') == 'amd64'
+
+    def test_linux_m2xlarge_arm64(self):
+        assert normalize_architecture('linux-m2xlarge/arm64') == 'arm64'
+
+    def test_linux_ppc64le(self):
+        assert normalize_architecture('linux/ppc64le') == 'ppc64le'
+
+    def test_bare_arch(self):
+        assert normalize_architecture('s390x') == 's390x'
+
+
+class TestExtractComponentName:
+    def test_quay_prefix(self):
+        assert extract_component_name('quay.io/rhoai/odh-dashboard-rhel9:{{target_branch}}') == 'odh-dashboard-rhel9'
+
+    def test_no_prefix(self):
+        assert extract_component_name('odh-dashboard-rhel9:latest') == 'odh-dashboard-rhel9'
+
+    def test_no_tag(self):
+        assert extract_component_name('quay.io/rhoai/odh-dashboard-rhel9') == 'odh-dashboard-rhel9'


### PR DESCRIPTION
- Add --format json and --format yaml to generate-table.py
- Add get_structured_cell_value() for machine-readable status output
- Add GitHub Actions workflow to regenerate report.yaml on architecture changes to rhoai-* branches (pipelineruns/, pipelines/, exceptions.toml)
- Workflow checks diff for architecture keywords before regenerating
- Add unit tests for new output formats (30 tests)
- Update README with JSON/YAML examples and schema docs

Jira: RHOAIENG-84746