### PR TITLE
Enabling mcp operator push pipeline for ppc64le

### DIFF
--- a/pipelineruns/mcp-lifecycle-module-operator/.tekton/odh-mcp-lifecycle-module-operator-v3-6-ea-2-push.yaml
+++ b/pipelineruns/mcp-lifecycle-module-operator/.tekton/odh-mcp-lifecycle-module-operator-v3-6-ea-2-push.yaml
@@ -47,6 +47,7 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+    - linux/s390x
   pipelineRef:
     params:
     - name: url

--- a/pipelineruns/mcp-lifecycle-module-operator/.tekton/odh-mcp-lifecycle-module-operator-v3-6-ea-2-push.yaml
+++ b/pipelineruns/mcp-lifecycle-module-operator/.tekton/odh-mcp-lifecycle-module-operator-v3-6-ea-2-push.yaml
@@ -46,6 +46,7 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+    - linux/ppc64le
   pipelineRef:
     params:
     - name: url

--- a/pipelineruns/mcp-lifecycle-operator/.tekton/odh-mcp-lifecycle-operator-v3-6-ea-2-push.yaml
+++ b/pipelineruns/mcp-lifecycle-operator/.tekton/odh-mcp-lifecycle-operator-v3-6-ea-2-push.yaml
@@ -47,6 +47,7 @@ spec:
     - linux/x86_64
     - linux-m2xlarge/arm64
     - linux/ppc64le
+    - linux/s390x
   pipelineRef:
     params:
     - name: url

--- a/pipelineruns/mcp-lifecycle-operator/.tekton/odh-mcp-lifecycle-operator-v3-6-ea-2-push.yaml
+++ b/pipelineruns/mcp-lifecycle-operator/.tekton/odh-mcp-lifecycle-operator-v3-6-ea-2-push.yaml
@@ -46,6 +46,7 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+    - linux/ppc64le
   pipelineRef:
     params:
     - name: url


### PR DESCRIPTION
Updating push pipelines for odh-mcp-lifecycle-module-operator image and odh-mcp-lifecycle-operator image to add linux/ppc64le platform. This is required for Enabling MCP catalog. Jira ticket: : https://redhat.atlassian.net/browse/RHOAIENG-85337