### PR TITLE
Set timeouts for pipeline and tasks for odh-workbench-codeserver-base…

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-baseline-cpu-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-baseline-cpu-py312-v3-6-ea-1-push.yaml
@@ -20,6 +20,9 @@ metadata:
   name: odh-workbench-codeserver-baseline-cpu-py312-v3-6-ea-1-on-push
   namespace: rhoai-tenant
 spec:
+  timeouts:
+    pipeline: 8h
+    tasks: 4h
   params:
   - name: git-url
     value: '{{source_url}}'


### PR DESCRIPTION
…line

Added timeouts for pipeline and tasks.

https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhoai-tenant/applications/rhoai-v3-6-ea-1/pipelineruns/odh-workbench-codeserver-baseline-cpu-py312-v3-6-ea-1-on-pst2g7