### PR TITLE
Bump odh-th-torch-rocm-py312 build-images memory to 16Gi/32Gi

### DIFF
--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-6-ea-1-push.yaml
@@ -61,9 +61,9 @@ spec:
     - name: build
       computeResources:
         requests:
-          memory: 4Gi
+          memory: 16Gi
         limits:
-          memory: 8Gi
+          memory: 32Gi
     - name: sbom-syft-generate
       computeResources:
         requests:


### PR DESCRIPTION
## Summary
- Raise `build-images` / `build` step memory for `odh-th-torch-rocm-py312-v3-6-ea-1` from 4Gi request / 8Gi limit to 16Gi / 32Gi.
- The hermetic `uv pip install` of torch + tensorflow-rocm + flash-attn was dying during STEP 7 with no error (typical SIGKILL at the 8Gi cap).
- Matches the memory class used for other heavy training-image builds in this repo.

## Test plan
- [ ] Merge retriggers the push PipelineRun (`pathChanged` on this YAML).
- [ ] Confirm `build-images` is not OOMKilled during `uv pip install`.
- [ ] Confirm later `prepare-sboms` / `sbom-syft-generate` still succeed at 4Gi/8Gi; bump those separately if they OOM on the larger image.
