### PR TITLE
chore(ogx-distribution): drop Hermeto generic prefetch (RHAIENG-6977)

### DIFF
--- a/pipelineruns/ogx-distribution/.tekton/odh-ogx-core-pull-request.yaml
+++ b/pipelineruns/ogx-distribution/.tekton/odh-ogx-core-pull-request.yaml
@@ -53,7 +53,7 @@ spec:
     value: true
   - name: prefetch-input
     value: |
-      [{"type": "pip", "path": ".", "requirements_files": ["distribution/requirements-lock-konflux.txt"], "allow_binary": true}, {"type": "generic", "path": "./distribution"}]
+      [{"type": "pip", "path": ".", "requirements_files": ["distribution/requirements-lock-konflux.txt"], "allow_binary": true}]
   - name: build-image-index
     value: true
   - name: enable-slack-failure-notification


### PR DESCRIPTION
## Summary

For the **ogx-distribution** component, removes the Hermeto **generic** entry from the `prefetch-input` parameter, leaving only the **pip** entry.

RHAIENG-6977 switches the downstream RHDS OGX distribution's hermetic Konflux build to consume model/data files (tiktoken encodings, `ibm-granite/granite-embedding-125m-english` HF model, docling layout models) from a pre-published OCI artifact (`registry.stage.redhat.io/rhai/redhatai-ogx-distribution:3.0`) instead of Hugging Face downloads prefetched via Hermeto's generic fetcher.

The build-side change lives in ogx-distribution PR #163 (`red-hat-data-services/ogx-distribution#163`, branch `konflux-oci-artifact`), which copies the files from the OCI artifact build stage and no longer reads `/cachi2/output/deps/generic`. Since `.tekton/` files in the component repo are auto-synced from `konflux-central`, the prefetch config must change here.

The build remains hermetic (`hermetic: true` unchanged).

## ⚠️ Do not merge until ogx-distribution #163 lands

This change must land **with or after** `red-hat-data-services/ogx-distribution#163`. If the generic prefetch is removed while the component's `Dockerfile.konflux` still copies from `/cachi2/output/deps/generic`, the build breaks. Leaving the generic prefetch in place temporarily after #163 merges is harmless. Kept as a **draft** until #163 is merged.

## Verification

Each edited `prefetch-input` value parses as valid JSON and contains only `['pip']`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)