### PR TITLE
RHOAIENG-85737: Set hermetic=true in odh-kserve-storage-initializer push spec

### DIFF
--- a/pipelineruns/kserve/.tekton/odh-kserve-storage-initializer-v3-6-ea-1-push.yaml
+++ b/pipelineruns/kserve/.tekton/odh-kserve-storage-initializer-v3-6-ea-1-push.yaml
@@ -37,7 +37,7 @@ spec:
   - name: path-context
     value: python
   - name: hermetic
-    value: false
+    value: true
   - name: build-source-image
     value: true
   - name: build-image-index


### PR DESCRIPTION
## Summary
- Set `hermetic` parameter to `true` in the push pipeline spec for odh-kserve-storage-initializer
- Matches the pull request pipeline configuration

## Jira
https://redhat.atlassian.net/browse/RHOAIENG-85737