### PR TITLE
RHOAIENG-85741: Set hermetic=true in odh-built-in-detector push spec

### DIFF
--- a/pipelineruns/guardrails-detectors/.tekton/odh-built-in-detector-v3-6-ea-2-push.yaml
+++ b/pipelineruns/guardrails-detectors/.tekton/odh-built-in-detector-v3-6-ea-2-push.yaml
@@ -37,7 +37,7 @@ spec:
   - name: path-context
     value: detectors
   - name: hermetic
-    value: false
+    value: true
   - name: build-source-image
     value: true
   - name: build-image-index


### PR DESCRIPTION
## Summary
- Set `hermetic` parameter to `true` in the push pipeline spec for odh-built-in-detector
- Matches the pull request pipeline configuration

## Jira
https://redhat.atlassian.net/browse/RHOAIENG-85741