### PR TITLE
RHOAIENG-85745: Set enable-package-registry-proxy=true in odh-mlserver-cuda push spec

### DIFF
--- a/pipelineruns/MLServer/.tekton/odh-mlserver-cuda-v3-6-ea-2-push.yaml
+++ b/pipelineruns/MLServer/.tekton/odh-mlserver-cuda-v3-6-ea-2-push.yaml
@@ -39,7 +39,7 @@ spec:
   - name: hermetic
     value: true
   - name: enable-package-registry-proxy
-    value: "false"
+    value: "true"
   - name: prefetch-input
     value: |
       {


### PR DESCRIPTION
## Summary
- Set `enable-package-registry-proxy` parameter to `true` in the push pipeline spec for odh-mlserver-cuda
- Ensures dependency prefetching routes through the package registry proxy

## Jira
https://redhat.atlassian.net/browse/RHOAIENG-85745