### PR TITLE
fix: block major/minor vLLM bumps to prevent cross-stream upgrades

### DIFF
--- a/renovate/custom-renovate.json5
+++ b/renovate/custom-renovate.json5
@@ -64,6 +64,18 @@
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-ea\\.(?<prerelease>\\d+))?(-(?<build>\\d+))?$",
       "enabled": true,
       "groupName": "vllm images"
+    },
+    {
+      // Block major/minor version bumps for vLLM images to prevent
+      // cross-stream upgrades (e.g. 3.4 → 3.5). Only patch and
+      // build-number updates should be picked up automatically.
+      // See: RHOAIENG-83616
+      "matchPackagePatterns": [
+        "registry\\.redhat\\.io\\/rhaii.*\\/vllm-",
+        "registry\\.stage\\.redhat\\.io\\/rhaii.*\\/vllm-"
+      ],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Summary

- Adds a `packageRule` after the existing vLLM entry that disables `major` and `minor` update types for vLLM images
- Prevents cross-stream upgrades (e.g. `3.4 → 3.5`) while preserving patch, build-number, and digest updates
- Root cause of [RHOAI-Build-Config PR #27979](https://github.com/red-hat-data-services/RHOAI-Build-Config/pull/27979) being auto-merged with wrong `3.5.0` images on the `rhoai-3.4` branch

## How it works

Renovate applies `packageRules` in order (last match wins per property). The existing vLLM rule sets `enabled: true` which overrides the global disable for **all** update types. The new rule re-disables specifically `major` and `minor` bumps, so only `patch` and `build` updates pass through.

## Test plan

- [ ] Merge this PR first, before the companion RHOAI-Build-Config PR
- [ ] Run Renovate dry run targeting `rhoai-3.4` to confirm it no longer proposes `3.5.0` bumps
- [ ] Verify digest-only updates still auto-merge as expected

Ref: [RHOAIENG-83616](https://redhat.atlassian.net/browse/RHOAIENG-83616)