### PR TITLE
chore(ogx-distribution): drop Hermeto generic prefetch on 3.6 EA1 push (RHAIENG-6977)

### DIFF
--- a/pipelineruns/ogx-distribution/.tekton/odh-ogx-core-v3-6-ea-1-push.yaml
+++ b/pipelineruns/ogx-distribution/.tekton/odh-ogx-core-v3-6-ea-1-push.yaml
@@ -41,7 +41,7 @@ spec:
     value: true
   - name: prefetch-input
     value: |
-      [{"type": "pip", "path": ".", "requirements_files": ["distribution/requirements-lock-konflux.txt"], "allow_binary": true}, {"type": "generic", "path": "./distribution"}]
+      [{"type": "pip", "path": ".", "requirements_files": ["distribution/requirements-lock-konflux.txt"], "allow_binary": true}]
   - name: build-source-image
     value: true
   - name: build-image-index


### PR DESCRIPTION
## Summary

For the **ogx-distribution** component on the **`rhoai-3.6-ea.1`** branch, removes the Hermeto **generic** entry from the `prefetch-input` parameter of the **push** pipeline (`odh-ogx-core-v3-6-ea-1-push.yaml`), leaving only the **pip** entry.

This is the EA1-branch companion to #3236 (which made the same change on `main` for the pull-request pipeline), requested by @eoinfennessy in https://github.com/red-hat-data-services/konflux-central/pull/3236#issuecomment-5353973798.

RHAIENG-6977 switches the downstream RHDS OGX distribution's hermetic Konflux build to consume model/data files (tiktoken encodings, `ibm-granite/granite-embedding-125m-english` HF model, docling layout models) from a pre-published OCI artifact (`registry.stage.redhat.io/rhai/redhatai-ogx-distribution:3.0`) instead of Hugging Face downloads prefetched via Hermeto's generic fetcher.

The build-side change lives in ogx-distribution PR #163 (`red-hat-data-services/ogx-distribution#163`), which copies the files from the OCI artifact build stage and no longer reads `/cachi2/output/deps/generic`.

The build remains hermetic (`hermetic: true` unchanged).

## ⚠️ Sequencing

This change must land **with or after** `red-hat-data-services/ogx-distribution#163`. If the generic prefetch is removed while the component's `Dockerfile.konflux` still copies from `/cachi2/output/deps/generic`, the build breaks. Leaving the generic prefetch in place temporarily after #163 merges is harmless.

## Verification

The edited `prefetch-input` value parses as valid JSON and contains only `['pip']`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)