### PR TITLE
RHOAIENG-87547: Add prefetch-input and set hermetic=true for odh-built-in-detector

### DIFF
--- a/pipelineruns/guardrails-detectors/.tekton/odh-built-in-detector-pull-request.yaml
+++ b/pipelineruns/guardrails-detectors/.tekton/odh-built-in-detector-pull-request.yaml
@@ -38,7 +38,9 @@ spec:
   - name: path-context
     value: detectors
   - name: hermetic
-    value: false
+    value: true
+  - name: prefetch-input
+    value: '[{"type": "pip", "path": "detectors", "requirements_files": ["requirements.txt"], "requirements_build_files": ["requirements-build.txt"], "binary": {"arch": "x86_64,aarch64,ppc64le,s390x"}}]'
   - name: build-image-index
     value: true
   - name: build-platforms


### PR DESCRIPTION
## Summary
- Set `hermetic` to `true` and add `prefetch-input` on the built-in-detector pull-request spec
- Restores the config from [guardrails-detectors#393](https://github.com/red-hat-data-services/guardrails-detectors/pull/393) that was clobbered by konflux-central sync

## Jira
https://redhat.atlassian.net/browse/RHOAIENG-87547