### PR TITLE
RHOAIENG-87548: Add prefetch-input to kserve-storage-initializer and built-in-detector push specs

### DIFF
--- a/pipelineruns/guardrails-detectors/.tekton/odh-built-in-detector-v3-6-ea-1-push.yaml
+++ b/pipelineruns/guardrails-detectors/.tekton/odh-built-in-detector-v3-6-ea-1-push.yaml
@@ -38,6 +38,8 @@ spec:
     value: detectors
   - name: hermetic
     value: true
+  - name: prefetch-input
+    value: '[{"type": "pip", "path": "detectors", "requirements_files": ["requirements.txt"], "requirements_build_files": ["requirements-build.txt"], "binary": {"arch": "x86_64,aarch64,ppc64le,s390x"}}]'
   - name: build-source-image
     value: true
   - name: build-image-index

--- a/pipelineruns/kserve/.tekton/odh-kserve-storage-initializer-v3-6-ea-1-push.yaml
+++ b/pipelineruns/kserve/.tekton/odh-kserve-storage-initializer-v3-6-ea-1-push.yaml
@@ -38,6 +38,12 @@ spec:
     value: python
   - name: hermetic
     value: true
+  - name: prefetch-input
+    value: |
+      [
+        {"type": "rpm", "path": "."},
+        {"type": "pip", "path": "python/storage", "allow_binary": true}
+      ]
   - name: build-source-image
     value: true
   - name: build-image-index


### PR DESCRIPTION
## Summary
- Add `prefetch-input` to odh-kserve-storage-initializer and odh-built-in-detector push specs
- Previous PRs (#3240, #3242) set `hermetic=true` but missed this parameter — without it, hermetic builds cannot prefetch dependencies

## Jira
https://redhat.atlassian.net/browse/RHOAIENG-87548