### PR TITLE
Enable Renovate for batch-gateway

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -60,6 +60,7 @@
     - name: "red-hat-data-services/rhoai-mcp"
     - name: "red-hat-data-services/notebooks"
     - name: "red-hat-data-services/data-connect-hub"
+    - name: "red-hat-data-services/batch-gateway"
 
 - renovate-config: "renovate/custom-renovate-distribution.json"
   sync-repositories:


### PR DESCRIPTION
Adds `red-hat-data-services/batch-gateway` to the default Renovate distribution in config.yaml.

| Field | Value |
|-------|-------|
| Component repo | `red-hat-data-services/batch-gateway` |
| Renovate entry | `red-hat-data-services/batch-gateway` |
| Distribution   | `renovate/default-renovate-distribution.json` |