### PR TITLE
update renovate config to include rpm-lockfile

### DIFF
--- a/renovate/default-renovate.json5
+++ b/renovate/default-renovate.json5
@@ -12,7 +12,7 @@
     "automerge": true,
     // No rate limit on PRs
     "prHourlyLimit": 0,
-    "enabledManagers": ["dockerfile", "rpm"],
+    "enabledManagers": ["dockerfile", "rpm", "rpm-lockfile"],
     "packageRules": [
       {
         // Auto-merge digest updates for Konflux Dockerfiles only


### PR DESCRIPTION
Builds for odh-fms-guardrails-orchestrator-v3-6-ea-1 are [failing on all 4 platforms](https://redhat.enterprise.slack.com/archives/C07ANR2U56C/p1787084574860379) due to stale RPM lock files.

The refresh-rpm-lockfiles preset is already present in [rpm-refresh-renovate.json5](https://github.com/red-hat-data-services/konflux-central/blob/main/renovate/rpm-refresh-renovate.json5), but enabledManagers in default-renovate.json5 was set to ["dockerfile", "rpm"] — a strict allowlist that silently blocked MintMaker's rpm-lockfile custom manager from running.

This PR adds rpm-lockfile to the allowlist, which is the only missing piece. Per [Chai-bot's advice](https://redhat.enterprise.slack.com/archives/C04PZ7H0VA8/p1787320367756629?thread_ts=1787319611.985889&cid=C04PZ7H0VA8), you need both:

refresh-rpm-lockfiles preset in extends — already in place
rpm-lockfile in enabledManagers — this PR
Affects repos using the rpm-refresh-renovate-distribution.json config: fms-guardrails-orchestrator and model-registry.
