### PR TITLE
Bump the memory for MLflow prefetch deps to 6Gi

### DIFF
--- a/pipelineruns/mlflow/.tekton/mlflow-pull-request.yaml
+++ b/pipelineruns/mlflow/.tekton/mlflow-pull-request.yaml
@@ -71,9 +71,9 @@ spec:
     computeResources:
       requests:
         cpu: '1'
-        memory: 4608Mi
+        memory: 6Gi
       limits:
-        memory: 4608Mi
+        memory: 6Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-pull-request-pipelines
   workspaces:


### PR DESCRIPTION
This should help with memory issues when prefetching Yarn deps.