### PR TITLE
Add odh-pipeline-runtime-baseline-cpu-py312-v3-6-ea-2 push PipelineRun

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-baseline-cpu-py312-v3-6-ea-2-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-baseline-cpu-py312-v3-6-ea-2-push.yaml
@@ -1,0 +1,63 @@
+
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    build.appstudio.openshift.io/build-nudge-files: "build/operator-nudging.yaml"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push"
+      && target_branch == "rhoai-3.6-ea.2"
+      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-pipeline-runtime-baseline-cpu-py312-v3-6-ea-2-push.yaml".pathChanged() )
+  labels:
+    appstudio.openshift.io/application: rhoai-v3-6-ea-2
+    appstudio.openshift.io/component: odh-pipeline-runtime-baseline-cpu-py312-v3-6-ea-2
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-pipeline-runtime-baseline-cpu-py312-v3-6-ea-2-on-push
+  namespace: rhoai-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: additional-tags
+    value:
+    - '{{target_branch}}-{{revision}}'
+  - name: output-image
+    value: quay.io/rhoai/odh-pipeline-runtime-baseline-cpu-py312-rhel9:{{target_branch}}
+  - name: rhoai-version
+    value: "3.6.0-ea.2"
+  - name: dockerfile
+    value: runtimes/baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
+  - name: path-context
+    value: .
+  - name: hermetic
+    value: true
+
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux-m2xlarge/arm64
+    - linux/ppc64le
+    - linux/s390x
+  pipelineRef:
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ target_branch }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+    resolver: git
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-pipeline-runtime-baseline-cpu-py312-v3-6-ea-2
+    podTemplate:
+      imagePullSecrets:
+      - name: redhat-appstudio-staginguser-pull-secret
+  timeouts:
+    pipeline: 2h


### PR DESCRIPTION
Adds push PipelineRun YAML for 'odh-pipeline-runtime-baseline-cpu-py312' targeting branch 'rhoai-3.6-ea.2'.

Component repo: https://github.com/red-hat-data-services/notebooks
Jira: https://redhat.atlassian.net/browse/RHOAIENG-81141