### PR TITLE
Update prefetch to requirements.builtIn.txt after requirements file rename

### DIFF
--- a/pipelineruns/guardrails-detectors/.tekton/odh-built-in-detector-v3-6-ea-1-push.yaml
+++ b/pipelineruns/guardrails-detectors/.tekton/odh-built-in-detector-v3-6-ea-1-push.yaml
@@ -39,7 +39,7 @@ spec:
   - name: hermetic
     value: true
   - name: prefetch-input
-    value: '[{"type": "pip", "path": "detectors", "requirements_files": ["requirements.txt"], "requirements_build_files": ["requirements-build.txt"], "binary": {"arch": "x86_64,aarch64,ppc64le,s390x"}}]'
+    value: '[{"type": "pip", "path": "detectors", "requirements_files": ["requirements.builtIn.txt"], "requirements_build_files": ["requirements-build.txt"], "binary": {"arch": "x86_64,aarch64,ppc64le,s390x"}}]'
   - name: build-source-image
     value: true
   - name: build-image-index


### PR DESCRIPTION
Update prefetch requirements file name from requirements.txt to requirements.builtIn.txt in odh-built-in-detector-v3-6-ea-1 push pipeline.

