### PR TITLE
fix(notebooks): move ROCm v2-25 stepOverrides from sbom-syft-generate to build

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v2-25-push.yaml
@@ -80,7 +80,7 @@ spec:
           memory: 32Gi
     - pipelineTaskName: build-images
       stepSpecs:
-        - name: sbom-syft-generate
+        - name: build
           computeResources:
             requests:
               cpu: '8'

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v2-25-push.yaml
@@ -80,7 +80,7 @@ spec:
           memory: 32Gi
     - pipelineTaskName: build-images
       stepSpecs:
-        - name: sbom-syft-generate
+        - name: build
           computeResources:
             requests:
               cpu: '8'

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v2-25-push.yaml
@@ -80,7 +80,7 @@ spec:
           memory: 32Gi
     - pipelineTaskName: build-images
       stepSpecs:
-        - name: sbom-syft-generate
+        - name: build
           computeResources:
             requests:
               cpu: '8'

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v2-25-push.yaml
@@ -84,7 +84,7 @@ spec:
           memory: 32Gi
     - pipelineTaskName: build-images
       stepSpecs:
-        - name: sbom-syft-generate
+        - name: build
           computeResources:
             requests:
               cpu: '8'

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v2-25-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v2-25-push.yaml
@@ -84,7 +84,7 @@ spec:
           memory: 32Gi
     - pipelineTaskName: build-images
       stepSpecs:
-        - name: sbom-syft-generate
+        - name: build
           computeResources:
             requests:
               cpu: '8'


### PR DESCRIPTION
## Summary

Fix `invalid StepOverride: No Step named sbom-syft-generate` on all ROCm `rhoai-2.25` notebook push PipelineRuns.

## Root cause

`rhoai-2.25` uses `pipelines/multi-arch-container-build.yaml` with `buildah-remote-oci-ta:0.12.0`. Starting in **0.11.0**, that task removed the `sbom-syft-generate` (and `push`) steps — SBOM generation and push now happen inside the **`build`** step ([Konflux migration guidance](https://github.com/openshift/agent-installer-utils/pull/337)).

The five ROCm v2-25 push PipelineRuns still had:

```yaml
taskRunSpecs:
  - pipelineTaskName: build-images
    stepSpecs:
      - name: sbom-syft-generate   # ← no longer exists
```

Tekton rejects the PipelineRun before any pod starts.

**Affected components (5):**
- `odh-workbench-jupyter-minimal-rocm-py312-v2-25`
- `odh-workbench-jupyter-pytorch-rocm-py312-v2-25`
- `odh-workbench-jupyter-tensorflow-rocm-py312-v2-25`
- `odh-pipeline-runtime-pytorch-rocm-py312-v2-25`
- `odh-pipeline-runtime-tensorflow-rocm-py312-v2-25`

(Not all 18 v2-25 images — CPU/CUDA pipelines never had this override.)

## Fix

Rename the step override target from `sbom-syft-generate` → `build`, preserving the existing CPU/memory sizing (32Gi/64Gi) since SBOM work now runs in that step.

## Test plan

- [x] Verified only the five ROCm push YAMLs are changed
- [ ] Merge and sync pipelineruns to `red-hat-data-services/notebooks` `rhoai-2.25`
- [ ] Retrigger one ROCm push PipelineRun; confirm it passes PipelineRun validation and reaches build

<details>
<summary>Trajectory</summary>

1. Slack thread on ODH 3.6-EA1 minimal notebook images — Universal Training team reported ROCm 3.6.ea1 tag missing from Quay while CUDA/CPU were published.
2. Konflux PipelineRun `odh-workbench-jupyter-minimal-rocm-py312-ubi9-ci-on-push-8t57x` (ODH) was failing on ephemeral storage during SBOM/syft — separate issue, fixed in [opendatahub-io/notebooks#4428](https://github.com/opendatahub-io/notebooks/pull/4428) (64Gi → 80Gi).
3. Waterfall dashboard (`ci/waterfall`) collected Konflux status via `oc` + KubeArchive; `rhoai-2.25` showed 6 latest `build_failed` cells, mostly ROCm.
4. User reported all `rhoai-2.25` failures with `invalid StepOverride: No Step named sbom-syft-generate`.
5. Grepped `konflux-central` `rhoai-2.25` — only five ROCm push PipelineRuns carry `stepSpecs` targeting `sbom-syft-generate`; other v2-25 images do not.
6. `pipelines/multi-arch-container-build.yaml` on `rhoai-2.25` references `buildah-remote-oci-ta:0.12.0` (since [PR #3220](https://github.com/red-hat-data-services/konflux-central/pull/3220), MintMaker auto-merge 2026-08-20). Changelog for 0.11.0 documents removal of `sbom-syft-generate`; migration script does not run because PipelineRuns use external `pipelineRef`.
7. Git archaeology: overrides originally added by Akshay Ghodake (2026-05-25, commits `9fe2d291` / `1ffd3767`) and Yash Ajgaonkar (memory bumps, runtime extensions) when task was still 0.10.x — valid at the time. Breakage triggered by MintMaker bundle bump 0.10.7 → 0.12.0 without pipelinerun migration.
8. Applied fix: rename step override `sbom-syft-generate` → `build` in all five ROCm v2-25 push YAMLs under `pipelineruns/notebooks/.tekton/`, keeping 8–16 CPU and 32Gi/64Gi memory limits.

</details>