### PR TITLE
Improve formatting of .tekton directory warning to fix markdown lint

### DIFF
--- a/pipelineruns/README.md.in
+++ b/pipelineruns/README.md.in
@@ -1,6 +1,8 @@
 # ⚠️ Do Not Modify Files in the `.tekton/` Directory Directly
 
-The `.tekton/` directory in each component repository is **automatically synchronized** from [`konflux-central`](https://github.com/red-hat-data-services/konflux-central) using automation. Any edits made directly to Tekton files in the component repositories will be **overwritten** by the next sync.
+The `.tekton/` directory in each component repository is **automatically synchronized**
+from [`konflux-central`](https://github.com/red-hat-data-services/konflux-central) using automation. 
+Any edits made directly to Tekton files in the component repositories will be **overwritten** by the next sync.
 
 All Tekton file updates **must be made in the `konflux-central` repository**.
 


### PR DESCRIPTION
Reformat warning about the .tekton directory synchronization to fix markdown lint.