### PR TITLE
Remove sbom-syft-generate from notebooks and odh-th-torch push pipelines

### DIFF
--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cpu-py312-v3-6-ea-1-push.yaml
@@ -65,12 +65,6 @@ spec:
           memory: 4Gi
         limits:
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          memory: 4Gi
-        limits:
-          memory: 8Gi
     - name: prepare-sboms
       computeResources:
         requests:

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-cuda-py312-v3-6-ea-1-push.yaml
@@ -65,12 +65,6 @@ spec:
           memory: 4Gi
         limits:
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          memory: 4Gi
-        limits:
-          memory: 8Gi
     - name: prepare-sboms
       computeResources:
         requests:

--- a/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/distributed-workloads/.tekton/odh-th-torch-rocm-py312-v3-6-ea-1-push.yaml
@@ -64,12 +64,6 @@ spec:
           memory: 4Gi
         limits:
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          memory: 4Gi
-        limits:
-          memory: 8Gi
     - name: prepare-sboms
       computeResources:
         requests:

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-datascience-cpu-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-datascience-cpu-py312-v3-6-ea-1-push.yaml
@@ -95,14 +95,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-minimal-cpu-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-minimal-cpu-py312-v3-6-ea-1-push.yaml
@@ -95,14 +95,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-v3-6-ea-1-push.yaml
@@ -93,14 +93,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-6-ea-1-push.yaml
@@ -93,14 +93,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v3-6-ea-1-push.yaml
@@ -92,14 +92,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-v3-6-ea-1-push.yaml
@@ -93,14 +93,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v3-6-ea-1-push.yaml
@@ -92,14 +92,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v3-6-ea-1-push.yaml
@@ -100,14 +100,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cpu-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cpu-py312-v3-6-ea-1-push.yaml
@@ -98,14 +98,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cuda-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cuda-py312-v3-6-ea-1-push.yaml
@@ -96,14 +96,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v3-6-ea-1-push.yaml
@@ -95,14 +95,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-v3-6-ea-1-push.yaml
@@ -96,14 +96,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v3-6-ea-1-push.yaml
@@ -95,14 +95,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v3-6-ea-1-push.yaml
@@ -96,14 +96,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v3-6-ea-1-push.yaml
@@ -95,14 +95,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-v3-6-ea-1-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-v3-6-ea-1-push.yaml
@@ -100,14 +100,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:


### PR DESCRIPTION
Remove sbom-syft-generate step from 16 notebooks push PipelineRuns and 3 odh-th-torch distributed-workloads push PipelineRuns on rhoai-3.6-ea.1.

Remove obsolete sbom-syft-generate step overrides from push PipelineRuns.

Buildah v0.11.0 removed the sbom-syft-generate step (SBOM generation moved into the build step). Retaining overrides for removed steps causes invalid StepOverride failures. See [buildah 0.11.0 migration guidance](https://github.com/konflux-ci/container-build-catalog/blob/main/task/buildah/CHANGELOG.md#0110).

Made with [Cursor](https://cursor.com)