### PR TITLE
Remove sbom-syft-generate from notebooks pull-request pipelines

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml
@@ -99,14 +99,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml
@@ -98,14 +98,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cuda-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-cuda-py312-pull-request.yaml
@@ -96,14 +96,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-minimal-rocm-py312-pull-request.yaml
@@ -95,14 +95,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
@@ -98,14 +98,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:


### PR DESCRIPTION
Remove obsolete `sbom-syft-generate` step overrides from 5 notebooks pull-request PipelineRuns on `main`.

Buildah task v0.11.0 removed the `sbom-syft-generate` step (SBOM generation now happens in the `build` step). Retaining overrides for removed steps causes `invalid StepOverride` failures.

Migration guidance: https://github.com/konflux-ci/container-build-catalog/blob/main/task/buildah/CHANGELOG.md#0110

Made with [Cursor](https://cursor.com)