### PR TITLE
fix: add cargo and rpm prefetch-input for data-connect-hub hermetic builds

### DIFF
--- a/pipelineruns/data-connect-hub/.tekton/odh-data-connect-hub-flight-v3-6-ea-2-push.yaml
+++ b/pipelineruns/data-connect-hub/.tekton/odh-data-connect-hub-flight-v3-6-ea-2-push.yaml
@@ -37,8 +37,13 @@ spec:
   - name: path-context
     value: .
   - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[{"type": "cargo", "path": "."},{"type": "rpm", "path": "."}]'
+  - name: build-source-image
     value: true
-
+  - name: enable-cache-proxy
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64

--- a/pipelineruns/data-connect-hub/.tekton/odh-data-connect-hub-rest-v3-6-ea-2-push.yaml
+++ b/pipelineruns/data-connect-hub/.tekton/odh-data-connect-hub-rest-v3-6-ea-2-push.yaml
@@ -37,8 +37,13 @@ spec:
   - name: path-context
     value: .
   - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[{"type": "cargo", "path": "."},{"type": "rpm", "path": "."}]'
+  - name: build-source-image
     value: true
-
+  - name: enable-cache-proxy
+    value: true
   - name: build-platforms
     value:
     - linux/x86_64


### PR DESCRIPTION
## Summary
- Adds `prefetch-input` parameter to both data-connect-hub push pipelines (flight and rest) on `rhoai-3.6-ea.2`
- Configures cachi2 to prefetch both **cargo** crates and **RPM** packages: `[{"type": "cargo", "path": "."},{"type": "rpm", "path": "."}]`
- Without this, hermetic builds fail because `microdnf` cannot resolve packages when network access is blocked (`Could not resolve host: cdn-ubi.redhat.com`)

## Companion PR
- data-connect-hub repo: Containerfile.konflux updates (UBI9-minimal builder + cargo RPM), `rpms.in.yaml`, `rpms.lock.yaml`, `ubi.repo`

## Test plan
- [ ] Verify flight-service Konflux hermetic build passes on all architectures (x86_64, arm64, ppc64le, s390x)
- [ ] Verify rest-service Konflux hermetic build passes on all architectures

Made with [Cursor](https://cursor.com)