### PR TITLE
RHOAIENG-88284: Add requirements_build_files to kserve-storage-initializer prefetch-input

### DIFF
--- a/pipelineruns/kserve/.tekton/odh-kserve-storage-initializer-v3-6-ea-1-push.yaml
+++ b/pipelineruns/kserve/.tekton/odh-kserve-storage-initializer-v3-6-ea-1-push.yaml
@@ -42,7 +42,8 @@ spec:
     value: |
       [
         {"type": "rpm", "path": "."},
-        {"type": "pip", "path": "python/storage", "allow_binary": true}
+        {"type": "pip", "path": "python/storage", "allow_binary": true,
+         "requirements_build_files": ["requirements-build-deps.txt"]}
       ]
   - name: build-source-image
     value: true


### PR DESCRIPTION
## Summary
- Add `requirements_build_files: ["requirements-build-deps.txt"]` to the kserve-storage-initializer push spec prefetch-input
- Without this, `setuptools==83.0.0` is not prefetched and hermetic builds fail
- Matches the config already in `red-hat-data-services/kserve` main branch

## Jira
https://redhat.atlassian.net/browse/RHOAIENG-88284