### PR TITLE
RHOAIENG-88286: Add requirements_build_files to kserve-storage-initializer prefetch-input

### DIFF
--- a/pipelineruns/kserve/.tekton/odh-kserve-storage-initializer-pull-request.yaml
+++ b/pipelineruns/kserve/.tekton/odh-kserve-storage-initializer-pull-request.yaml
@@ -49,7 +49,8 @@ spec:
     value: |
       [
         {"type": "rpm", "path": "."},
-        {"type": "pip", "path": "python/storage", "allow_binary": true}
+        {"type": "pip", "path": "python/storage", "allow_binary": true,
+         "requirements_build_files": ["requirements-build-deps.txt"]}
       ]
   - name: build-image-index
     value: true


### PR DESCRIPTION
## Summary
- Add `requirements_build_files: ["requirements-build-deps.txt"]` to the kserve-storage-initializer PR spec prefetch-input
- Syncs the konflux-central spec with what's already in `red-hat-data-services/kserve` main branch
- Without this, `setuptools==83.0.0` is not prefetched and hermetic builds fail

## Jira
https://redhat.atlassian.net/browse/RHOAIENG-88286