### PR TITLE
fix: Prefetch AIPCC RHAI wheels for feast feature-server PR builds

### DIFF
--- a/pipelineruns/feast/.tekton/odh-feature-server-pull-request.yaml
+++ b/pipelineruns/feast/.tekton/odh-feature-server-pull-request.yaml
@@ -39,40 +39,23 @@ spec:
   - name: dockerfile
     value: Dockerfiles/Dockerfile.feature-server.konflux
   - name: path-context
-    value: "sdk/python/feast/infra/feature_servers/multicloud"
+    value: "."
   - name: hermetic
-    value: true
+    value: "true"
   - name: prefetch-input
     value: |
       [
         {
           "type": "pip",
-          "path": ".",
-          "requirements_files": [
-            "sdk/python/feast/infra/feature_servers/multicloud/requirements.txt",
-            "sdk/python/feast/infra/feature_servers/multicloud/requirements-ppc64le.txt",
-            "sdk/python/feast/infra/feature_servers/multicloud/requirements-ppc64le2.txt"
-          ],
-          "requirements_build_files": [
-            "sdk/python/requirements/py3.12-minimal-requirements.txt",
-            "sdk/python/requirements/py3.12-minimal-sdist-requirements.txt",
-            "sdk/python/requirements/py3.12-minimal-sdist-requirements-build.txt"
-          ],
-          "allow_binary": "true"
-        },
-        {
-          "type": "rpm",
-          "path": "sdk/python/feast/infra/feature_servers/multicloud/offline"
-        },
-        {
-          "type": "generic",
-          "path": "sdk/python/feast/infra/feature_servers/multicloud"
+          "path": "sdk/python/feast/infra/feature_servers/multicloud",
+          "requirements_files": ["requirements-rhai.txt"],
+          "binary": {"arch": "x86_64,aarch64,ppc64le"}
         }
       ]
   - name: build-source-image
-    value: true
+    value: "true"
   - name: build-image-index
-    value: true
+    value: "true"
   - name: build-platforms
     value:
     - linux/x86_64


### PR DESCRIPTION
- Update the feast `odh-feature-server` **pull-request** PipelineRun so Konflux hermetic builds prefetch AIPCC RHAI wheels instead of PyPI / ppc64le / RPM / generic artifacts.
- `path-context` is repo root (`.`) so `Dockerfile.feature-server.konflux` can COPY `LICENSE`, `pyproject.toml`, and `sdk/python`.
- Prefetch is pip-only: `sdk/python/feast/infra/feature_servers/multicloud/requirements-rhai.txt` for `x86_64,aarch64,ppc64le`.
- No Tekton `BASE_IMAGE` build-arg; the digest is pinned in the feast Dockerfile.
