### PR TITLE
fix: use repo-root path-context for odh-feature-server EA.2 push

### DIFF
--- a/pipelineruns/feast/.tekton/odh-feature-server-v3-6-ea-2-push.yaml
+++ b/pipelineruns/feast/.tekton/odh-feature-server-v3-6-ea-2-push.yaml
@@ -38,7 +38,7 @@ spec:
   - name: dockerfile
     value: Dockerfiles/Dockerfile.feature-server.konflux
   - name: path-context
-    value: sdk/python/feast/infra/feature_servers/multicloud
+    value: .
   - name: hermetic
     value: true
   - name: prefetch-input


### PR DESCRIPTION
Set `path-context` to `.` in `pipelineruns/feast/.tekton/odh-feature-server-v3-6-ea-2-push.yaml`.

