### PR TITLE
Add gomod prefetch-input for odh-workbenches-controller hermetic builds

### DIFF
--- a/pipelineruns/workbenches/.tekton/odh-workbenches-controller-pull-request.yaml
+++ b/pipelineruns/workbenches/.tekton/odh-workbenches-controller-pull-request.yaml
@@ -32,7 +32,11 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
-
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: |
+      [{"type": "gomod", "path": "workspaces/controller"}]
   - name: build-platforms
     value:
     - linux/x86_64


### PR DESCRIPTION
Cachi2 was not fetching Go modules, so hermetic PR builds failed at go mod download against proxy.golang.org.

same as: https://github.com/red-hat-data-services/konflux-central/blob/df2317cea26d21677c363ebdbe21ddc74885ceaf/pipelineruns/workbenches/.tekton/odh-workbenches-controller-v3-6-ea-1-push.yaml#L42


Build failed here: https://github.com/red-hat-data-services/workbenches/pull/47/checks?check_run_id=98262410831
Related-to: https://redhat.atlassian.net/browse/RHOAIENG-84638
https://github.com/red-hat-data-services/workbenches/pull/47