### PR TITLE
Override the ACTIVATION_KEY param for odh-llm-d-inference-scheduler-v2-25-push

### DIFF
--- a/pipelineruns/llm-d-inference-scheduler/.tekton/odh-llm-d-inference-scheduler-v2-25-push.yaml
+++ b/pipelineruns/llm-d-inference-scheduler/.tekton/odh-llm-d-inference-scheduler-v2-25-push.yaml
@@ -51,6 +51,8 @@ spec:
     value:
     - linux/x86_64
     - linux-m2xlarge/arm64
+  - name: rhel-subscription-activation-key
+    value: "rhel-subscription-activation-key-nonexistent"
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
The same fix exist on the rhoai-3.4 branch and was recommended by konflux support.

Pipeline [1] is constantly failing since mid July, and it seems it is cert related:

time="2026-07-14T03:07:25Z" level=info msg="hermeto [stderr] 2026-07-14 03:07:25,779 ERROR FetchError: exception_name: ClientOSError, details: [Errno 1] [SSL: TLSV1_ALERT_UNKNOWN_CA] tlsv1 alert unknown ca (_ssl.c:2568)"
  time="2026-07-14T03:07:25Z" level=info msg="hermeto [stderr] Error: FetchError: exception_name: ClientOSError, details: [Errno 1] [SSL: TLSV1_ALERT_UNKNOWN_CA] tlsv1 alert unknown ca (_ssl.c:2568)"

time="2026-08-02T03:14:16Z" level=info msg="hermeto [stderr] 2026-08-02 03:14:16,575 ERROR Unsuccessful download: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/aarch64/rhelai/3.0/os/Packages/z/zeromq-devel-4.3.5-1.el9ai.aarch64.rpm"
time="2026-08-02T03:14:16Z" level=info msg="hermeto [stderr] 2026-08-02 03:14:16,601 ERROR FetchError: exception_name: ClientOSError, details: [Errno 1] [SSL: TLSV1_ALERT_UNKNOWN_CA] tlsv1 alert unknown ca (_ssl.c:2568)"
time="2026-08-02T03:14:16Z" level=info msg="hermeto [stderr] Error: FetchError: exception_name: ClientOSError, details: [Errno 1] [SSL: TLSV1_ALERT_UNKNOWN_CA] tlsv1 alert unknown ca (_ssl.c:2568)"

The package that is causing issue is published and available, which is indicates connectivity issue in Konflux.

Root Cause: Activation key + Hermeto entitlement cert conflict

When an activation-key secret exists in your tenant namespace, the prefetch-dependencies task automatically picks it up and uses it to register with subscription-manager. This generates entitlement certificates, and Hermeto then incorrectly uses those entitlement certs when connecting to rhsm-pulp.corp.redhat.com — which doesn't expect or need them. That's what triggers the TLSV1_ALERT_UNKNOWN_CA error.

This is not a general connectivity issue in Konflux — it's specific to how the activation key interacts with Hermeto's certificate handling during prefetch.

Workaround: Override the ACTIVATION_KEY param on the prefetch-dependencies task

In the Pipeline definition (in the .tekton/ directory), override the ACTIVATION_KEY parameter for the prefetch-dependencies task to point to a secret name that does not exist. This prevents subscription-manager from registering during prefetch, so Hermeto won't pick up the entitlement certs that conflict with rhsm-pulp.