### PR TITLE
fix(konflux): prefetch gomod deps from spark-operator-module path

### DIFF
--- a/pipelineruns/spark-operator/.tekton/odh-spark-operator-module-pull-request.yaml
+++ b/pipelineruns/spark-operator/.tekton/odh-spark-operator-module-pull-request.yaml
@@ -34,7 +34,7 @@ spec:
     value: "false"
   - name: prefetch-input
     value: |
-      [{"type": "gomod", "path": "."}]
+      [{"type": "gomod", "path": "spark-operator-module"}]
   - name: build-platforms
     value:
     - linux/x86_64


### PR DESCRIPTION
The module-controller build runs go mod download against spark-operator-module/go.mod, but cachi2 prefetched the root module, so deps were missing from the hermetic cache. Point prefetch-input at the spark-operator-module path.

Related: https://github.com/red-hat-data-services/spark-operator/pull/251