### PR TITLE
[rhoai-3.6-ea2] Enable hermetic prefetch for codeserver baseline EA.2 push pipeline.

### DIFF
--- a/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-baseline-cpu-py312-v3-6-ea-2-push.yaml
+++ b/pipelineruns/notebooks/.tekton/odh-workbench-codeserver-baseline-cpu-py312-v3-6-ea-2-push.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
@@ -12,7 +11,10 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "rhoai-3.6-ea.2"
-      && ( files.all.exists(p, !p.matches('^\\.tekton/')) || ".tekton/odh-workbench-codeserver-baseline-cpu-py312-v3-6-ea-2-push.yaml".pathChanged() )
+      && !("manifests/rhoai/base/params-latest.env".pathChanged())
+      && ( ".tekton/odh-workbench-codeserver-baseline-cpu-py312-v3-6-ea-2-push.yaml".pathChanged() ||
+           "codeserver-baseline/ubi9-python-3.12/**".pathChanged() ||
+           "codeserver-baseline/ubi9-python-3.12/build-args/konflux.cpu.conf".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-6-ea-2
     appstudio.openshift.io/component: odh-workbench-codeserver-baseline-cpu-py312-v3-6-ea-2
@@ -20,35 +22,190 @@ metadata:
   name: odh-workbench-codeserver-baseline-cpu-py312-v3-6-ea-2-on-push
   namespace: rhoai-tenant
 spec:
+  timeouts:
+    pipeline: "12h0m0s"
+    tasks: "8h0m0s"
   params:
   - name: git-url
     value: '{{source_url}}'
+  - name: enable-cache-proxy
+    value: "true"
+  - name: hermetic
+    value: "true"
   - name: revision
     value: '{{revision}}'
-  - name: additional-tags
-    value:
-    - '{{target_branch}}-{{revision}}'
   - name: output-image
     value: quay.io/rhoai/odh-workbench-codeserver-baseline-cpu-py312-rhel9:{{target_branch}}
   - name: rhoai-version
     value: "3.6.0-ea.2"
+  - name: additional-tags
+    value:
+    - '{{target_branch}}-{{revision}}'
   - name: dockerfile
     value: codeserver-baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
-  - name: path-context
-    value: .
-  - name: hermetic
-    value: false
-  - name: rhel-subscription-activation-key
-    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
-  - name: build-platforms
-    value:
-    - linux/x86_64
-    - linux-m2xlarge/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: build-args-file
     value: codeserver-baseline/ubi9-python-3.12/build-args/konflux.cpu.conf
+  - name: path-context
+    value: .
+  - name: build-image-index
+    value: true
+  - name: build-platforms
+    value:
+    - linux-d160-m8xlarge/amd64
+    - linux-d160-m8xlarge/arm64
+    - linux/ppc64le
+    - linux/s390x
+  - name: disable-slack-notifications
+    value: "true"
+  - name: rhel-subscription-activation-key
+    value: "rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6"
+  - name: prefetch-input
+    value:
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/rhds
+      type: rpm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/rhds
+      type: generic
+    - path: codeserver-baseline/ubi9-python-3.12
+      type: pip
+      binary:
+        arch: "x86_64,aarch64,ppc64le,s390x"
+      requirements_files: ["requirements.cpu.txt"]
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/.vscode/extensions/vscode-selfhost-import-aid
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/.vscode/extensions/vscode-selfhost-test-provider
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/build
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/build/npm/gyp
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/build/vite
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/build/rspack
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/.vscode/extensions/vscode-extras
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/.vscode/extensions/vscode-pr-pinger
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/configuration-editing
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/copilot
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/copilot/chat-lib
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/css-language-features
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/css-language-features/server
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/debug-auto-launch
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/debug-server-ready
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/extension-editing
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/git
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/git-base
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/github
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/github-authentication
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/grunt
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/gulp
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/html-language-features
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/html-language-features/server
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/ipynb
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/jake
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/json-language-features
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/json-language-features/server
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/markdown-language-features
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/markdown-math
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/media-preview
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/merge-conflict
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/mermaid-markdown-features
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/notebook-renderers
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/npm
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/php-language-features
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/references-view
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/search-result
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/simple-browser
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/terminal-suggest
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/tunnel-forwarding
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/typescript-language-features
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/vscode-api-tests
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/vscode-colorize-perf-tests
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/vscode-colorize-tests
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions/vscode-test-resolver
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/remote
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/remote/web
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/test/automation
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/test/integration/browser
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/test/mcp
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/test/monaco
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/test/smoke
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/test/sanity
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/src/vs/sessions/test/e2e
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server/test/e2e/extensions/test-extension
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/code-server
+      type: npm
+    # patches/ overlay (overwrites code-server at build); use these so Cachi2 prefetches registry-only lockfiles
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/patches/code-server-v4.122.1/lib/vscode
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/patches/code-server-v4.122.1/lib/vscode/remote
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/patches/code-server-v4.122.1/lib/vscode/extensions
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/patches/code-server-v4.122.1/lib/vscode/extensions/emmet
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/patches/code-server-v4.122.1/lib/vscode/build/vite
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/patches/code-server-v4.122.1/test
+      type: npm
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/patches/code-server-v4.122.1/lib/vscode/extensions/microsoft-authentication
+      type: npm
+    # Registry-only npm deps (ProdSec); @parcel/watcher, @emmetio/css-parser, @playwright/browser-chromium in custom-packages/package.json
+    - path: codeserver-baseline/ubi9-python-3.12/prefetch-input/patches/code-server-v4.122.1/custom-packages
+      type: npm
   pipelineRef:
+    resolver: git
     params:
     - name: url
       value: https://github.com/red-hat-data-services/konflux-central.git
@@ -56,11 +213,81 @@ spec:
       value: '{{ target_branch }}'
     - name: pathInRepo
       value: pipelines/multi-arch-container-build.yaml
-    resolver: git
+  taskRunSpecs:
+  - pipelineTaskName: prefetch-dependencies
+    computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
+      limits:
+        cpu: '4'
+        memory: 8Gi
+  - pipelineTaskName: build-images
+    stepSpecs:
+    - name: build
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 16Gi
+          ephemeral-storage: 80Gi
+        limits:
+          cpu: '8'
+          memory: 16Gi
+          ephemeral-storage: 80Gi
+    - name: prepare-sboms
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+    - name: sbom-syft-generate
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: clair-scan
+    computeResources:
+      requests:
+        cpu: '8'
+        memory: 8Gi
+      limits:
+        cpu: '8'
+        memory: 8Gi
+  - pipelineTaskName: ecosystem-cert-preflight-checks
+    computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
+      limits:
+        cpu: '4'
+        memory: 8Gi
+  - pipelineTaskName: clamav-scan
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: sast-shell-check
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: rpms-signature-scan
+    computeResources:
+      limits:
+        memory: 8Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-workbench-codeserver-baseline-cpu-py312-v3-6-ea-2
     podTemplate:
       imagePullSecrets:
       - name: redhat-appstudio-staginguser-pull-secret
-  timeouts:
-    pipeline: 2h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'


### PR DESCRIPTION
Align the rhoai-3.6-ea.2 push pipeline with hermetic builds 
related to: https://redhat.atlassian.net/browse/RHAIENG-7139