### PR TITLE
feat: remove generic prefetch from NeMo-Guardrails

### DIFF
--- a/pipelineruns/NeMo-Guardrails/.tekton/odh-trustyai-nemo-guardrails-server-v3-6-ea-2-push.yaml
+++ b/pipelineruns/NeMo-Guardrails/.tekton/odh-trustyai-nemo-guardrails-server-v3-6-ea-2-push.yaml
@@ -46,12 +46,8 @@ spec:
       [{
         "type": "pip",
         "path": ".",
-        "requirements_files": ["requirements.txt", "requirements-models.txt"],
+        "requirements_files": ["requirements.txt"],
         "binary": {"arch": "x86_64,aarch64,ppc64le,s390x"}
-      },
-      {
-        "type": "generic",
-        "path": "."
       }]
   - name: build-source-image
     value: true


### PR DESCRIPTION
## Summary
- Remove `requirements-models.txt` from pip prefetch `requirements_files` and remove the generic prefetch block from the NeMo-Guardrails Tekton pipelinerun
- NeMo-Guardrails now uses modelcars instead of generic file fetcher for model downloads

## Context
- Upstream PR: https://github.com/red-hat-data-services/NeMo-Guardrails/pull/348
- Jira: [RHOAIENG-89417](https://redhat.atlassian.net/browse/RHOAIENG-89417)

## Test plan
- [ ] Verify NeMo-Guardrails push build succeeds on rhoai-3.6-ea.2 without generic prefetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)